### PR TITLE
fix(core): fix deleting an empty patch

### DIFF
--- a/packages/xod-core/src/project/selectors.js
+++ b/packages/xod-core/src/project/selectors.js
@@ -199,7 +199,7 @@ export const getNodeTypeById = R.curry((state, id) => R.pipe(
 */
 
 export const getNodes = R.curry((patchId, state) => R.compose(
-  R.prop('nodes'),
+  R.propOr({}, 'nodes'),
   getPatchById(patchId)
 )(state));
 


### PR DESCRIPTION
Adresses #327
Now we can delete an inactive empty patch, but it still blows up 
without warning when we try to delete a current patch.