### PR TITLE
feat(xod-client): allow snack bar messages have buttons and not hide on timeout

### DIFF
--- a/packages/xod-client/src/core/styles/components/SnackBarMessage.scss
+++ b/packages/xod-client/src/core/styles/components/SnackBarMessage.scss
@@ -45,6 +45,14 @@
     cursor: default;
     outline: none;
 
-    p { margin: 0; }
+    .message-content { margin: 0; }
+  }
+
+  .SnackBar-buttons-container {
+    margin-top: 7px;
+
+    .Button {
+      margin-right: 5px;
+    }
   }
 }

--- a/packages/xod-client/src/messages/actions.js
+++ b/packages/xod-client/src/messages/actions.js
@@ -4,11 +4,12 @@ import { STATUS } from '../utils/constants';
 
 const getTimestamp = () => new Date().getTime();
 
-export const addMessage = (type, message) => ({
+export const addMessage = (type, message, buttons = [], persistent = false) => ({
   type: ActionType.MESSAGE_ADD,
-  payload: { message },
+  payload: { message, buttons },
   meta: {
     type,
+    persistent,
     timestamp: getTimestamp(),
     status: STATUS.STARTED,
   },
@@ -25,6 +26,6 @@ export const deleteMessage = id => ({
   },
 });
 
-export const addError = message => addMessage(MESSAGE_TYPE.ERROR, message);
-export const addConfirmation = message => addMessage(MESSAGE_TYPE.CONFIRMATION, message);
-export const addNotification = message => addMessage(MESSAGE_TYPE.NOTIFICATION, message);
+export const addError = (...args) => addMessage(MESSAGE_TYPE.ERROR, ...args);
+export const addConfirmation = (...args) => addMessage(MESSAGE_TYPE.CONFIRMATION, ...args);
+export const addNotification = (...args) => addMessage(MESSAGE_TYPE.NOTIFICATION, ...args);

--- a/packages/xod-client/src/messages/components/SnackBarMessage.jsx
+++ b/packages/xod-client/src/messages/components/SnackBarMessage.jsx
@@ -25,20 +25,33 @@ class SnackBarMessage extends React.Component {
   }
 
   getMessageContent() {
-    const message = this.props.message;
+    const { message, onClickMessageButton } = this.props;
 
-    if (message.type === MESSAGE_TYPE.ERROR) {
-      return (
-        <p>
-          {message.payload.message}
-        </p>
-      );
-    }
+    const buttons = R.unless(
+      R.isEmpty,
+      R.compose(
+        btns => React.createElement(
+          'div',
+          { className: 'SnackBar-buttons-container' },
+          btns
+        ),
+        R.map(({ id, text }) => (
+          <button
+            className="Button Button--small"
+            key={id}
+            onClick={() => onClickMessageButton(id, message)}
+          >
+            {text}
+          </button>
+        ))
+      )
+    )(message.payload.buttons);
 
     return (
-      <p>
+      <div className="message-content">
         {message.payload.message}
-      </p>
+        {buttons}
+      </div>
     );
   }
 
@@ -64,7 +77,7 @@ class SnackBarMessage extends React.Component {
   }
 
   render() {
-    const message = this.props.message;
+    const { message } = this.props;
     const cls = classNames('SnackBarMessage', {
       hidden: this.state.hidden,
       display: this.state.display,
@@ -77,7 +90,6 @@ class SnackBarMessage extends React.Component {
     return (
       <li
         className={cls}
-        dataId={message.id}
       >
         <a tabIndex={message.id} >
           {messageContent}
@@ -88,7 +100,25 @@ class SnackBarMessage extends React.Component {
 }
 
 SnackBarMessage.propTypes = {
-  message: PropTypes.object,
+  message: PropTypes.shape({
+    /* eslint-disable react/no-unused-prop-types */
+    id: PropTypes.number,
+    type: PropTypes.string,
+    persistent: PropTypes.bool,
+    payload: PropTypes.shape({
+      message: PropTypes.string.isRequired,
+      buttons: PropTypes.arrayOf(PropTypes.shape({
+        id: PropTypes.string,
+        text: PropTypes.string,
+      })).isRequired,
+    }),
+    /* eslint-enable react/no-unused-prop-types */
+  }),
+  onClickMessageButton: PropTypes.func,
+};
+
+SnackBarMessage.defaultProps = {
+  onClickMessageButton: () => {},
 };
 
 export default SnackBarMessage;

--- a/packages/xod-client/src/messages/reducer.js
+++ b/packages/xod-client/src/messages/reducer.js
@@ -12,6 +12,7 @@ export default (messages = {}, action) => {
           id: newId,
           type: action.meta.type,
           timestamp: action.meta.timestamp,
+          persistent: action.meta.persistent,
           payload: action.payload,
         },
         messages

--- a/packages/xod-client/stories/SnackBarMessage.jsx
+++ b/packages/xod-client/stories/SnackBarMessage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { storiesOf } from '@kadira/storybook';
+import { storiesOf, action } from '@kadira/storybook';
 
 import '../src/core/styles/main.scss';
 import SnackBarMessage from '../src/messages/components/SnackBarMessage';
@@ -9,6 +9,7 @@ const err = {
   id: 1,
   payload: {
     message: 'Something bad just happened',
+    buttons: [],
   },
   timestamp: 1234567890,
   type: MESSAGE_TYPE.ERROR,
@@ -18,6 +19,7 @@ const confirmationMsg = {
   id: 2,
   payload: {
     message: 'Please confirm something',
+    buttons: [],
   },
   timestamp: 1234567890,
   type: MESSAGE_TYPE.CONFIRMATION,
@@ -27,9 +29,24 @@ const notificationMsg = {
   id: 3,
   payload: {
     message: 'Something happened. Just wanted you to know.',
+    buttons: [],
   },
   timestamp: 1234567890,
-  type: MESSAGE_TYPE.NOTIFICATION
+  type: MESSAGE_TYPE.NOTIFICATION,
+};
+
+const notificationWithBtns = {
+  id: 4,
+  payload: {
+    message: 'Something happened. What should we do with it?',
+    buttons: [
+      { id: 'abort', text: 'Abort' },
+      { id: 'retry', text: 'Retry' },
+      { id: 'ignore', text: 'Ignore' },
+    ],
+  },
+  timestamp: 1234567890,
+  type: MESSAGE_TYPE.CONFIRMATION,
 };
 
 storiesOf('SnackBarMessage', module)
@@ -53,6 +70,12 @@ storiesOf('SnackBarMessage', module)
       message={notificationMsg}
     />
   ))
+  .add('notification with buttons', () => (
+    <SnackBarMessage
+      message={notificationWithBtns}
+      onClickMessageButton={action('OnButton')}
+    />
+  ))
   .add('multiple messages', () => (
     <ul className="SnackBarList">
       <SnackBarMessage
@@ -63,6 +86,10 @@ storiesOf('SnackBarMessage', module)
       />
       <SnackBarMessage
         message={notificationMsg}
+      />
+      <SnackBarMessage
+        message={notificationWithBtns}
+        onClickMessageButton={action('OnButton')}
       />
     </ul>
   ));


### PR DESCRIPTION
This is required for #528.

Summary of additions to APIs:

- `addMessage` action creator now accepts 2 more parameters(both are optional): `buttons` and `persistent`:
For example, `addMessage(MESSAGE_TYPE.CONFIRMATION, 'Something happened', [{ id: 'ok', text: 'Ok' }], false)` will create a confirmation that will have an 'Ok' button and won't disappear on timeout.
- `SnackBar` container now has an `onClickMessageButton` callback prop, that will be called when a button in a message is pressed with button `id` as a first argument and the whole message object as a second.
