### PR TITLE
Fix React warning due to the lack of key

### DIFF
--- a/packages/xod-client/src/projectBrowser/containers/ProjectBrowser.jsx
+++ b/packages/xod-client/src/projectBrowser/containers/ProjectBrowser.jsx
@@ -165,6 +165,7 @@ class ProjectBrowser extends React.Component {
         target="_blank"
         rel="noopener noreferrer"
         className="hover-button"
+        key="patch-guide-button"
       >
         <IconGuide
           className="project-browser--guide-button"


### PR DESCRIPTION
It appeared in the #647.