### PR TITLE
Support for prerelease branches

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,18 +19,6 @@ install:
 
 build_script:
 - yarn run build
-- ps: |
-    $tags=(git tag --points-at $env:APPVEYOR_REPO_COMMIT)
-    if ($tags) {
-      yarn run electron-dist
-      $config = New-TemporaryFile
-      echo $env:GOOGLE_CLOUD_STORAGE_CONFIG | node -e "console.log(new Buffer ('$env:GOOGLE_CLOUD_STORAGE_CONFIG', 'base64').toString('utf8').trim())" > $config
-      (Get-Content -Path $config) | %{ $_.Replace("\xEF\xBB\xBF", "") } | Set-Content -Path $config
-      foreach ($tag in $tags) {
-        foreach ($file in (Get-ChildItem -Path packages/xod-client-electron/dist -File)) {
-          node tools/electron-upload.js --config=$config --file=$($file.FullName) --tag=$tag
-        }
-      }
-    }
+- ps: . .\tools\appveyor.ps1
 
 test: off

--- a/tools/appveyor.ps1
+++ b/tools/appveyor.ps1
@@ -1,0 +1,27 @@
+
+function Upload-Dist-To-GCS($tag) {
+  $config = New-TemporaryFile
+  echo $env:GOOGLE_CLOUD_STORAGE_CONFIG | node -e "console.log(new Buffer ('$env:GOOGLE_CLOUD_STORAGE_CONFIG', 'base64').toString('utf8').trim())" > $config
+  (Get-Content -Path $config) | %{ $_.Replace("\xEF\xBB\xBF", "") } | Set-Content -Path $config
+  foreach ($file in (Get-ChildItem -Path packages/xod-client-electron/dist -File)) {
+    node tools/electron-upload.js --config=$config --file=$($file.FullName) --tag=$tag
+  }
+}
+
+$tags=(git tag --points-at $env:APPVEYOR_REPO_COMMIT)
+
+if ($tags) {
+  yarn run electron-dist
+  foreach ($tag in $tags) {
+    Upload-Dist-To-GCS $tag
+  }
+}
+
+if ($env:APPVEYOR_REPO_BRANCH.StartsWith("prerelease")) {
+  Write-Host 'Building prerelease distributive...' -ForegroundColor Yellow
+  yarn lerna -- publish --skip-git --skip-npm --cd-version=minor --yes
+  yarn lerna -- publish --skip-git --skip-npm --canary --yes
+  $tag=(node -e "console.log('v' + require('./packages/xod-client-electron/package.json').version)")
+  yarn run electron-dist
+  Upload-Dist-To-GCS $tag
+}

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -1,17 +1,34 @@
 #!/usr/bin/env bash
 
-set -ev
+set -e
+
+upload_dist_to_gcs() {
+    tag=$1
+    config=$(mktemp)
+    echo "$GOOGLE_CLOUD_STORAGE_CONFIG" | base64 --decode >"$config"
+    find packages/xod-client-electron/dist -maxdepth 1 -type f \
+        -exec node tools/electron-upload.js \
+            --config="$config" --file={} --tag="$tag" \;
+}
 
 tags=$(git tag --points-at "$TRAVIS_COMMIT")
 if [ -n "$tags" ]; then
     yarn run electron-dist
-    config=$(mktemp)
-    echo "$GOOGLE_CLOUD_STORAGE_CONFIG" | base64 --decode >"$config"
     while read -r tag; do
         node tools/extract-release-notes.js "${tag#v}"  \
             <CHANGELOG.md >packages/xod-client-electron/dist/RELEASE_NOTES.md
-        find packages/xod-client-electron/dist -maxdepth 1 -type f \
-            -exec node tools/electron-upload.js \
-                --config="$config" --file={} --tag="$tag" \;
+        upload_dist_to_gcs $tag
     done <<<"$tags"
+fi
+
+if [[ $TRAVIS_BRANCH == prerelease-* ]]; then
+    echo 'Building prerelease distributive...'
+    # Lerna bug https://github.com/lerna/lerna/issues/915
+    # we have to run publish twice to change a version from
+    # 0.42.0 to 0.42.0-alpha.abcdef
+    lerna publish --skip-git --skip-npm --cd-version=minor --yes
+    lerna publish --skip-git --skip-npm --canary --yes
+    tag=$(node -e "console.log('v' + require('./packages/xod-client-electron/package.json').version)")
+    yarn run electron-dist
+    upload_dist_to_gcs $tag
 fi


### PR DESCRIPTION
This PR adds support to build a new development distributive set without abusing git tags.

Every commit to a branch named `prerelease-*` (wildcard glob) would run distro packaging process and publish distributives with a version tag like `v0.42.0-alpha.abcdef` where `abcdef` is a git SHA of the commit pushed.