### PR TITLE
Revert a DevTool component

### DIFF
--- a/packages/xod-client/src/core/containers/Root.jsx
+++ b/packages/xod-client/src/core/containers/Root.jsx
@@ -4,6 +4,7 @@ import { createStore } from 'redux';
 import { Provider } from 'react-redux';
 import core from 'xod-core';
 
+import DevTools from '../../utils/devtools';
 import generateReducers from '../reducer';
 import initialState from '../state';
 import { EditorMiddleware } from '../middlewares';
@@ -67,7 +68,10 @@ export default class Root extends React.Component {
   render() {
     return (
       <Provider store={this.store}>
+        <div>
         {this.props.children}
+        {DevTools}
+        </div>
       </Provider>
     );
   }

--- a/packages/xod-client/src/core/middlewares.js
+++ b/packages/xod-client/src/core/middlewares.js
@@ -1,15 +1,12 @@
 import { compose, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import { apiMiddleware } from 'redux-api-middleware';
-import DevTools from './containers/DevTools';
 
 import { authEnhancer } from '../user/enhancer';
-
-const devTools = (typeof window === 'object' && typeof window.devToolsExtension !== 'undefined') ?
-  window.devToolsExtension() : DevTools.instrument();
+import { devToolMiddleware } from '../utils/devtools';
 
 export const EditorMiddleware = compose(
   authEnhancer,
   applyMiddleware(thunk, apiMiddleware),
-  devTools
+  devToolMiddleware
 );

--- a/packages/xod-client/src/utils/devtools.jsx
+++ b/packages/xod-client/src/utils/devtools.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import DevTools from '../core/containers/DevTools';
+
+const hasDevToolExtension = (typeof window === 'object' && typeof window.devToolsExtension !== 'undefined');
+
+export const devToolMiddleware = hasDevToolExtension ?
+  window.devToolsExtension() : DevTools.instrument();
+
+export const devTool = (hasDevToolExtension ? null : <DevTools />);
+
+export default devTool;


### PR DESCRIPTION
Now we can use DevTool component in cases if an environment hasn't a DevToolExtension installed.

toggle it: `ctrl-h`
change position:  `ctrl-p`
change devtool mode: `ctrl-m`