### PR TITLE
FIX: Add property "Pin" into nodeType metadata of LED

### DIFF
--- a/packages/xod-core/nodes/meta/led.json5
+++ b/packages/xod-core/nodes/meta/led.json5
@@ -7,5 +7,11 @@
     label: 'Brightness',
     value: 0,
     description: 'Shine brightness'
+  }],
+  properties: [{
+    key: 'pin',
+    label: 'Pin',
+    type: 'string',
+    value: 'LED1',
   }]
 }


### PR DESCRIPTION
There was a bug with LED nodes that haven't Pin property.
We've lost it in the led.json5, so I added it.
