### PR TITLE
Improve load save

### DIFF
--- a/app/constants/errorMessages.js
+++ b/app/constants/errorMessages.js
@@ -3,3 +3,7 @@ export const LINK_ERRORS = {
   SAME_NODE: 'Can\'t create link between pins of the same node!',
   ONE_LINK_FOR_INPUT_PIN: 'Input pin can have only one link!',
 };
+
+export const SAVE_LOAD_ERRORS = {
+  LOAD_EXTENSION: 'Application accepts files only with .xod extension!',
+};

--- a/app/containers/Toolbar.jsx
+++ b/app/containers/Toolbar.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Selectors from '../selectors';
 import * as Actions from '../actions';
+import { SAVE_LOAD_ERRORS } from '../constants/errorMessages';
 
 class Toolbar extends React.Component {
   constructor(props) {
@@ -27,6 +28,9 @@ class Toolbar extends React.Component {
       const file = files[i];
 
       if (!(/.+\.xod$/).test(file.name)) {
+        this.props.actions.showError({
+          message: SAVE_LOAD_ERRORS.LOAD_EXTENSION,
+        });
         return;
       }
 
@@ -123,6 +127,7 @@ const mapDispatchToProps = (dispatch) => ({
   actions: bindActionCreators({
     updateMeta: Actions.updateMeta,
     loadProjectFromJSON: Actions.loadProjectFromJSON,
+    showError: Actions.showError,
   }, dispatch),
 });
 


### PR DESCRIPTION
1. By clicking "Save project as" we get a dialog box (if it possible: in chrome web and chrome app works fine) with suggested file name and extension: %PROJECT_NAME%.xod
2. By clicking "Load project" we get a dialog box with filtering for .xod extension (but a user can turn this filter off and we can't turn it off).
3. In case that we use unregistered in OS extension there is no file.type. So I check for ending of the file name — it must be "*.xod". If check fails — we'll show an error in right bottom corner.
