### PR TITLE
Add packages: babel-eslint and babel-plugin-transform-decorators-legacy

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "react"]
+  "presets": ["es2015", "react"],
+  "plugins": ["babel-plugin-transform-decorators-legacy"]
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,6 @@
 module.exports = {
+  'parser': 'babel-eslint',
+
   'parserOptions': {
     'ecmaVersion': 6,
     'sourceType': 'module',
@@ -22,7 +24,7 @@ module.exports = {
   ],
 
   'settings': {
-    'import/resolver': {'node': {"extensions": [".js", ".jsx"]}},
+    'import/resolver': ['node', 'webpack'],
   },
 
   'rules': {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "file-loader": "^0.8.5",
     "ramda": "^0.21.0",
     "react": "^0.14.6",
+    "react-addons-update": "^15.1.0",
     "react-dom": "^0.14.6",
     "react-redux": "^4.0.6",
     "redux": "^3.0.5",
@@ -33,6 +34,8 @@
   },
   "devDependencies": {
     "babel-cli": "^6.4.0",
+    "babel-eslint": "^6.1.0",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "chai": "^3.4.1",
     "chai-immutable": "^1.5.3",
     "eslint": "^2.13.0",


### PR DESCRIPTION
plugin provides to build jsx with @decorators
babel-eslint lints correctly @decorators (without "unexpected token @" error)

in addition to the packages, there is changes in .eslintrc and .babelrc
