### PR TITLE
Fix deleting opened empty patch

### DIFF
--- a/packages/xod-client/src/editor/components/TabsItem.jsx
+++ b/packages/xod-client/src/editor/components/TabsItem.jsx
@@ -6,7 +6,7 @@ const TabsItem = ({ data, onClick, onClose }) => {
     'is-active': data.isActive,
   });
 
-  const handleClick = () => onClick(data.patchId);
+  const handleClick = () => onClick(data.id);
   const handleClose = (event) => {
     event.stopPropagation();
     onClose(data.id);
@@ -32,7 +32,6 @@ const TabsItem = ({ data, onClick, onClose }) => {
 
 const TabsDataPropType = React.PropTypes.shape({
   id: React.PropTypes.string,
-  patchId: React.PropTypes.string,
   index: React.PropTypes.number,
   label: React.PropTypes.string,
   isActive: React.PropTypes.boolean,

--- a/packages/xod-client/src/editor/reducer.js
+++ b/packages/xod-client/src/editor/reducer.js
@@ -49,7 +49,6 @@ const addTab = (state, action) => {
 
   return R.assocPath(['tabs', patchId], {
     id: patchId,
-    patchId,
     index: newIndex,
   }, state);
 };
@@ -126,7 +125,7 @@ const editorReducer = (state = {}, action) => {
           R.assoc('currentPatchId'),
           [
             R.compose( // get patch id from last of remaining tabs
-              R.propOr(null, 'patchId'),
+              R.propOr(null, 'id'),
               R.last,
               R.values,
               R.prop('tabs')

--- a/packages/xod-client/src/editor/selectors.js
+++ b/packages/xod-client/src/editor/selectors.js
@@ -104,12 +104,12 @@ export const getPreparedTabs = (state) => {
     getTabs,
     R.values,
     R.map((tab) => {
-      const patch = core.getPatchById(tab.patchId, projectState);
+      const patch = core.getPatchById(tab.id, projectState);
       return R.merge(
         tab,
         {
           label: patch.label,
-          isActive: (currentPatchId === tab.patchId),
+          isActive: (currentPatchId === tab.id),
         }
       );
     }),

--- a/packages/xod-client/src/editor/state.js
+++ b/packages/xod-client/src/editor/state.js
@@ -8,9 +8,8 @@ export default {
   linkingPin: null,
   selectedNodeType: null,
   tabs: {
-    1: {
-      id: '1',
-      patchId: '@/1',
+    '@/1': {
+      id: '@/1',
       index: 0,
     },
   },


### PR DESCRIPTION
It fixed #330 

The User could delete opened empty patch without any errors. After deleting it tab will be removed too and switched to another opened or to nothing (no opened patch screen will be showed).

For simplifying the solution I removed generating an id for tabs and uses patch id as tab id.