### PR TITLE
Add test for error message if Node refers to non-existent patch

### DIFF
--- a/packages/xod-project/src/flatten.js
+++ b/packages/xod-project/src/flatten.js
@@ -130,7 +130,7 @@ const extractLeafPatchesFromNodes = R.curry((recursiveFn, impls, project, patch)
 );
 
 // :: String[] -> Project -> Path -> [Either Error [Path, Patch]]
-const extractLeafPatches = R.curry((impls, project, path, patch) =>
+export const extractLeafPatches = R.curry((impls, project, path, patch) =>
   R.cond([
     [
       isLeafPatchWithImplsOrTerminal(impls),


### PR DESCRIPTION
It completely fixes #556.
@nkrkv almost done this issue with PR #564, so I've added a just test for this case.