### PR TITLE
tweak(xod-project, xod-fs, xod-client): ensure that Project has a valid version

### DIFF
--- a/packages/xod-client/src/project/state.js
+++ b/packages/xod-client/src/project/state.js
@@ -7,7 +7,7 @@ export default {
   description: '',
   license: '',
   name: 'untitled',
-  version: '',
+  version: '0.0.0',
   patches: {
     '@/1': {
       impls: {},

--- a/packages/xod-client/test/reducers/editor.spec.js
+++ b/packages/xod-client/test/reducers/editor.spec.js
@@ -62,7 +62,7 @@ describe('Editor reducer', () => {
         ],
         description: '',
         license: '',
-        version: '',
+        version: '0.0.0',
         name: 'Test project',
         patches: {
           '@/1': {

--- a/packages/xod-client/test/regression.spec.js
+++ b/packages/xod-client/test/regression.spec.js
@@ -20,7 +20,7 @@ const initialProject = defaultizeProject({
   ],
   description: '',
   license: '',
-  version: '',
+  version: '0.0.0',
   name: 'Awesome project',
   patches: {
     '@/main': {},

--- a/packages/xod-fs/test/fixtures/unpacked.json
+++ b/packages/xod-fs/test/fixtures/unpacked.json
@@ -7,7 +7,7 @@
       ],
       "description": "",
       "license": "",
-      "version": "42",
+      "version": "0.0.42",
       "name": "awesome-project"
     }
   },

--- a/packages/xod-fs/test/fixtures/workspace/awesome-project/project.xod
+++ b/packages/xod-fs/test/fixtures/workspace/awesome-project/project.xod
@@ -5,5 +5,5 @@
   "description": "",
   "license": "",
   "name": "awesome-project",
-  "version": "42"
+  "version": "0.0.42"
 }

--- a/packages/xod-fs/test/fixtures/xodball.json
+++ b/packages/xod-fs/test/fixtures/xodball.json
@@ -4,7 +4,7 @@
   ],
   "description": "",
   "license": "",
-  "version": "42",
+  "version": "0.0.42",
   "name": "awesome-project",
   "patches": {
     "xod/core/and": {

--- a/packages/xod-fs/test/load.spec.js
+++ b/packages/xod-fs/test/load.spec.js
@@ -40,7 +40,7 @@ describe('Loader', () => {
               description: '',
               license: '',
               name: 'awesome-project',
-              version: '42',
+              version: '0.0.42',
             },
           },
         ]);

--- a/packages/xod-project/src/project.js
+++ b/packages/xod-project/src/project.js
@@ -32,7 +32,7 @@ export const createProject = def(
     authors: [],
     description: '',
     license: '',
-    version: '',
+    version: '0.0.0',
     patches: {},
     name: 'untitled',
   })

--- a/packages/xod-project/src/types.js
+++ b/packages/xod-project/src/types.js
@@ -98,7 +98,7 @@ export const Project = Model('Project', {
   name: Identifier,
   authors: $.Array($.String),
   license: $.String,
-  version: $.String,
+  version: Version,
   description: $.String,
 });
 

--- a/packages/xod-project/test/fixtures/blinking.flat.json
+++ b/packages/xod-project/test/fixtures/blinking.flat.json
@@ -1,13 +1,11 @@
 {
-  "version": "",
   "name": "untitled",
   "authors": [],
   "description": "",
   "license": "",
-  "version": "",
+  "version": "0.0.0",
   "patches": {
     "xod/core/digital-output": {
-      "description": "",
       "path": "xod/core/digital-output",
       "nodes": {
         "noNativeImpl": {
@@ -51,7 +49,6 @@
       }
     },
     "xod/math/multiply": {
-      "description": "",
       "path": "xod/math/multiply",
       "nodes": {
         "noNativeImpl": {
@@ -106,7 +103,6 @@
       }
     },
     "xod/core/latch": {
-      "description": "",
       "path": "xod/core/latch",
       "nodes": {
         "noNativeImpl": {
@@ -172,7 +168,6 @@
       }
     },
     "xod/core/clock": {
-      "description": "",
       "path": "xod/core/clock",
       "nodes": {
         "noNativeImpl": {
@@ -216,7 +211,6 @@
       }
     },
     "xod/core/cast-boolean-to-number": {
-      "description": "",
       "path": "xod/core/cast-boolean-to-number",
       "nodes": {
         "noNativeImpl": {
@@ -260,7 +254,6 @@
       }
     },
     "@/main": {
-      "description": "",
       "path": "@/main",
       "nodes": {
         "SJ7g05EdFe~rJWgAqVOtx": {

--- a/packages/xod-project/test/fixtures/blinking.json
+++ b/packages/xod-project/test/fixtures/blinking.json
@@ -6,7 +6,7 @@
   "name": "awesome-project",
   "description": "",
   "license": "",
-  "version": "",
+  "version": "0.0.0",
   "patches": {
     "xod/math/subtrac": {
       "description": "",

--- a/packages/xod-project/test/helpers.js
+++ b/packages/xod-project/test/helpers.js
@@ -153,7 +153,7 @@ export const defaultizeProject = R.compose(
     authors: [],
     license: '',
     description: '',
-    version: '',
+    version: '0.0.0',
     patches: {},
     name: 'test-project-name',
   })

--- a/workspace/arduino-starter-kit/project.xod
+++ b/workspace/arduino-starter-kit/project.xod
@@ -3,5 +3,5 @@
   "description": "",
   "license": "",
   "name": "arduino-starter-kit",
-  "version": ""
+  "version": "0.0.0"
 }


### PR DESCRIPTION
no issue for this, but here are some problems that this PR is solving:

In code:
- `createProject`
- `getProjectVersion`
- it expects that return value will be `Version`, **BOOM**

User scenario:
- create new project
- add some patches etc, save it
- try to publish it
- **BOOM**, `xodc` throws exception
