### PR TITLE
fix(stdlib): change type of nodes used in stdlib from ‘xod/built-in/*’ to ‘xod/patch-nodes/*’

### DIFF
--- a/workspace/lib/xod/core/absolute/patch.xodp
+++ b/workspace/lib/xod/core/absolute/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "B1LNICdSDJW",
-      "type": "xod/built-in/output-number",
+      "type": "xod/patch-nodes/output-number",
       "label": "ABSX",
       "description": "",
       "position": {
@@ -15,7 +15,7 @@
     },
     {
       "id": "H1SVIAuBDJZ",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "X",
       "description": "",
       "position": {
@@ -32,7 +32,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/add/patch.xodp
+++ b/workspace/lib/xod/core/add/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "BJnQUR_BwyZ",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "X",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "HkqmLAOrD1W",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "Y",
       "description": "",
       "position": {
@@ -24,7 +24,7 @@
     },
     {
       "id": "SyomIRurDJ-",
-      "type": "xod/built-in/output-number",
+      "type": "xod/patch-nodes/output-number",
       "label": "SUM",
       "description": "",
       "position": {
@@ -43,7 +43,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/analog-input/patch.xodp
+++ b/workspace/lib/xod/core/analog-input/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "B1retBvyb",
-      "type": "xod/built-in/input-pulse",
+      "type": "xod/patch-nodes/input-pulse",
       "label": "UPD",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "B1zbKSDy-",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "PORT",
       "description": "",
       "position": {
@@ -24,7 +24,7 @@
     },
     {
       "id": "r1yGKrvyZ",
-      "type": "xod/built-in/output-number",
+      "type": "xod/patch-nodes/output-number",
       "label": "ADC",
       "description": "",
       "position": {
@@ -43,7 +43,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/analog-output/patch.xodp
+++ b/workspace/lib/xod/core/analog-output/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "Sy3ttSwkW",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "PORT",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "rJ4KKSDJW",
-      "type": "xod/built-in/input-pulse",
+      "type": "xod/patch-nodes/input-pulse",
       "label": "UPD",
       "description": "",
       "position": {
@@ -24,7 +24,7 @@
     },
     {
       "id": "rkodYHD1W",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "DAC",
       "description": "",
       "position": {
@@ -41,7 +41,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/and/patch.xodp
+++ b/workspace/lib/xod/core/and/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "B1gN80uHvk-",
-      "type": "xod/built-in/output-boolean",
+      "type": "xod/patch-nodes/output-boolean",
       "label": "AND",
       "description": "",
       "position": {
@@ -15,7 +15,7 @@
     },
     {
       "id": "SJMVU0urvkZ",
-      "type": "xod/built-in/input-boolean",
+      "type": "xod/patch-nodes/input-boolean",
       "label": "A",
       "description": "",
       "position": {
@@ -26,7 +26,7 @@
     },
     {
       "id": "r1bVLR_BPJW",
-      "type": "xod/built-in/input-boolean",
+      "type": "xod/patch-nodes/input-boolean",
       "label": "B",
       "description": "",
       "position": {
@@ -43,7 +43,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/any/patch.xodp
+++ b/workspace/lib/xod/core/any/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "ByHmL0uHPk-",
-      "type": "xod/built-in/output-pulse",
+      "type": "xod/patch-nodes/output-pulse",
       "label": "ANY",
       "description": "",
       "position": {
@@ -15,7 +15,7 @@
     },
     {
       "id": "ByU7LRuSPkW",
-      "type": "xod/built-in/input-pulse",
+      "type": "xod/patch-nodes/input-pulse",
       "label": "P2",
       "description": "",
       "position": {
@@ -26,7 +26,7 @@
     },
     {
       "id": "ryv7IRdSP1b",
-      "type": "xod/built-in/input-pulse",
+      "type": "xod/patch-nodes/input-pulse",
       "label": "P1",
       "description": "",
       "position": {
@@ -43,7 +43,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/boot/patch.xodp
+++ b/workspace/lib/xod/core/boot/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "ryVmUAOrvkb",
-      "type": "xod/built-in/output-pulse",
+      "type": "xod/patch-nodes/output-pulse",
       "label": "BOOT",
       "description": "",
       "position": {
@@ -21,7 +21,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/buffer/patch.xodp
+++ b/workspace/lib/xod/core/buffer/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "B1zQ8CdSvJ-",
-      "type": "xod/built-in/output-pulse",
+      "type": "xod/patch-nodes/output-pulse",
       "label": "CHNG",
       "description": "",
       "position": {
@@ -15,7 +15,7 @@
     },
     {
       "id": "HkXm80uHPyb",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "NEW",
       "description": "",
       "position": {
@@ -26,7 +26,7 @@
     },
     {
       "id": "Hy-QUR_BPkZ",
-      "type": "xod/built-in/input-pulse",
+      "type": "xod/patch-nodes/input-pulse",
       "label": "UPD",
       "description": "",
       "position": {
@@ -37,7 +37,7 @@
     },
     {
       "id": "r1lQLAOBwJb",
-      "type": "xod/built-in/output-number",
+      "type": "xod/patch-nodes/output-number",
       "label": "MEM",
       "description": "",
       "position": {
@@ -56,7 +56,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/ceil/patch.xodp
+++ b/workspace/lib/xod/core/ceil/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "BkdbLAuSPyZ",
-      "type": "xod/built-in/output-number",
+      "type": "xod/patch-nodes/output-number",
       "label": "CEIL",
       "description": "",
       "position": {
@@ -15,7 +15,7 @@
     },
     {
       "id": "H1v-80uHDyZ",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "X",
       "description": "",
       "position": {
@@ -32,7 +32,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/change-interrupt/patch.xodp
+++ b/workspace/lib/xod/core/change-interrupt/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "By8H5rDkZ",
-      "type": "xod/built-in/output-pulse",
+      "type": "xod/patch-nodes/output-pulse",
       "label": "FALL",
       "description": "",
       "position": {
@@ -15,7 +15,7 @@
     },
     {
       "id": "rJxr9rDJZ",
-      "type": "xod/built-in/output-pulse",
+      "type": "xod/patch-nodes/output-pulse",
       "label": "RISE",
       "description": "",
       "position": {
@@ -28,7 +28,7 @@
     },
     {
       "id": "rkuEqBD1W",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "PORT",
       "description": "",
       "position": {
@@ -45,7 +45,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/clock/patch.xodp
+++ b/workspace/lib/xod/core/clock/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "BkIZIA_rDk-",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "IVAL",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "ByHWU0drvkW",
-      "type": "xod/built-in/input-pulse",
+      "type": "xod/patch-nodes/input-pulse",
       "label": "RST",
       "description": "",
       "position": {
@@ -24,7 +24,7 @@
     },
     {
       "id": "rJVZUAdHwk-",
-      "type": "xod/built-in/output-pulse",
+      "type": "xod/patch-nodes/output-pulse",
       "label": "TICK",
       "description": "",
       "position": {
@@ -43,7 +43,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/console-log/patch.xodp
+++ b/workspace/lib/xod/core/console-log/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "HJdO9HwJ-",
-      "type": "xod/built-in/input-string",
+      "type": "xod/patch-nodes/input-string",
       "label": "LINE",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "S1n95SDJb",
-      "type": "xod/built-in/input-pulse",
+      "type": "xod/patch-nodes/input-pulse",
       "label": "DUMP",
       "description": "",
       "position": {
@@ -30,7 +30,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/constrain/patch.xodp
+++ b/workspace/lib/xod/core/constrain/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "BJgZ80uBw1-",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "MIN",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "BkmZL0uSv1W",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "X",
       "description": "",
       "position": {
@@ -24,7 +24,7 @@
     },
     {
       "id": "rJWWUAdHDyW",
-      "type": "xod/built-in/output-number",
+      "type": "xod/patch-nodes/output-number",
       "label": "XC",
       "description": "",
       "position": {
@@ -37,7 +37,7 @@
     },
     {
       "id": "ryzZIC_BDJW",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "MAX",
       "description": "",
       "position": {
@@ -54,7 +54,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/delay/patch.xodp
+++ b/workspace/lib/xod/core/delay/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "B1GeLR_BPyZ",
-      "type": "xod/built-in/output-boolean",
+      "type": "xod/patch-nodes/output-boolean",
       "label": "ACT",
       "description": "",
       "position": {
@@ -15,7 +15,7 @@
     },
     {
       "id": "Bk4gU0drwJ-",
-      "type": "xod/built-in/output-pulse",
+      "type": "xod/patch-nodes/output-pulse",
       "label": "DONE",
       "description": "",
       "position": {
@@ -28,7 +28,7 @@
     },
     {
       "id": "H1mlUC_HDJZ",
-      "type": "xod/built-in/input-pulse",
+      "type": "xod/patch-nodes/input-pulse",
       "label": "RST",
       "description": "",
       "position": {
@@ -39,7 +39,7 @@
     },
     {
       "id": "Skre8ROSv1-",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "T",
       "description": "",
       "position": {
@@ -56,7 +56,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/digital-input/patch.xodp
+++ b/workspace/lib/xod/core/digital-input/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "B1ZUA_Hv1W",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "PORT",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "B1gI0urv1W",
-      "type": "xod/built-in/output-boolean",
+      "type": "xod/patch-nodes/output-boolean",
       "label": "SIG",
       "description": "",
       "position": {
@@ -26,7 +26,7 @@
     },
     {
       "id": "SyLCdSwJZ",
-      "type": "xod/built-in/input-pulse",
+      "type": "xod/patch-nodes/input-pulse",
       "label": "UPD",
       "description": "",
       "position": {
@@ -43,7 +43,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/divide/patch.xodp
+++ b/workspace/lib/xod/core/divide/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "BkqLCOSw1W",
-      "type": "xod/built-in/output-number",
+      "type": "xod/patch-nodes/output-number",
       "label": "FRAC",
       "description": "",
       "position": {
@@ -15,7 +15,7 @@
     },
     {
       "id": "BytUCdHD1-",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "Y",
       "description": "",
       "position": {
@@ -26,7 +26,7 @@
     },
     {
       "id": "SkdIRuBD1b",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "X",
       "description": "",
       "position": {
@@ -43,7 +43,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/equal/patch.xodp
+++ b/workspace/lib/xod/core/equal/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "H1E8AuSPkZ",
-      "type": "xod/built-in/output-boolean",
+      "type": "xod/patch-nodes/output-boolean",
       "label": "EQ",
       "description": "",
       "position": {
@@ -15,7 +15,7 @@
     },
     {
       "id": "HJG8C_SPkb",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "RHS",
       "description": "",
       "position": {
@@ -26,7 +26,7 @@
     },
     {
       "id": "rJXICuSwyW",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "LHS",
       "description": "",
       "position": {
@@ -43,7 +43,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/flip-flop/patch.xodp
+++ b/workspace/lib/xod/core/flip-flop/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "B1RU0OrDkb",
-      "type": "xod/built-in/input-pulse",
+      "type": "xod/patch-nodes/input-pulse",
       "label": "RST",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "Bkh8A_Sv1-",
-      "type": "xod/built-in/input-pulse",
+      "type": "xod/patch-nodes/input-pulse",
       "label": "SET",
       "description": "",
       "position": {
@@ -24,7 +24,7 @@
     },
     {
       "id": "HkyxURuSPyW",
-      "type": "xod/built-in/output-boolean",
+      "type": "xod/patch-nodes/output-boolean",
       "label": "MEM",
       "description": "",
       "position": {
@@ -37,7 +37,7 @@
     },
     {
       "id": "HyjUA_HvkW",
-      "type": "xod/built-in/output-pulse",
+      "type": "xod/patch-nodes/output-pulse",
       "label": "CHNG",
       "description": "",
       "position": {
@@ -50,7 +50,7 @@
     },
     {
       "id": "ryTIROHwkW",
-      "type": "xod/built-in/input-pulse",
+      "type": "xod/patch-nodes/input-pulse",
       "label": "TGL",
       "description": "",
       "position": {
@@ -67,7 +67,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/floor/patch.xodp
+++ b/workspace/lib/xod/core/floor/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "SklxICdHP1b",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "X",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "rkWeUCdBDkZ",
-      "type": "xod/built-in/output-number",
+      "type": "xod/patch-nodes/output-number",
       "label": "FLR",
       "description": "",
       "position": {
@@ -32,7 +32,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/gate/patch.xodp
+++ b/workspace/lib/xod/core/gate/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "HkDgIRdrv1W",
-      "type": "xod/built-in/input-pulse",
+      "type": "xod/patch-nodes/input-pulse",
       "label": "DRN",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "S1OlUAuBD1-",
-      "type": "xod/built-in/input-boolean",
+      "type": "xod/patch-nodes/input-boolean",
       "label": "GATE",
       "description": "",
       "position": {
@@ -24,7 +24,7 @@
     },
     {
       "id": "SJUl8Aurv1W",
-      "type": "xod/built-in/output-pulse",
+      "type": "xod/patch-nodes/output-pulse",
       "label": "SRC",
       "description": "",
       "position": {
@@ -43,7 +43,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/greater/patch.xodp
+++ b/workspace/lib/xod/core/greater/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "r1YxLRdrwyZ",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "RHS",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "rkoeU0_Bwkb",
-      "type": "xod/built-in/output-boolean",
+      "type": "xod/patch-nodes/output-boolean",
       "label": "GT",
       "description": "",
       "position": {
@@ -26,7 +26,7 @@
     },
     {
       "id": "ry5eIAuBPkW",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "LHS",
       "description": "",
       "position": {
@@ -43,7 +43,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/if-else/patch.xodp
+++ b/workspace/lib/xod/core/if-else/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "S13xLCuHvkW",
-      "type": "xod/built-in/output-number",
+      "type": "xod/patch-nodes/output-number",
       "label": "R",
       "description": "",
       "position": {
@@ -15,7 +15,7 @@
     },
     {
       "id": "S1yZIA_rDJZ",
-      "type": "xod/built-in/input-boolean",
+      "type": "xod/patch-nodes/input-boolean",
       "label": "COND",
       "description": "",
       "position": {
@@ -26,7 +26,7 @@
     },
     {
       "id": "r1AgIROHDJW",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "F",
       "description": "",
       "position": {
@@ -37,7 +37,7 @@
     },
     {
       "id": "ryTeUROHD1b",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "T",
       "description": "",
       "position": {
@@ -54,7 +54,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/less/patch.xodp
+++ b/workspace/lib/xod/core/less/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "HJjZLRdBw1-",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "LHS",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "HktZUCdrPkZ",
-      "type": "xod/built-in/input-boolean",
+      "type": "xod/patch-nodes/input-boolean",
       "label": "LT",
       "description": "",
       "position": {
@@ -24,7 +24,7 @@
     },
     {
       "id": "SJqZ8COrDkW",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "RHS",
       "description": "",
       "position": {
@@ -41,7 +41,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/map-range/patch.xodp
+++ b/workspace/lib/xod/core/map-range/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "BJlzICOSv1-",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "X",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "H12bIR_SPyZ",
-      "type": "xod/built-in/output-number",
+      "type": "xod/patch-nodes/output-number",
       "label": "Xm",
       "description": "",
       "position": {
@@ -26,7 +26,7 @@
     },
     {
       "id": "HJCWLAdSwyW",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "Smax",
       "description": "",
       "position": {
@@ -37,7 +37,7 @@
     },
     {
       "id": "rJbGU0_Hv1Z",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "Tmin",
       "description": "",
       "position": {
@@ -48,7 +48,7 @@
     },
     {
       "id": "rkpbU0OrwyZ",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "Tmax",
       "description": "",
       "position": {
@@ -59,7 +59,7 @@
     },
     {
       "id": "ry1z8CuBDy-",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "Smin",
       "description": "",
       "position": {
@@ -76,7 +76,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/multiply/patch.xodp
+++ b/workspace/lib/xod/core/multiply/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "B1GfLR_SPk-",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "X",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "BkQzLCurwJZ",
-      "type": "xod/built-in/output-number",
+      "type": "xod/patch-nodes/output-number",
       "label": "PROD",
       "description": "",
       "position": {
@@ -26,7 +26,7 @@
     },
     {
       "id": "SJ4zUC_BD1-",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "Y",
       "description": "",
       "position": {
@@ -43,7 +43,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/nand/patch.xodp
+++ b/workspace/lib/xod/core/nand/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "BkwGIROSw1Z",
-      "type": "xod/built-in/input-boolean",
+      "type": "xod/patch-nodes/input-boolean",
       "label": "A",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "HkHG8COBPJ-",
-      "type": "xod/built-in/input-boolean",
+      "type": "xod/patch-nodes/input-boolean",
       "label": "B",
       "description": "",
       "position": {
@@ -24,7 +24,7 @@
     },
     {
       "id": "r18G80_Hvyb",
-      "type": "xod/built-in/output-boolean",
+      "type": "xod/patch-nodes/output-boolean",
       "label": "NAND",
       "description": "",
       "position": {
@@ -43,7 +43,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/nor/patch.xodp
+++ b/workspace/lib/xod/core/nor/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "S1dG8AOBPJW",
-      "type": "xod/built-in/input-boolean",
+      "type": "xod/patch-nodes/input-boolean",
       "label": "B",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "r1tz8CdBDkb",
-      "type": "xod/built-in/input-boolean",
+      "type": "xod/patch-nodes/input-boolean",
       "label": "A",
       "description": "",
       "position": {
@@ -24,7 +24,7 @@
     },
     {
       "id": "rJqfIRdHwkW",
-      "type": "xod/built-in/output-boolean",
+      "type": "xod/patch-nodes/output-boolean",
       "label": "NOR",
       "description": "",
       "position": {
@@ -43,7 +43,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/not/patch.xodp
+++ b/workspace/lib/xod/core/not/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "r1if8ROSDJ-",
-      "type": "xod/built-in/output-boolean",
+      "type": "xod/patch-nodes/output-boolean",
       "label": "NOTX",
       "description": "",
       "position": {
@@ -15,7 +15,7 @@
     },
     {
       "id": "ry3zLA_Bv1Z",
-      "type": "xod/built-in/input-boolean",
+      "type": "xod/patch-nodes/input-boolean",
       "label": "X",
       "description": "",
       "position": {
@@ -32,7 +32,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/or/patch.xodp
+++ b/workspace/lib/xod/core/or/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "BJaG80urD1-",
-      "type": "xod/built-in/input-boolean",
+      "type": "xod/patch-nodes/input-boolean",
       "label": "A",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "HJCfI0dBDkb",
-      "type": "xod/built-in/input-boolean",
+      "type": "xod/patch-nodes/input-boolean",
       "label": "B",
       "description": "",
       "position": {
@@ -24,7 +24,7 @@
     },
     {
       "id": "SJyXI0OrD1-",
-      "type": "xod/built-in/output-boolean",
+      "type": "xod/patch-nodes/output-boolean",
       "label": "OR",
       "description": "",
       "position": {
@@ -43,7 +43,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/pwm-output/patch.xodp
+++ b/workspace/lib/xod/core/pwm-output/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "ByXnYHPyb",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "DUTY",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "rJsaFSvk-",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "PORT",
       "description": "",
       "position": {
@@ -24,7 +24,7 @@
     },
     {
       "id": "rkAnKBvyZ",
-      "type": "xod/built-in/input-pulse",
+      "type": "xod/patch-nodes/input-pulse",
       "label": "UPD",
       "description": "",
       "position": {
@@ -41,7 +41,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/round/patch.xodp
+++ b/workspace/lib/xod/core/round/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "BkF78AurDJW",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "X",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "rkO7L0uSP1Z",
-      "type": "xod/built-in/output-number",
+      "type": "xod/patch-nodes/output-number",
       "label": "RND",
       "description": "",
       "position": {
@@ -32,7 +32,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/subtract/patch.xodp
+++ b/workspace/lib/xod/core/subtract/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "BypX80uSD1Z",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "X",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "HyRmUCdBDkZ",
-      "type": "xod/built-in/output-number",
+      "type": "xod/patch-nodes/output-number",
       "label": "DIFF",
       "description": "",
       "position": {
@@ -26,7 +26,7 @@
     },
     {
       "id": "rkJ4URuHDJ-",
-      "type": "xod/built-in/input-number",
+      "type": "xod/patch-nodes/input-number",
       "label": "Y",
       "description": "",
       "position": {
@@ -43,7 +43,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/system-time/patch.xodp
+++ b/workspace/lib/xod/core/system-time/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "Bk74I0_SPyb",
-      "type": "xod/built-in/input-pulse",
+      "type": "xod/patch-nodes/input-pulse",
       "label": "UPD",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "BkEVI0uHwJb",
-      "type": "xod/built-in/output-number",
+      "type": "xod/patch-nodes/output-number",
       "label": "TIME",
       "description": "",
       "position": {
@@ -32,7 +32,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],

--- a/workspace/lib/xod/core/xor/patch.xodp
+++ b/workspace/lib/xod/core/xor/patch.xodp
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "HkOV8CdSvyW",
-      "type": "xod/built-in/input-boolean",
+      "type": "xod/patch-nodes/input-boolean",
       "label": "A",
       "description": "",
       "position": {
@@ -13,7 +13,7 @@
     },
     {
       "id": "Hkw48AdSPyb",
-      "type": "xod/built-in/output-boolean",
+      "type": "xod/patch-nodes/output-boolean",
       "label": "XOR",
       "description": "",
       "position": {
@@ -26,7 +26,7 @@
     },
     {
       "id": "SkKNUR_SwyW",
-      "type": "xod/built-in/input-boolean",
+      "type": "xod/patch-nodes/input-boolean",
       "label": "B",
       "description": "",
       "position": {
@@ -43,7 +43,7 @@
         "x": 100,
         "y": 100
       },
-      "type": "xod/built-in/not-implemented-in-xod",
+      "type": "xod/patch-nodes/not-implemented-in-xod",
       "boundValues": {}
     }
   ],


### PR DESCRIPTION
Closes #523