### PR TITLE
feat(xod-project): add getPatchDescription/setPatchDescription functions

### DIFF
--- a/packages/xod-project/src/index.js
+++ b/packages/xod-project/src/index.js
@@ -3,6 +3,8 @@ export {
   createPatch,
   duplicatePatch,
   getPatchPath,
+  getPatchDescription,
+  setPatchDescription,
   listImpls,
   hasImpls,
   getImpl,

--- a/packages/xod-project/src/patch.js
+++ b/packages/xod-project/src/patch.js
@@ -73,6 +73,16 @@ export const setPatchPath = def(
   )
 );
 
+export const getPatchDescription = def(
+  'getPatchDescription :: Patch -> String',
+  R.prop('description')
+);
+
+export const setPatchDescription = def(
+  'setPatchDescription :: String -> Patch -> Patch',
+  R.assoc('description')
+);
+
  /**
   * Returns a list of implementations for which a `patch` has native implementation
   *


### PR DESCRIPTION
because `Patch` has a `description` field, but no functions to get/set it 😬