### PR TITLE
Add redux-thunk package as middleware

### DIFF
--- a/app/middlewares.js
+++ b/app/middlewares.js
@@ -1,6 +1,8 @@
-import { compose } from 'redux';
+import { compose, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
 
 export const EditorMiddleware = compose(
+  applyMiddleware(thunk),
   typeof window === 'object' && typeof window.devToolsExtension !== 'undefined' ?
     window.devToolsExtension() : f => f
 );

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^0.14.6",
     "react-redux": "^4.0.6",
     "redux": "^3.0.5",
+    "redux-thunk": "^2.1.0",
     "reselect": "^2.5.1",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.10"


### PR DESCRIPTION
**Why do we need it?**
1. If we want to perform some action that depends on data from another reducer. For example, if we want to create a node, we'll pass into action next arguments: position, nodeTypeId. And the remaining parameters (pins, category and etc) we will get inside the action with getState() method, that returns entire store.
2. If we want to validate any payload, before apply it —it helps to make this work easier. So we can check it out and dispatch action on success validation, or dispatch error action, or do nothing.
3. If we want to make something async and we have to wait while a response is loading. And then do something (success action, error action, repeat or something else).

The first and second item in the list is already topical.
Any objections?
