### PR TITLE
fix(xod-client-electron): correct css loading for fonts awesome

### DIFF
--- a/packages/xod-client-electron/webpack.config.js
+++ b/packages/xod-client-electron/webpack.config.js
@@ -74,6 +74,14 @@ const options = {
         ],
       },
       {
+        include: pkgpath('node_modules/font-awesome'),
+        test: /\.css$/,
+        loaders: [
+          'style',
+          'css',
+        ],
+      },
+      {
         test: /\.json$/,
         loader: 'json-loader',
       },


### PR DESCRIPTION
Fixes #354 