### PR TITLE
Show normalized pin labels in the UI

### DIFF
--- a/packages/xod-client/src/editor/components/NodeInspector.jsx
+++ b/packages/xod-client/src/editor/components/NodeInspector.jsx
@@ -27,6 +27,7 @@ const getPinWidgetProps = R.applySpec({
   keyName: XP.getPinKey,
   type: XP.getPinType,
   label: XP.getPinLabel,
+  normalizedLabel: R.prop('normalizedLabel'),
   value: R.prop('value'),
   direction: XP.getPinDirection,
   isConnected: R.prop('isConnected'),

--- a/packages/xod-client/src/editor/components/inspectorWidgets/Widget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/Widget.jsx
@@ -99,6 +99,7 @@ export default function composeWidget(Component, widgetProps) {
           <Component
             elementId={elementId}
             label={this.props.label}
+            normalizedLabel={this.props.normalizedLabel}
             isConnected={this.props.isConnected}
             isBindable={this.props.isBindable}
             direction={this.props.direction}
@@ -121,6 +122,7 @@ export default function composeWidget(Component, widgetProps) {
     keyName: React.PropTypes.string.isRequired, // one of NODE_PROPERTY_KEY or pin key
     kind: React.PropTypes.string,
     label: React.PropTypes.string,
+    normalizedLabel: React.PropTypes.string,
     direction: React.PropTypes.string,
     value: React.PropTypes.oneOfType([
       React.PropTypes.string,
@@ -139,6 +141,7 @@ export default function composeWidget(Component, widgetProps) {
   Widget.defaultProps = {
     className: '',
     label: 'Unknown property',
+    normalizedLabel: '',
     value: '',
     focused: false,
     isConnected: false,

--- a/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/BoolPinWidget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/BoolPinWidget.jsx
@@ -11,6 +11,7 @@ function BoolWidget(props) {
     <PinWidget
       elementId={props.elementId}
       label={props.label}
+      normalizedLabel={props.normalizedLabel}
       dataType={props.dataType}
       isConnected={props.isConnected}
       isBindable={props.isBindable}
@@ -33,6 +34,7 @@ function BoolWidget(props) {
 BoolWidget.propTypes = {
   elementId: React.PropTypes.string.isRequired,
   label: React.PropTypes.string,
+  normalizedLabel: React.PropTypes.string.isRequired,
   dataType: React.PropTypes.string,
   isConnected: React.PropTypes.bool,
   isBindable: React.PropTypes.bool,

--- a/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/NumberPinWidget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/NumberPinWidget.jsx
@@ -18,6 +18,7 @@ const NumberWidget = (props) => {
     <PinWidget
       elementId={props.elementId}
       label={props.label}
+      normalizedLabel={props.normalizedLabel}
       dataType={props.dataType}
       isConnected={props.isConnected}
       isBindable={props.isBindable}
@@ -38,6 +39,7 @@ const NumberWidget = (props) => {
 
 NumberWidget.propTypes = {
   elementId: React.PropTypes.string.isRequired,
+  normalizedLabel: React.PropTypes.string.isRequired,
   label: React.PropTypes.string,
   dataType: React.PropTypes.string,
   isConnected: React.PropTypes.bool,

--- a/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/PinWidget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/PinWidget.jsx
@@ -37,9 +37,8 @@ function PinWidget(props) {
         value={getReason(props)}
       />
     ) : props.children;
-
   return (
-    <div className="Widget PinWidget">
+    <div className="Widget PinWidget" title={props.normalizedLabel}>
       {input}
       <PinIcon
         id={props.elementId}
@@ -57,6 +56,7 @@ function PinWidget(props) {
 
 PinWidget.propTypes = {
   elementId: React.PropTypes.string.isRequired,
+  normalizedLabel: React.PropTypes.string.isRequired,
   label: React.PropTypes.string,
   dataType: React.PropTypes.string,
   isConnected: React.PropTypes.bool,

--- a/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/PulsePinWidget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/PulsePinWidget.jsx
@@ -6,6 +6,7 @@ const PulseWidget = props => (
   <PinWidget
     elementId={props.elementId}
     label={props.label}
+    normalizedLabel={props.normalizedLabel}
     dataType={props.dataType}
     isConnected={props.isConnected}
     isBindable={props.isBindable}
@@ -22,6 +23,7 @@ const PulseWidget = props => (
 
 PulseWidget.propTypes = {
   elementId: React.PropTypes.string.isRequired,
+  normalizedLabel: React.PropTypes.string.isRequired,
   label: React.PropTypes.string,
   dataType: React.PropTypes.string,
   isConnected: React.PropTypes.bool,

--- a/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/StringPinWidget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/StringPinWidget.jsx
@@ -11,6 +11,7 @@ const StringWidget = (props) => {
     <PinWidget
       elementId={props.elementId}
       label={props.label}
+      normalizedLabel={props.normalizedLabel}
       dataType={props.dataType}
       isConnected={props.isConnected}
       isBindable={props.isBindable}
@@ -30,6 +31,7 @@ const StringWidget = (props) => {
 
 StringWidget.propTypes = {
   elementId: React.PropTypes.string.isRequired,
+  normalizedLabel: React.PropTypes.string.isRequired,
   label: React.PropTypes.string,
   dataType: React.PropTypes.string,
   isConnected: React.PropTypes.bool,

--- a/packages/xod-client/src/project/selectors.js
+++ b/packages/xod-client/src/project/selectors.js
@@ -96,9 +96,19 @@ const mergePinDataFromPatch = R.curry((project, node) => {
       XP.getBoundValueOrDefault(pin, node),
       pin
     )),
+    patchPins => R.compose(
+      R.mergeWith(R.merge, R.__, patchPins),
+      R.map(R.compose(
+        R.objOf('normalizedLabel'),
+        XP.getPinLabel
+      )),
+      R.indexBy(XP.getPinKey),
+      XP.normalizePinLabels,
+      R.values
+    )(patchPins),
     // TODO: add something like getPinsIndexedByKey to xod-project?
     // + see other 'indexBy's below
-    R.indexBy(R.prop('key')),
+    R.indexBy(XP.getPinKey),
     XP.listPins,
     XP.getPatchByPathUnsafe(type)
   )(project);


### PR DESCRIPTION
It will completely close #491.
Normalised pin labels displayed in the `title` attribute of PinWidgets in the Inspector (just hover over a row to show what you will get in the implementations).