### PR TITLE
Allow fractional steps in `count` node

### DIFF
--- a/workspace/lib/xod/core/count/any.cpp
+++ b/workspace/lib/xod/core/count/any.cpp
@@ -1,6 +1,6 @@
 
 struct State {
-    int32_t count = 0;
+    Number count = 0;
 };
 
 {{ GENERATED_CODE }}
@@ -11,7 +11,7 @@ void evaluate(Context ctx) {
     if (isInputDirty<input_RST>(ctx)) {
         state->count = 0;
     } else if (isInputDirty<input_INC>(ctx)) {
-        auto step = (int32_t)getValue<input_STEP>(ctx);
+        auto step = getValue<input_STEP>(ctx);
         state->count += step;
     }
 


### PR DESCRIPTION
Silly bug fix #735 