### PR TITLE
infra(stdlib): add converted patch templates

### DIFF
--- a/workspace/lib/xod/core/absolute/patch.xodp
+++ b/workspace/lib/xod/core/absolute/patch.xodp
@@ -1,0 +1,41 @@
+{
+  "nodes": [
+    {
+      "id": "B1LNICdSDJW",
+      "type": "xod/built-in/output-number",
+      "label": "ABSX",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": 0
+      }
+    },
+    {
+      "id": "H1SVIAuBDJZ",
+      "type": "xod/built-in/input-number",
+      "label": "X",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/add/patch.xodp
+++ b/workspace/lib/xod/core/add/patch.xodp
@@ -1,0 +1,52 @@
+{
+  "nodes": [
+    {
+      "id": "BJnQUR_BwyZ",
+      "type": "xod/built-in/input-number",
+      "label": "X",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "HkqmLAOrD1W",
+      "type": "xod/built-in/input-number",
+      "label": "Y",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "SyomIRurDJ-",
+      "type": "xod/built-in/output-number",
+      "label": "SUM",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": 0
+      }
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/analog-input/patch.xodp
+++ b/workspace/lib/xod/core/analog-input/patch.xodp
@@ -1,0 +1,52 @@
+{
+  "nodes": [
+    {
+      "id": "B1retBvyb",
+      "type": "xod/built-in/input-pulse",
+      "label": "UPD",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "B1zbKSDy-",
+      "type": "xod/built-in/input-number",
+      "label": "PORT",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "r1yGKrvyZ",
+      "type": "xod/built-in/output-number",
+      "label": "ADC",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": 0
+      }
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/analog-output/patch.xodp
+++ b/workspace/lib/xod/core/analog-output/patch.xodp
@@ -1,0 +1,50 @@
+{
+  "nodes": [
+    {
+      "id": "Sy3ttSwkW",
+      "type": "xod/built-in/input-number",
+      "label": "PORT",
+      "description": "",
+      "position": {
+        "x": 266,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "rJ4KKSDJW",
+      "type": "xod/built-in/input-pulse",
+      "label": "UPD",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "rkodYHD1W",
+      "type": "xod/built-in/input-number",
+      "label": "DAC",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/and/patch.xodp
+++ b/workspace/lib/xod/core/and/patch.xodp
@@ -1,0 +1,52 @@
+{
+  "nodes": [
+    {
+      "id": "B1gN80uHvk-",
+      "type": "xod/built-in/output-boolean",
+      "label": "AND",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "id": "SJMVU0urvkZ",
+      "type": "xod/built-in/input-boolean",
+      "label": "A",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "r1bVLR_BPJW",
+      "type": "xod/built-in/input-boolean",
+      "label": "B",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/any/patch.xodp
+++ b/workspace/lib/xod/core/any/patch.xodp
@@ -1,0 +1,52 @@
+{
+  "nodes": [
+    {
+      "id": "ByHmL0uHPk-",
+      "type": "xod/built-in/output-pulse",
+      "label": "ANY",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "id": "ByU7LRuSPkW",
+      "type": "xod/built-in/input-pulse",
+      "label": "P2",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "ryv7IRdSP1b",
+      "type": "xod/built-in/input-pulse",
+      "label": "P1",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/boot/patch.xodp
+++ b/workspace/lib/xod/core/boot/patch.xodp
@@ -1,0 +1,30 @@
+{
+  "nodes": [
+    {
+      "id": "ryVmUAOrvkb",
+      "type": "xod/built-in/output-pulse",
+      "label": "BOOT",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/buffer/patch.xodp
+++ b/workspace/lib/xod/core/buffer/patch.xodp
@@ -1,0 +1,65 @@
+{
+  "nodes": [
+    {
+      "id": "B1zQ8CdSvJ-",
+      "type": "xod/built-in/output-pulse",
+      "label": "CHNG",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "id": "HkXm80uHPyb",
+      "type": "xod/built-in/input-number",
+      "label": "NEW",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "Hy-QUR_BPkZ",
+      "type": "xod/built-in/input-pulse",
+      "label": "UPD",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "r1lQLAOBwJb",
+      "type": "xod/built-in/output-number",
+      "label": "MEM",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": 0
+      }
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/ceil/patch.xodp
+++ b/workspace/lib/xod/core/ceil/patch.xodp
@@ -1,0 +1,41 @@
+{
+  "nodes": [
+    {
+      "id": "BkdbLAuSPyZ",
+      "type": "xod/built-in/output-number",
+      "label": "CEIL",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": 0
+      }
+    },
+    {
+      "id": "H1v-80uHDyZ",
+      "type": "xod/built-in/input-number",
+      "label": "X",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/change-interrupt/patch.xodp
+++ b/workspace/lib/xod/core/change-interrupt/patch.xodp
@@ -1,0 +1,54 @@
+{
+  "nodes": [
+    {
+      "id": "By8H5rDkZ",
+      "type": "xod/built-in/output-pulse",
+      "label": "FALL",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "id": "rJxr9rDJZ",
+      "type": "xod/built-in/output-pulse",
+      "label": "RISE",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "id": "rkuEqBD1W",
+      "type": "xod/built-in/input-number",
+      "label": "PORT",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/clock/patch.xodp
+++ b/workspace/lib/xod/core/clock/patch.xodp
@@ -1,0 +1,52 @@
+{
+  "nodes": [
+    {
+      "id": "BkIZIA_rDk-",
+      "type": "xod/built-in/input-number",
+      "label": "IVAL",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "ByHWU0drvkW",
+      "type": "xod/built-in/input-pulse",
+      "label": "RST",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "rJVZUAdHwk-",
+      "type": "xod/built-in/output-pulse",
+      "label": "TICK",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/console-log/patch.xodp
+++ b/workspace/lib/xod/core/console-log/patch.xodp
@@ -1,0 +1,39 @@
+{
+  "nodes": [
+    {
+      "id": "HJdO9HwJ-",
+      "type": "xod/built-in/input-string",
+      "label": "LINE",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "S1n95SDJb",
+      "type": "xod/built-in/input-pulse",
+      "label": "DUMP",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/constrain/patch.xodp
+++ b/workspace/lib/xod/core/constrain/patch.xodp
@@ -1,0 +1,63 @@
+{
+  "nodes": [
+    {
+      "id": "BJgZ80uBw1-",
+      "type": "xod/built-in/input-number",
+      "label": "MIN",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "BkmZL0uSv1W",
+      "type": "xod/built-in/input-number",
+      "label": "X",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "rJWWUAdHDyW",
+      "type": "xod/built-in/output-number",
+      "label": "XC",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": 0
+      }
+    },
+    {
+      "id": "ryzZIC_BDJW",
+      "type": "xod/built-in/input-number",
+      "label": "MAX",
+      "description": "",
+      "position": {
+        "x": 266,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/delay/patch.xodp
+++ b/workspace/lib/xod/core/delay/patch.xodp
@@ -1,0 +1,65 @@
+{
+  "nodes": [
+    {
+      "id": "B1GeLR_BPyZ",
+      "type": "xod/built-in/output-boolean",
+      "label": "ACT",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "id": "Bk4gU0drwJ-",
+      "type": "xod/built-in/output-pulse",
+      "label": "DONE",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "id": "H1mlUC_HDJZ",
+      "type": "xod/built-in/input-pulse",
+      "label": "RST",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "Skre8ROSv1-",
+      "type": "xod/built-in/input-number",
+      "label": "T",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/digital-input/patch.xodp
+++ b/workspace/lib/xod/core/digital-input/patch.xodp
@@ -1,0 +1,52 @@
+{
+  "nodes": [
+    {
+      "id": "B1ZUA_Hv1W",
+      "type": "xod/built-in/input-number",
+      "label": "PORT",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "B1gI0urv1W",
+      "type": "xod/built-in/output-boolean",
+      "label": "SIG",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "id": "SyLCdSwJZ",
+      "type": "xod/built-in/input-pulse",
+      "label": "UPD",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/divide/patch.xodp
+++ b/workspace/lib/xod/core/divide/patch.xodp
@@ -1,0 +1,52 @@
+{
+  "nodes": [
+    {
+      "id": "BkqLCOSw1W",
+      "type": "xod/built-in/output-number",
+      "label": "FRAC",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": 0
+      }
+    },
+    {
+      "id": "BytUCdHD1-",
+      "type": "xod/built-in/input-number",
+      "label": "Y",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "SkdIRuBD1b",
+      "type": "xod/built-in/input-number",
+      "label": "X",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/equal/patch.xodp
+++ b/workspace/lib/xod/core/equal/patch.xodp
@@ -1,0 +1,52 @@
+{
+  "nodes": [
+    {
+      "id": "H1E8AuSPkZ",
+      "type": "xod/built-in/output-boolean",
+      "label": "EQ",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "id": "HJG8C_SPkb",
+      "type": "xod/built-in/input-number",
+      "label": "RHS",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "rJXICuSwyW",
+      "type": "xod/built-in/input-number",
+      "label": "LHS",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/flip-flop/patch.xodp
+++ b/workspace/lib/xod/core/flip-flop/patch.xodp
@@ -1,0 +1,76 @@
+{
+  "nodes": [
+    {
+      "id": "B1RU0OrDkb",
+      "type": "xod/built-in/input-pulse",
+      "label": "RST",
+      "description": "",
+      "position": {
+        "x": 266,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "Bkh8A_Sv1-",
+      "type": "xod/built-in/input-pulse",
+      "label": "SET",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "HkyxURuSPyW",
+      "type": "xod/built-in/output-boolean",
+      "label": "MEM",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "id": "HyjUA_HvkW",
+      "type": "xod/built-in/output-pulse",
+      "label": "CHNG",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "id": "ryTIROHwkW",
+      "type": "xod/built-in/input-pulse",
+      "label": "TGL",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/floor/patch.xodp
+++ b/workspace/lib/xod/core/floor/patch.xodp
@@ -1,0 +1,41 @@
+{
+  "nodes": [
+    {
+      "id": "SklxICdHP1b",
+      "type": "xod/built-in/input-number",
+      "label": "X",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "rkWeUCdBDkZ",
+      "type": "xod/built-in/output-number",
+      "label": "FLR",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": 0
+      }
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/gate/patch.xodp
+++ b/workspace/lib/xod/core/gate/patch.xodp
@@ -1,0 +1,52 @@
+{
+  "nodes": [
+    {
+      "id": "HkDgIRdrv1W",
+      "type": "xod/built-in/input-pulse",
+      "label": "DRN",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "S1OlUAuBD1-",
+      "type": "xod/built-in/input-boolean",
+      "label": "GATE",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "SJUl8Aurv1W",
+      "type": "xod/built-in/output-pulse",
+      "label": "SRC",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/greater/patch.xodp
+++ b/workspace/lib/xod/core/greater/patch.xodp
@@ -1,0 +1,52 @@
+{
+  "nodes": [
+    {
+      "id": "r1YxLRdrwyZ",
+      "type": "xod/built-in/input-number",
+      "label": "RHS",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "rkoeU0_Bwkb",
+      "type": "xod/built-in/output-boolean",
+      "label": "GT",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "id": "ry5eIAuBPkW",
+      "type": "xod/built-in/input-number",
+      "label": "LHS",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/if-else/patch.xodp
+++ b/workspace/lib/xod/core/if-else/patch.xodp
@@ -1,0 +1,63 @@
+{
+  "nodes": [
+    {
+      "id": "S13xLCuHvkW",
+      "type": "xod/built-in/output-number",
+      "label": "R",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": 0
+      }
+    },
+    {
+      "id": "S1yZIA_rDJZ",
+      "type": "xod/built-in/input-boolean",
+      "label": "COND",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "r1AgIROHDJW",
+      "type": "xod/built-in/input-number",
+      "label": "F",
+      "description": "",
+      "position": {
+        "x": 266,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "ryTeUROHD1b",
+      "type": "xod/built-in/input-number",
+      "label": "T",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/less/patch.xodp
+++ b/workspace/lib/xod/core/less/patch.xodp
@@ -1,0 +1,50 @@
+{
+  "nodes": [
+    {
+      "id": "HJjZLRdBw1-",
+      "type": "xod/built-in/input-number",
+      "label": "LHS",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "HktZUCdrPkZ",
+      "type": "xod/built-in/input-boolean",
+      "label": "LT",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "SJqZ8COrDkW",
+      "type": "xod/built-in/input-number",
+      "label": "RHS",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/map-range/patch.xodp
+++ b/workspace/lib/xod/core/map-range/patch.xodp
@@ -1,0 +1,85 @@
+{
+  "nodes": [
+    {
+      "id": "BJlzICOSv1-",
+      "type": "xod/built-in/input-number",
+      "label": "X",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "H12bIR_SPyZ",
+      "type": "xod/built-in/output-number",
+      "label": "Xm",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": 0
+      }
+    },
+    {
+      "id": "HJCWLAdSwyW",
+      "type": "xod/built-in/input-number",
+      "label": "Smax",
+      "description": "",
+      "position": {
+        "x": 266,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "rJbGU0_Hv1Z",
+      "type": "xod/built-in/input-number",
+      "label": "Tmin",
+      "description": "",
+      "position": {
+        "x": 394,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "rkpbU0OrwyZ",
+      "type": "xod/built-in/input-number",
+      "label": "Tmax",
+      "description": "",
+      "position": {
+        "x": 522,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "ry1z8CuBDy-",
+      "type": "xod/built-in/input-number",
+      "label": "Smin",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/multiply/patch.xodp
+++ b/workspace/lib/xod/core/multiply/patch.xodp
@@ -1,0 +1,52 @@
+{
+  "nodes": [
+    {
+      "id": "B1GfLR_SPk-",
+      "type": "xod/built-in/input-number",
+      "label": "X",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "BkQzLCurwJZ",
+      "type": "xod/built-in/output-number",
+      "label": "PROD",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": 0
+      }
+    },
+    {
+      "id": "SJ4zUC_BD1-",
+      "type": "xod/built-in/input-number",
+      "label": "Y",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/nand/patch.xodp
+++ b/workspace/lib/xod/core/nand/patch.xodp
@@ -1,0 +1,52 @@
+{
+  "nodes": [
+    {
+      "id": "BkwGIROSw1Z",
+      "type": "xod/built-in/input-boolean",
+      "label": "A",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "HkHG8COBPJ-",
+      "type": "xod/built-in/input-boolean",
+      "label": "B",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "r18G80_Hvyb",
+      "type": "xod/built-in/output-boolean",
+      "label": "NAND",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/nor/patch.xodp
+++ b/workspace/lib/xod/core/nor/patch.xodp
@@ -1,0 +1,52 @@
+{
+  "nodes": [
+    {
+      "id": "S1dG8AOBPJW",
+      "type": "xod/built-in/input-boolean",
+      "label": "B",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "r1tz8CdBDkb",
+      "type": "xod/built-in/input-boolean",
+      "label": "A",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "rJqfIRdHwkW",
+      "type": "xod/built-in/output-boolean",
+      "label": "NOR",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/not/patch.xodp
+++ b/workspace/lib/xod/core/not/patch.xodp
@@ -1,0 +1,41 @@
+{
+  "nodes": [
+    {
+      "id": "r1if8ROSDJ-",
+      "type": "xod/built-in/output-boolean",
+      "label": "NOTX",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "id": "ry3zLA_Bv1Z",
+      "type": "xod/built-in/input-boolean",
+      "label": "X",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/or/patch.xodp
+++ b/workspace/lib/xod/core/or/patch.xodp
@@ -1,0 +1,52 @@
+{
+  "nodes": [
+    {
+      "id": "BJaG80urD1-",
+      "type": "xod/built-in/input-boolean",
+      "label": "A",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "HJCfI0dBDkb",
+      "type": "xod/built-in/input-boolean",
+      "label": "B",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "SJyXI0OrD1-",
+      "type": "xod/built-in/output-boolean",
+      "label": "OR",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/pwm-output/patch.xodp
+++ b/workspace/lib/xod/core/pwm-output/patch.xodp
@@ -1,0 +1,50 @@
+{
+  "nodes": [
+    {
+      "id": "ByXnYHPyb",
+      "type": "xod/built-in/input-number",
+      "label": "DUTY",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "rJsaFSvk-",
+      "type": "xod/built-in/input-number",
+      "label": "PORT",
+      "description": "",
+      "position": {
+        "x": 266,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "rkAnKBvyZ",
+      "type": "xod/built-in/input-pulse",
+      "label": "UPD",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/round/patch.xodp
+++ b/workspace/lib/xod/core/round/patch.xodp
@@ -1,0 +1,41 @@
+{
+  "nodes": [
+    {
+      "id": "BkF78AurDJW",
+      "type": "xod/built-in/input-number",
+      "label": "X",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "rkO7L0uSP1Z",
+      "type": "xod/built-in/output-number",
+      "label": "RND",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": 0
+      }
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/subtract/patch.xodp
+++ b/workspace/lib/xod/core/subtract/patch.xodp
@@ -1,0 +1,52 @@
+{
+  "nodes": [
+    {
+      "id": "BypX80uSD1Z",
+      "type": "xod/built-in/input-number",
+      "label": "X",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "HyRmUCdBDkZ",
+      "type": "xod/built-in/output-number",
+      "label": "DIFF",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": 0
+      }
+    },
+    {
+      "id": "rkJ4URuHDJ-",
+      "type": "xod/built-in/input-number",
+      "label": "Y",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/system-time/patch.xodp
+++ b/workspace/lib/xod/core/system-time/patch.xodp
@@ -1,0 +1,41 @@
+{
+  "nodes": [
+    {
+      "id": "Bk74I0_SPyb",
+      "type": "xod/built-in/input-pulse",
+      "label": "UPD",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "BkEVI0uHwJb",
+      "type": "xod/built-in/output-number",
+      "label": "TIME",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": 0
+      }
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}

--- a/workspace/lib/xod/core/xor/patch.xodp
+++ b/workspace/lib/xod/core/xor/patch.xodp
@@ -1,0 +1,52 @@
+{
+  "nodes": [
+    {
+      "id": "HkOV8CdSvyW",
+      "type": "xod/built-in/input-boolean",
+      "label": "A",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "id": "Hkw48AdSPyb",
+      "type": "xod/built-in/output-boolean",
+      "label": "XOR",
+      "description": "",
+      "position": {
+        "x": 10,
+        "y": 224
+      },
+      "boundValues": {
+        "__in__": false
+      }
+    },
+    {
+      "id": "SkKNUR_SwyW",
+      "type": "xod/built-in/input-boolean",
+      "label": "B",
+      "description": "",
+      "position": {
+        "x": 138,
+        "y": 16
+      },
+      "boundValues": {}
+    },
+    {
+      "description": "",
+      "id": "noNativeImpl",
+      "label": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/built-in/not-implemented-in-xod",
+      "boundValues": {}
+    }
+  ],
+  "links": [],
+  "description": ""
+}


### PR DESCRIPTION
There might be some mistakes in the original patches(for example, input instead of output), but the purpose of this PR is to just convert patches from old format.