### PR TITLE
fix(xod-arduino): resolve `engines.node` version mismatch in `packages/xod-arduino-builder/package.json`

### DIFF
--- a/packages/xod-arduino-builder/package.json
+++ b/packages/xod-arduino-builder/package.json
@@ -14,7 +14,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": "7.4.0"
+    "node": "6.0.0"
   },
   "dependencies": {
     "child-process-promise": "^2.2.1",


### PR DESCRIPTION
Closes #486.