### PR TITLE
feat(xod-client-browser): production versions of IDEs should build with NODE_ENV=production

### DIFF
--- a/packages/xod-client-browser/concourse/deploy.yaml
+++ b/packages/xod-client-browser/concourse/deploy.yaml
@@ -1,0 +1,33 @@
+image_resource:
+  source:
+    repository: node
+    tag: 7.10.0
+  type: docker-image
+inputs:
+  - name: xod
+outputs:
+  - name: ide
+platform: linux
+run:
+  args:
+    - '-exc'
+    - |
+      IDE=$(realpath ide)
+      XOD=$(realpath xod)
+
+      cd "$XOD" || exit 1
+      export NODE_ENV=production
+      yarn install --no-progress
+      yarn run build
+
+      cd "$XOD/packages/xod-client-browser" || exit 1
+      echo 'double-tap' >DOUBLE_TAP
+      echo 'xodio/ide' >IMAGE_NAME
+      node -p 'require("./package.json").version' >VERSION
+      cp -at "$IDE"  \
+       "$XOD/packages/xod-client-browser/dist"  \
+       "$XOD/packages/xod-client-browser/Dockerfile"  \
+       "$XOD/packages/xod-client-browser/DOUBLE_TAP"  \
+       "$XOD/packages/xod-client-browser/IMAGE_NAME"  \
+       "$XOD/packages/xod-client-browser/VERSION"
+  path: sh


### PR DESCRIPTION
Closes #638.