### PR TITLE
Tweak: Selected serial port defaults to any USB or ACM

### DIFF
--- a/packages/xod-client-electron/src/upload/components/PopupUploadConfig.jsx
+++ b/packages/xod-client-electron/src/upload/components/PopupUploadConfig.jsx
@@ -77,9 +77,17 @@ class PopupUploadConfig extends React.Component {
       .then(R.tap(ports => this.setState({ ports })))
       .then((ports) => {
         const hasSelectedPort = R.contains(this.props.selectedPort, ports);
+        const defaultPort = (ports && ports.length > 0) ? ports[0] : null;
+        const defaultPreferredPort = R.compose(
+          R.defaultTo(defaultPort),
+          R.find(R.compose(
+            R.test(/^(\/dev\/ttyUSB|\/dev\/tty.usb|\/dev\/cu.usb|\/dev\/ttyACM)/i),
+            R.prop('comName')
+          ))
+        )(ports);
+
         if (!hasSelectedPort) {
-          const portToSelect = (ports && ports.length > 0) ? ports[0] : null;
-          this.changePort(portToSelect);
+          this.changePort(defaultPreferredPort);
         }
       });
   }


### PR DESCRIPTION
In Arduino Upload Config Popup.
If nothing selected before.
No issue 😬 