### PR TITLE
chore(infra): add max-composition-depth eslint rule (max 11 now)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
   plugins: [
     'react',
     'import',
+    'xod-fp',
   ],
 
   extends: [
@@ -33,6 +34,11 @@ module.exports = {
   },
 
   rules: {
+    'xod-fp/max-composition-depth': ['error', {
+      max: 11, // TODO: it should be lowered to 6
+      ignoreCurry: true,
+      ignoreMocha: true,
+    }],
     'no-underscore-dangle': ['error', {
       allow: ["__"], /* Ramda’s R.__ */
       allowAfterThis: true,

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-import": "^1.16.0",
     "eslint-plugin-jsx-a11y": "^2.2.2",
     "eslint-plugin-react": "^6.3.0",
+    "eslint-plugin-xod-fp": "^0.1.1",
     "exports-loader": "^0.6.3",
     "file-loader": "^0.9.0",
     "globals-loader": "0.0.3",


### PR DESCRIPTION
This is the first step toward #319. It just installs the rule but does not limits a maximal depth to the desired level yet.