### PR TITLE
Move static data to the PGM space on AVR MCU’s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: node_js
+node_js: '7.10.1'
+sudo: false
+dist: trusty
 
 matrix:
   fast_finish: true
   include:
   - os: linux
-    node_js: '7.10.1'
-    sudo: false
-    dist: trusty
+    python: '2.7' # for PlatformIO
   - os: osx
-    node_js: '7.10.1'
     osx_image: xcode8.3
 
 addons:
@@ -28,10 +28,21 @@ env:
 cache:
   directories:
   - node_modules
+  - packages/xod-arduino-deploy/node_modules
+  - packages/xod-arduino/node_modules
+  - packages/xod-cli/node_modules
+  - packages/xod-client-browser/node_modules
+  - packages/xod-client-electron/node_modules
+  - packages/xod-client/node_modules
+  - packages/xod-fs/node_modules
+  - packages/xod-func-tools/node_modules
+  - packages/xod-project/node_modules
   - $HOME/.cache/electron
   - $HOME/.cache/electron-builder
   - $HOME/.npm/_prebuilds
+  - $HOME/.platformio
   yarn: true
+  pip: true
 
 before_install:
 - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.27.3
@@ -39,6 +50,10 @@ before_install:
 
 install:
 - yarn
+- if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    pip install -U platformio;
+  fi
+
 
 before_script: |
   if [ "$TRAVIS_OS_NAME" == "linux" ]; then
@@ -48,5 +63,9 @@ before_script: |
   fi
 
 script:
-- yarn verify
+- yarn build
+- yarn lint
+- yarn test
+- if [ "$TRAVIS_OS_NAME" == "linux" ]; then yarn test-cpp; fi
+- yarn test-func
 - travis_wait 50 ./tools/travis.sh

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ subcommands:
 - `yarn electron-dist` — build OS-specific distributive
 - `yarn test` — run unit tests
 - `yarn test:watch` — like test, but watches for changes with auto-retest
+- `yarn test-cpp` — run C++ code tests
 - `yarn test-func` — run functional tests
 - `yarn lint` — run the linter to check code style
 - `yarn verify` — build, lint, test; run this prior to a pull request
@@ -90,6 +91,12 @@ You can set `XOD_DEBUG_TESTS` environment variable to keep IDE open on failure:
 
 Use `yarn start:spectron-repl` to run an interactive session and control the
 IDE window programmatically.
+
+### Running C++ tests
+
+You need `avr-gcc` and [PlatformIO Core](http://platformio.org/get-started/cli)
+to be installed system-wide to run C++ code tests. They are available as OS
+packages for most platforms.
 
 License
 -------

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test": "XOD_HM_DEF=true node ./tools/lerna-run-sorted test",
     "test:watch": "node ./tools/lerna-serve test:watch",
     "test-func": "node ./tools/lerna-run-sorted test-func",
-    "verify": "yarn run build && yarn run lint && yarn run test && yarn run test-func"
+    "test-cpp": "node ./tools/lerna-run-sorted test-cpp",
+    "verify": "yarn build && yarn lint && yarn test && yarn test-cpp && yarn test-func"
   },
   "devDependencies": {
     "@google-cloud/storage": "^1.1.0",

--- a/packages/xod-arduino/.gitignore
+++ b/packages/xod-arduino/.gitignore
@@ -1,1 +1,2 @@
 test-cpp/run-tests
+.pio-build

--- a/packages/xod-arduino/package.json
+++ b/packages/xod-arduino/package.json
@@ -7,7 +7,7 @@
     "dev": "yarn run build -- --watch",
     "doc": "documentation build --format html --output doc --sort-order alpha src/",
     "test": "BABEL_DISABLE_CACHE=1 mocha test/**/*.spec.js",
-    "test:cpp": "./tools/test-cpp.sh"
+    "test-cpp": "./tools/test-cpp.sh && ./tools/test-avr-size.sh"
   },
   "repository": {},
   "keywords": [],

--- a/packages/xod-arduino/platform/patchContext.tpl.cpp
+++ b/packages/xod-arduino/platform/patchContext.tpl.cpp
@@ -3,22 +3,29 @@
 
 struct Storage {
     State state;
+  {{#each outputs}}
+    {{ type }} output_{{ pinKey }};
+  {{/each}}
+};
+
+struct Wiring {
+    EvalFuncPtr eval;
   {{#each inputs}}
-    PinRef input_{{ pinKey }};
+    UpstreamPinRef input_{{ pinKey }};
   {{/each}}
   {{#each outputs}}
-    OutputPin<{{ type }}> output_{{ pinKey }};
+    const NodeId* output_{{ pinKey }};
   {{/each}}
 };
 
 State* getState(NodeId nid) {
-    return reinterpret_cast<State*>(storages[nid]);
+    return reinterpret_cast<State*>(getStoragePtr(nid, 0));
 }
 
 {{#each inputs}}
-using input_{{ pinKey }} = InputDescriptor<{{ type }}, offsetof(Storage, input_{{ pinKey }})>;
+using input_{{ pinKey }} = InputDescriptor<{{ type }}, offsetof(Wiring, input_{{ pinKey }})>;
 {{/each}}
 
 {{#each outputs}}
-using output_{{ pinKey }} = OutputDescriptor<{{ type }}, offsetof(Storage, output_{{ pinKey }}), {{@index}}>;
+using output_{{ pinKey }} = OutputDescriptor<{{ type }}, offsetof(Wiring, output_{{ pinKey }}), offsetof(Storage, output_{{ pinKey }}), {{@index}}>;
 {{/each}}

--- a/packages/xod-arduino/platform/preamble.h
+++ b/packages/xod-arduino/platform/preamble.h
@@ -16,4 +16,4 @@
 
 #include <Arduino.h>
 #include <inttypes.h>
-
+#include <avr/pgmspace.h>

--- a/packages/xod-arduino/platform/program.tpl.cpp
+++ b/packages/xod-arduino/platform/program.tpl.cpp
@@ -9,46 +9,71 @@
  =============================================================================*/
 
 namespace xod {
+
+    //-------------------------------------------------------------------------
+    // Dynamic data
+    //-------------------------------------------------------------------------
   {{#each nodes}}
   {{mergePins }}
-  {{#each outputs }}
-    NodeId links_{{ ../id }}_{{ pinKey }}[] = { {{#each to }}{{ this }}, {{/each}}NO_NODE };
-    {{/each}}
-    {{ patch/owner }}__{{ patch/libName }}__{{ patch/patchName }}::Storage storage_{{ id }} = {
+    // Storage of #{{ id }} {{ patch.owner }}/{{ patch.libName }}/{{ patch.patchName }}
+    {{ns patch }}::Storage storage_{{ id }} = {
         { }, // state
-      {{#each inputs }}
-        {{#exists nodeId }}
-        { NodeId({{ nodeId }}), {{ patch/owner }}__{{ patch/libName }}__{{ patch/patchName }}::output_{{ fromPinKey  }}::KEY }, // input_{{ pinKey }}
-        {{else }}
-        { NO_NODE, 0 }, // input_{{ pinKey }}
-        {{/exists }}
-      {{/each}}
       {{#each outputs }}
-        { {{ value }}, links_{{ ../id }}_{{ pinKey }} }{{#unless @last }},{{/unless }} // output_{{ pinKey }}
+        {{ value }}{{#unless @last }},{{/unless }} // output_{{ pinKey }}
       {{/each}}
     };
   {{/each}}
 
-    void* storages[NODE_COUNT] = {
+    DirtyFlags g_dirtyFlags[NODE_COUNT] = {
+        {{#each nodes}}DirtyFlags({{ dirtyFlags }}){{#unless @last}},
+        {{/unless}}{{/each}}
+    };
+
+    TimeMs g_schedule[NODE_COUNT] = { 0 };
+
+    //-------------------------------------------------------------------------
+    // Static (immutable) data
+    //-------------------------------------------------------------------------
+  {{#each nodes}}
+  {{mergePins }}
+    // Wiring of #{{ id }} {{ patch.owner }}/{{ patch.libName }}/{{ patch.patchName }}
+  {{#each outputs }}
+    const NodeId outLinks_{{ ../id }}_{{ pinKey }}[] PROGMEM = { {{#each to }}{{ this }}, {{/each}}NO_NODE };
+  {{/each}}
+    const {{ns patch }}::Wiring wiring_{{ id }} PROGMEM = {
+        &{{ns patch }}::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+      {{#each inputs }}
+        {{#exists nodeId }}
+        { NodeId({{ nodeId }}),
+            {{ns patch }}::output_{{ fromPinKey  }}::INDEX,
+            {{ns patch }}::output_{{ fromPinKey  }}::STORAGE_OFFSET }, // input_{{ pinKey }}
+        {{else }}
+        { NO_NODE, 0, 0 }, // input_{{ pinKey }}
+        {{/exists }}
+      {{/each}}
+        // outputs (NodeId list binding)
+      {{#each outputs }}
+        outLinks_{{ ../id }}_{{ pinKey }}{{#unless @last }},{{/unless }} // output_{{ pinKey }}
+      {{/each}}
+    };
+  {{/each}}
+
+    // PGM array with pointers to PGM wiring information structs
+    const void* const g_wiring[NODE_COUNT] PROGMEM = {
+      {{#each nodes}}
+        &wiring_{{ id }}{{#unless @last }},{{/unless }}
+      {{/each}}
+    };
+
+    // PGM array with pointers to RAM-located storages
+    void* const g_storages[NODE_COUNT] PROGMEM = {
       {{#each nodes}}
         &storage_{{ id }}{{#unless @last }},{{/unless }}
       {{/each}}
     };
 
-    EvalFuncPtr evaluationFuncs[NODE_COUNT] = {
-      {{#each nodes}}
-        (EvalFuncPtr)&{{ patch/owner }}__{{ patch/libName }}__{{ patch/patchName }}::evaluate{{#unless @last }},{{/unless }}
-      {{/each}}
-    };
-
-    DirtyFlags dirtyFlags[NODE_COUNT] = {
-        {{#each nodes}}DirtyFlags({{ dirtyFlags }}){{#unless @last}},
-        {{/unless}}{{/each}}
-    };
-
-    NodeId topology[NODE_COUNT] = {
+    NodeId g_topology[NODE_COUNT] = {
         {{#each topology}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}
     };
-
-    TimeMs schedule[NODE_COUNT] = { 0 };
 }

--- a/packages/xod-arduino/platform/runtime.cpp
+++ b/packages/xod-arduino/platform/runtime.cpp
@@ -51,21 +51,32 @@ namespace xod {
 typedef double Number;
 typedef bool Logic;
 
-// TODO: optimize, we should choose uint8_t if there are less than 255 nodes in total
-// and uint32_t if there are more than 65535
+#if NODE_COUNT < 256
+typedef uint8_t NodeId;
+#elif NODE_COUNT < 65536
 typedef uint16_t NodeId;
+#else
+typedef uint32_t NodeId;
+#endif
 
+/*
+ * Context is a handle passed to each node `evaluate` function. Currently, it’s
+ * alias for NodeId but likely will be changed in future to support list
+ * lifting and other features
+ */
 typedef NodeId Context;
 
-// TODO: optimize, we should choose a proper type with a minimal enough capacity
 /*
  * LSB of a dirty flag shows whether a particular node is dirty or not
  * Other bits shows dirtieness of its particular outputs:
  * - 1-st bit for 0-th output
  * - 2-nd bit for 1-st output
  * - etc
+ *
+ * An outcome limitation is that a native node must not have more than 7 output
+ * pins.
  */
-typedef uint16_t DirtyFlags;
+typedef uint8_t DirtyFlags;
 
 typedef unsigned long TimeMs;
 typedef void (*EvalFuncPtr)(Context ctx);
@@ -130,7 +141,7 @@ extern void* const g_storages[NODE_COUNT];
 extern const void* const g_wiring[NODE_COUNT];
 extern DirtyFlags g_dirtyFlags[NODE_COUNT];
 
-// TOOD: get rid of an extra indirection layer completely
+// TODO: get rid of an extra indirection layer completely
 // would save 2 bytes per node
 extern NodeId g_topology[NODE_COUNT];
 

--- a/packages/xod-arduino/platform/runtime.cpp
+++ b/packages/xod-arduino/platform/runtime.cpp
@@ -27,226 +27,273 @@
 #endif
 
 //----------------------------------------------------------------------------
+// PGM space utilities
+//----------------------------------------------------------------------------
+#define pgm_read_nodeid(address) (pgm_read_word(address))
+
+/*
+ * Workaround for bugs:
+ * https://github.com/arduino/ArduinoCore-sam/pull/43
+ * https://github.com/arduino/ArduinoCore-samd/pull/253
+ * Remove after the PRs merge
+ */
+#if !defined(ARDUINO_ARCH_AVR) && defined(pgm_read_ptr)
+#  undef pgm_read_ptr
+#  define pgm_read_ptr(addr) (*(const void **)(addr))
+#endif
+
+namespace xod {
+//----------------------------------------------------------------------------
 // Type definitions
 //----------------------------------------------------------------------------
-#define PIN_KEY_OFFSET_BITS     (16 - MAX_OUTPUT_COUNT)
 #define NO_NODE                 ((NodeId)-1)
 
-namespace xod {
-    typedef double Number;
-    typedef bool Logic;
+typedef double Number;
+typedef bool Logic;
 
-    // TODO: optimize, we should choose uint8_t if there are less than 255 nodes in total
-    // and uint32_t if there are more than 65535
-    typedef uint16_t NodeId;
+// TODO: optimize, we should choose uint8_t if there are less than 255 nodes in total
+// and uint32_t if there are more than 65535
+typedef uint16_t NodeId;
 
-    typedef NodeId Context;
+typedef NodeId Context;
 
-    /*
-     * PinKey is an address value used to find input’s or output’s data within
-     * node’s Storage.
-     *
-     * For inputs its value is simply an offset in bytes from the beginning of
-     * Storage structure instance. There will be a PinRef pointing to an upstream
-     * output at this address.
-     *
-     * For outputs the pin key consists of two parts ORed bitwise. Least
-     * significant bits (count defined by `PIN_KEY_OFFSET_BITS`) define an offset
-     * from the beginning of node’s Storage where output data could be found. It
-     * would be an OutputPin structure. Most significant bits define an index
-     * number of that output among all outputs of the node. The index is used to
-     * work with dirty flags bit-value.
-     */
-    // TODO: optimize, we should choose a proper type with a minimal enough capacity
-    typedef uint16_t PinKey;
+// TODO: optimize, we should choose a proper type with a minimal enough capacity
+/*
+ * LSB of a dirty flag shows whether a particular node is dirty or not
+ * Other bits shows dirtieness of its particular outputs:
+ * - 1-st bit for 0-th output
+ * - 2-nd bit for 1-st output
+ * - etc
+ */
+typedef uint16_t DirtyFlags;
 
-    // TODO: optimize, we should choose a proper type with a minimal enough capacity
-    typedef uint16_t DirtyFlags;
+typedef unsigned long TimeMs;
+typedef void (*EvalFuncPtr)(Context ctx);
 
-    typedef unsigned long TimeMs;
-    typedef void (*EvalFuncPtr)(NodeId nid, void* state);
+typedef xod::List<char>::ListPtr XString;
 
-    typedef xod::List<char>::ListPtr XString;
+/*
+ * Each input stores a reference to its upstream node so that we can get values
+ * on input pins. Having a direct pointer to the value is not enough because we
+ * want to know dirty’ness as well. So we have to use this structure instead of
+ * a pointer.
+ */
+struct UpstreamPinRef {
+    // Upstream node ID
+    NodeId nodeId;
+    // Index of the upstream node’s output.
+    // Use 3 bits as it just enough to store values 0..7
+    uint16_t pinIndex : 3;
+    // Byte offset in a storage of the upstream node where the actual pin value
+    // is stored
+    uint16_t storageOffset : 13;
+};
+
+/*
+ * Input descriptor is a metaprogramming structure used to enforce an
+ * input’s type and store its wiring data location as a zero-RAM constant.
+ *
+ * A specialized descriptor is required by `getValue` function. Every
+ * input of every type node gets its own descriptor in generated code that
+ * can be accessed as input_FOO. Where FOO is a pin identifier.
+ */
+template<typename ValueT_, size_t wiringOffset>
+struct InputDescriptor {
+    typedef ValueT_ ValueT;
+    enum {
+        WIRING_OFFSET = wiringOffset
+    };
+};
+
+/*
+ * Output descriptor serve the same purpose as InputDescriptor but for
+ * ouputs.
+ *
+ * In addition to wiring data location it keeps storage data location (where
+ * actual value is stored) and own zero-based index among outputs of a particular
+ * node
+ */
+template<typename ValueT_, size_t wiringOffset, size_t storageOffset, uint8_t index>
+struct OutputDescriptor {
+    typedef ValueT_ ValueT;
+    enum {
+        WIRING_OFFSET = wiringOffset,
+        STORAGE_OFFSET = storageOffset,
+        INDEX = index
+    };
+};
+
+//----------------------------------------------------------------------------
+// Forward declarations
+//----------------------------------------------------------------------------
+extern void* const g_storages[NODE_COUNT];
+extern const void* const g_wiring[NODE_COUNT];
+extern DirtyFlags g_dirtyFlags[NODE_COUNT];
+
+// TOOD: get rid of an extra indirection layer completely
+// would save 2 bytes per node
+extern NodeId g_topology[NODE_COUNT];
+
+// TODO: replace with a compact list
+extern TimeMs g_schedule[NODE_COUNT];
+
+void clearTimeout(NodeId nid);
+
+//----------------------------------------------------------------------------
+// Engine (private API)
+//----------------------------------------------------------------------------
+
+void* getStoragePtr(NodeId nid, size_t offset) {
+    return (uint8_t*)pgm_read_ptr(&g_storages[nid]) + offset;
+}
+
+template<typename T>
+T getStorageValue(NodeId nid, size_t offset) {
+    return *reinterpret_cast<T*>(getStoragePtr(nid, offset));
+}
+
+void* getWiringPgmPtr(NodeId nid, size_t offset) {
+    return (uint8_t*)pgm_read_ptr(&g_wiring[nid]) + offset;
+}
+
+template<typename T>
+T getWiringValue(NodeId nid, size_t offset) {
+    T result;
+    memcpy_P(&result, getWiringPgmPtr(nid, offset), sizeof(T));
+    return result;
+}
+
+bool isOutputDirty(NodeId nid, uint8_t index) {
+    return g_dirtyFlags[nid] & (1 << (index + 1));
+}
+
+bool isInputDirtyImpl(NodeId nid, size_t wiringOffset) {
+    UpstreamPinRef ref = getWiringValue<UpstreamPinRef>(nid, wiringOffset);
+    if (ref.nodeId == NO_NODE)
+        return false;
+
+    return isOutputDirty(ref.nodeId, ref.pinIndex);
+}
+
+template<typename InputT>
+bool isInputDirty(NodeId nid) {
+    return isInputDirtyImpl(nid, InputT::WIRING_OFFSET);
+}
+
+void markPinDirty(NodeId nid, uint8_t index) {
+    g_dirtyFlags[nid] |= 1 << (index + 1);
+}
+
+void markNodeDirty(NodeId nid) {
+    g_dirtyFlags[nid] |= 0x1;
+}
+
+bool isNodeDirty(NodeId nid) {
+    return g_dirtyFlags[nid] & 0x1;
+}
+
+template<typename T>
+T getOutputValueImpl(NodeId nid, size_t storageOffset) {
+    return getStorageValue<T>(nid, storageOffset);
+}
+
+template<typename T>
+T getInputValueImpl(NodeId nid, size_t wiringOffset) {
+    UpstreamPinRef ref = getWiringValue<UpstreamPinRef>(nid, wiringOffset);
+    if (ref.nodeId == NO_NODE)
+        return (T)0;
+
+    return getOutputValueImpl<T>(ref.nodeId, ref.storageOffset);
+}
+
+template<typename T>
+void emitValueImpl(
+        NodeId nid,
+        size_t storageOffset,
+        size_t wiringOffset,
+        uint8_t index,
+        T value) {
+
+    // Store new value and make the node itself dirty
+    T* storedValue = reinterpret_cast<T*>(getStoragePtr(nid, storageOffset));
+    *storedValue = value;
+    markPinDirty(nid, index);
+
+    // Notify downstream nodes about changes
+    // NB: linked nodes array is in PGM space
+    const NodeId* pDownstreamNid = getWiringValue<const NodeId*>(nid, wiringOffset);
+    NodeId downstreamNid = pgm_read_nodeid(pDownstreamNid);
+
+    while (downstreamNid != NO_NODE) {
+        markNodeDirty(downstreamNid);
+        downstreamNid = pgm_read_nodeid(pDownstreamNid++);
+    }
+}
+
+void evaluateNode(NodeId nid) {
+    XOD_TRACE_F("eval #");
+    XOD_TRACE_LN(nid);
+    EvalFuncPtr eval = getWiringValue<EvalFuncPtr>(nid, 0);
+    eval(nid);
+}
+
+void runTransaction() {
+    XOD_TRACE_F("Transaction started, t=");
+    XOD_TRACE_LN(millis());
+    for (NodeId nid : g_topology) {
+        if (isNodeDirty(nid))
+            evaluateNode(nid);
+    }
+
+    memset(g_dirtyFlags, 0, sizeof(g_dirtyFlags));
+    XOD_TRACE_F("Transaction completed, t=");
+    XOD_TRACE_LN(millis());
+}
+
+void idle() {
+    TimeMs now = millis();
+    for (NodeId nid = 0; nid < NODE_COUNT; ++nid) {
+        TimeMs t = g_schedule[nid];
+        if (t && t <= now) {
+            markNodeDirty(nid);
+            clearTimeout(nid);
+            return;
+        }
+    }
 }
 
 //----------------------------------------------------------------------------
-// Engine
+// Public API (can be used by native nodes’ `evaluate` functions)
 //----------------------------------------------------------------------------
-namespace xod {
-    extern void* storages[NODE_COUNT];
-    extern EvalFuncPtr evaluationFuncs[NODE_COUNT];
-    extern DirtyFlags dirtyFlags[NODE_COUNT];
-    extern NodeId topology[NODE_COUNT];
 
-    // TODO: replace with a compact list
-    extern TimeMs schedule[NODE_COUNT];
-
-    template<typename T>
-    struct OutputPin {
-        T value;
-        // Keep outgoing link list with terminating `NO_NODE`
-        NodeId* links;
-    };
-
-    struct PinRef {
-        NodeId nodeId;
-        PinKey pinKey;
-    };
-
-    /*
-     * Input descriptor is a metaprogramming structure used to enforce an
-     * input’s type and store its PinKey as a zero-memory constant.
-     *
-     * A specialized descriptor is required by `getValue` function. Every
-     * input of every type node gets its own descriptor in generated code that
-     * can be accessed as input_FOO. Where FOO is a pin identifier.
-     */
-    template<typename ValueT_, size_t offsetInStorage>
-    struct InputDescriptor {
-        typedef ValueT_ ValueT;
-        enum Offset : PinKey {
-            KEY = offsetInStorage
-        };
-    };
-
-    /*
-     * Output descriptor serve the same purpose as InputDescriptor but for
-     * ouputs.
-     */
-    template<typename ValueT_, size_t offsetInStorage, int index>
-    struct OutputDescriptor {
-        typedef ValueT_ ValueT;
-        enum Offset : PinKey {
-            KEY = offsetInStorage | (index << PIN_KEY_OFFSET_BITS)
-        };
-    };
-
-    void* pinPtr(void* storage, PinKey key) {
-        const size_t offset = key & ~(PinKey(-1) << PIN_KEY_OFFSET_BITS);
-        return (uint8_t*)storage + offset;
-    }
-
-    DirtyFlags dirtyPinBit(PinKey key) {
-        const PinKey nbit = (key >> PIN_KEY_OFFSET_BITS) + 1;
-        return 1 << nbit;
-    }
-
-    bool isOutputDirty(NodeId nid, PinKey key) {
-        return dirtyFlags[nid] & dirtyPinBit(key);
-    }
-
-    bool isInputDirtyImpl(NodeId nid, PinKey key) {
-        PinRef* ref = (PinRef*)pinPtr(storages[nid], key);
-        if (ref->nodeId == NO_NODE)
-            return false;
-
-        return isOutputDirty(ref->nodeId, ref->pinKey);
-    }
-
-    template<typename InputT>
-    bool isInputDirty(NodeId nid) {
-        return isInputDirtyImpl(nid, InputT::KEY);
-    }
-
-    void markPinDirty(NodeId nid, PinKey key) {
-        dirtyFlags[nid] |= dirtyPinBit(key);
-    }
-
-    void markNodeDirty(NodeId nid) {
-        dirtyFlags[nid] |= 0x1;
-    }
-
-    bool isNodeDirty(NodeId nid) {
-        return dirtyFlags[nid] & 0x1;
-    }
-
-    TimeMs transactionTime() {
-        return millis();
-    }
-
-    void setTimeout(NodeId nid, TimeMs timeout) {
-        schedule[nid] = transactionTime() + timeout;
-    }
-
-    void clearTimeout(NodeId nid) {
-        schedule[nid] = 0;
-    }
-
-    template<typename T>
-    T getValueImpl(NodeId nid, PinKey key) {
-        PinRef* ref = (PinRef*)pinPtr(storages[nid], key);
-        if (ref->nodeId == NO_NODE)
-            return (T)0;
-
-        return *(T*)pinPtr(storages[ref->nodeId], ref->pinKey);
-    }
-
-    template<typename InputT>
-    typename InputT::ValueT getValue(NodeId nid) {
-        return getValueImpl<typename InputT::ValueT>(nid, InputT::KEY);
-    }
-
-    template<typename T>
-    void emitValueImpl(NodeId nid, PinKey key, T value) {
-        OutputPin<T>* outputPin = (OutputPin<T>*)pinPtr(storages[nid], key);
-
-        outputPin->value = value;
-        markPinDirty(nid, key);
-
-        NodeId* linkedNode = outputPin->links;
-        while (*linkedNode != NO_NODE) {
-            markNodeDirty(*linkedNode++);
-        }
-    }
-
-    template<typename OutputT>
-    void emitValue(NodeId nid, typename OutputT::ValueT value) {
-        emitValueImpl(nid, OutputT::KEY, value);
-    }
-
-    template<typename T>
-    void reemitValueImpl(NodeId nid, PinKey key) {
-        OutputPin<T>* outputPin = (OutputPin<T>*)pinPtr(storages[nid], key);
-        emitValueImpl<T>(nid, key, outputPin->value);
-    }
-
-    template<typename OutputT>
-    void reemitValue(NodeId nid) {
-        reemitValueImpl<typename OutputT::ValueT>(nid, OutputT::KEY);
-    }
-
-    void evaluateNode(NodeId nid) {
-        XOD_TRACE_F("eval #");
-        XOD_TRACE_LN(nid);
-        EvalFuncPtr eval = evaluationFuncs[nid];
-        eval(nid, storages[nid]);
-    }
-
-    void runTransaction() {
-        XOD_TRACE_F("Transaction started, t=");
-        XOD_TRACE_LN(millis());
-        for (NodeId nid : topology) {
-            if (isNodeDirty(nid))
-                evaluateNode(nid);
-        }
-
-        memset(dirtyFlags, 0, sizeof(dirtyFlags));
-        XOD_TRACE_F("Transaction completed, t=");
-        XOD_TRACE_LN(millis());
-    }
-
-    void idle() {
-        TimeMs now = millis();
-        for (NodeId nid = 0; nid < NODE_COUNT; ++nid) {
-            TimeMs t = schedule[nid];
-            if (t && t <= now) {
-                markNodeDirty(nid);
-                clearTimeout(nid);
-                return;
-            }
-        }
-    }
+template<typename InputT>
+typename InputT::ValueT getValue(NodeId nid) {
+    return getInputValueImpl<typename InputT::ValueT>(nid, InputT::WIRING_OFFSET);
 }
+
+template<typename OutputT>
+void emitValue(NodeId nid, typename OutputT::ValueT value) {
+    emitValueImpl(
+            nid,
+            OutputT::STORAGE_OFFSET,
+            OutputT::WIRING_OFFSET,
+            OutputT::INDEX,
+            value);
+}
+
+TimeMs transactionTime() {
+    return millis();
+}
+
+void setTimeout(NodeId nid, TimeMs timeout) {
+    g_schedule[nid] = transactionTime() + timeout;
+}
+
+void clearTimeout(NodeId nid) {
+    g_schedule[nid] = 0;
+}
+
+} // namespace xod
 
 //----------------------------------------------------------------------------
 // Entry point
@@ -257,7 +304,7 @@ void setup() {
 #ifdef XOD_DEBUG
     DEBUG_SERIAL.begin(9600);
 #endif
-    XOD_TRACE_FLN("Program started");
+    XOD_TRACE_FLN("\n\nProgram started");
 }
 
 void loop() {

--- a/packages/xod-arduino/src/templates.js
+++ b/packages/xod-arduino/src/templates.js
@@ -48,6 +48,11 @@ Handlebars.registerHelper('mergePins', function mergePins() {
   this.inputs = mergeAndListPins('inputs', this);
   this.outputs = mergeAndListPins('outputs', this);
 });
+// Generate patch-level namespace name
+Handlebars.registerHelper('ns', R.compose(
+  R.join('__'),
+  R.props(['owner', 'libName', 'patchName'])
+));
 // Check that variable is not undefined
 Handlebars.registerHelper('exists', function existsHelper(variable, options) {
   return (typeof variable !== 'undefined') ?

--- a/packages/xod-arduino/test/fixtures/implList.cpp
+++ b/packages/xod-arduino/test/fixtures/implList.cpp
@@ -18,19 +18,24 @@ struct State {
 
 struct Storage {
     State state;
-    PinRef input_IN1;
-    PinRef input_IN2;
-    OutputPin<Number> output_OUT;
+    Number output_OUT;
+};
+
+struct Wiring {
+    EvalFuncPtr eval;
+    UpstreamPinRef input_IN1;
+    UpstreamPinRef input_IN2;
+    const NodeId* output_OUT;
 };
 
 State* getState(NodeId nid) {
-    return reinterpret_cast<State*>(storages[nid]);
+    return reinterpret_cast<State*>(getStoragePtr(nid, 0));
 }
 
-using input_IN1 = InputDescriptor<Number, offsetof(Storage, input_IN1)>;
-using input_IN2 = InputDescriptor<Number, offsetof(Storage, input_IN2)>;
+using input_IN1 = InputDescriptor<Number, offsetof(Wiring, input_IN1)>;
+using input_IN2 = InputDescriptor<Number, offsetof(Wiring, input_IN2)>;
 
-using output_OUT = OutputDescriptor<Number, offsetof(Storage, output_OUT), 0>;
+using output_OUT = OutputDescriptor<Number, offsetof(Wiring, output_OUT), offsetof(Storage, output_OUT), 0>;
 
 void evaluate(Context ctx) {
     /* Native implementation goes here */

--- a/packages/xod-arduino/test/fixtures/program.cpp
+++ b/packages/xod-arduino/test/fixtures/program.cpp
@@ -8,40 +8,70 @@
 
 namespace xod {
 
-    NodeId links_0_OUT[] = { 1, NO_NODE };
+    //-------------------------------------------------------------------------
+    // Dynamic data
+    //-------------------------------------------------------------------------
+
+    // Storage of #0 xod/math/multiply
     xod__math__multiply::Storage storage_0 = {
         { }, // state
-        { NO_NODE, 0 }, // input_IN1
-        { NO_NODE, 0 }, // input_IN2
-        { 42, links_0_OUT } // output_OUT
+        42 // output_OUT
     };
 
-    NodeId links_1_OUT[] = { NO_NODE };
+    // Storage of #1 xod/math/multiply
     xod__math__multiply::Storage storage_1 = {
         { }, // state
-        { NodeId(0), xod__math__multiply::output_OUT::KEY }, // input_IN1
-        { NO_NODE, 0 }, // input_IN2
-        { 0, links_1_OUT } // output_OUT
+        0 // output_OUT
     };
 
-    void* storages[NODE_COUNT] = {
-        &storage_0,
-        &storage_1
-    };
-
-    EvalFuncPtr evaluationFuncs[NODE_COUNT] = {
-        (EvalFuncPtr)&xod__math__multiply::evaluate,
-        (EvalFuncPtr)&xod__math__multiply::evaluate
-    };
-
-    DirtyFlags dirtyFlags[NODE_COUNT] = {
+    DirtyFlags g_dirtyFlags[NODE_COUNT] = {
         DirtyFlags(255),
         DirtyFlags(255)
     };
 
-    NodeId topology[NODE_COUNT] = {
-        0, 1
+    TimeMs g_schedule[NODE_COUNT] = { 0 };
+
+    //-------------------------------------------------------------------------
+    // Static (immutable) data
+    //-------------------------------------------------------------------------
+
+    // Wiring of #0 xod/math/multiply
+    const NodeId outLinks_0_OUT[] PROGMEM = { 1, NO_NODE };
+    const xod__math__multiply::Wiring wiring_0 PROGMEM = {
+        &xod__math__multiply::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        { NO_NODE, 0, 0 }, // input_IN1
+        { NO_NODE, 0, 0 }, // input_IN2
+        // outputs (NodeId list binding)
+        outLinks_0_OUT // output_OUT
     };
 
-    TimeMs schedule[NODE_COUNT] = { 0 };
+    // Wiring of #1 xod/math/multiply
+    const NodeId outLinks_1_OUT[] PROGMEM = { NO_NODE };
+    const xod__math__multiply::Wiring wiring_1 PROGMEM = {
+        &xod__math__multiply::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        { NodeId(0),
+            xod__math__multiply::output_OUT::INDEX,
+            xod__math__multiply::output_OUT::STORAGE_OFFSET }, // input_IN1
+        { NO_NODE, 0, 0 }, // input_IN2
+        // outputs (NodeId list binding)
+        outLinks_1_OUT // output_OUT
+    };
+
+    // PGM array with pointers to PGM wiring information structs
+    const void* const g_wiring[NODE_COUNT] PROGMEM = {
+        &wiring_0,
+        &wiring_1
+    };
+
+    // PGM array with pointers to RAM-located storages
+    void* const g_storages[NODE_COUNT] PROGMEM = {
+        &storage_0,
+        &storage_1
+    };
+
+    NodeId g_topology[NODE_COUNT] = {
+        0, 1
+    };
 }

--- a/packages/xod-arduino/tools/test-avr-size.sh
+++ b/packages/xod-arduino/tools/test-avr-size.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+echo "Testing size of fixtures compiled for AVR platform..."
+
+SELF_DIR=`dirname $0`
+
+WS_DIR="$SELF_DIR/../../../workspace"
+BUILD_DIR="$SELF_DIR/../.pio-build"
+
+AVR_SIZE=~/.platformio/packages/toolchain-atmelavr/bin/avr-size
+
+mkdir -p $BUILD_DIR
+platformio ci \
+  --board=uno \
+  --build-dir=$BUILD_DIR \
+  --keep-build-dir \
+  $WS_DIR/blink/__fixtures__/arduino.cpp \
+  > /dev/null
+
+AVR_SIZE_OUTPUT=$($AVR_SIZE -d -C --mcu=atmega328p $BUILD_DIR/.pioenvs/uno/firmware.elf)
+EXPECTED_OUTPUT="\
+AVR Memory Usage
+----------------
+Device: atmega328p
+
+Program:    2580 bytes (7.9% Full)
+(.text + .data + .bootloader)
+
+Data:         58 bytes (2.8% Full)
+(.data + .bss + .noinit)"
+
+if [[ $AVR_SIZE_OUTPUT =~ "$EXPECTED_OUTPUT" ]]; then
+  echo "+ OK"
+else
+  echo "- FAIL"
+  echo
+  echo "Expected ====================================================="
+  echo
+  echo "$EXPECTED_OUTPUT"
+  echo
+  echo "Actual ======================================================="
+  echo
+  echo "$AVR_SIZE_OUTPUT"
+  echo
+  echo "If the size became better, fix expectation in"
+  echo "packages/xod-arduino/tools/test-avr-size.sh script,"
+  echo "and if the size became worse, fix C++"
+  exit 1
+fi

--- a/packages/xod-arduino/tools/test-cpp.sh
+++ b/packages/xod-arduino/tools/test-cpp.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 DIR=test-cpp
 RUNNER=$DIR/run-tests
 
-g++ -g -O0 -o $RUNNER $DIR/test.cpp $DIR/list.cpp
+g++ -std=c++11 -g -O0 -o $RUNNER $DIR/test.cpp $DIR/list.cpp
 
 if [[ $* == *--leak-check* ]]; then
     valgrind --leak-check=yes $RUNNER

--- a/packages/xod-arduino/yarn.lock
+++ b/packages/xod-arduino/yarn.lock
@@ -39,10 +39,6 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chai-string@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/chai-string/-/chai-string-1.3.0.tgz#df6139f294391b1035be5606f60a843b3a5041e7"
-
 chai@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"

--- a/packages/xod-client-electron/test-func/fixtures/blink.cpp
+++ b/packages/xod-client-electron/test-func/fixtures/blink.cpp
@@ -16,7 +16,7 @@
 
 #include <Arduino.h>
 #include <inttypes.h>
-
+#include <avr/pgmspace.h>
 
 // ============================================================================
 //
@@ -666,226 +666,284 @@ template <typename T> class List {
 #endif
 
 //----------------------------------------------------------------------------
+// PGM space utilities
+//----------------------------------------------------------------------------
+#define pgm_read_nodeid(address) (pgm_read_word(address))
+
+/*
+ * Workaround for bugs:
+ * https://github.com/arduino/ArduinoCore-sam/pull/43
+ * https://github.com/arduino/ArduinoCore-samd/pull/253
+ * Remove after the PRs merge
+ */
+#if !defined(ARDUINO_ARCH_AVR) && defined(pgm_read_ptr)
+#  undef pgm_read_ptr
+#  define pgm_read_ptr(addr) (*(const void **)(addr))
+#endif
+
+namespace xod {
+//----------------------------------------------------------------------------
 // Type definitions
 //----------------------------------------------------------------------------
-#define PIN_KEY_OFFSET_BITS     (16 - MAX_OUTPUT_COUNT)
 #define NO_NODE                 ((NodeId)-1)
 
-namespace xod {
-    typedef double Number;
-    typedef bool Logic;
+typedef double Number;
+typedef bool Logic;
 
-    // TODO: optimize, we should choose uint8_t if there are less than 255 nodes in total
-    // and uint32_t if there are more than 65535
-    typedef uint16_t NodeId;
+#if NODE_COUNT < 256
+typedef uint8_t NodeId;
+#elif NODE_COUNT < 65536
+typedef uint16_t NodeId;
+#else
+typedef uint32_t NodeId;
+#endif
 
-    typedef NodeId Context;
+/*
+ * Context is a handle passed to each node `evaluate` function. Currently, it’s
+ * alias for NodeId but likely will be changed in future to support list
+ * lifting and other features
+ */
+typedef NodeId Context;
 
-    /*
-     * PinKey is an address value used to find input’s or output’s data within
-     * node’s Storage.
-     *
-     * For inputs its value is simply an offset in bytes from the beginning of
-     * Storage structure instance. There will be a PinRef pointing to an upstream
-     * output at this address.
-     *
-     * For outputs the pin key consists of two parts ORed bitwise. Least
-     * significant bits (count defined by `PIN_KEY_OFFSET_BITS`) define an offset
-     * from the beginning of node’s Storage where output data could be found. It
-     * would be an OutputPin structure. Most significant bits define an index
-     * number of that output among all outputs of the node. The index is used to
-     * work with dirty flags bit-value.
-     */
-    // TODO: optimize, we should choose a proper type with a minimal enough capacity
-    typedef uint16_t PinKey;
+/*
+ * LSB of a dirty flag shows whether a particular node is dirty or not
+ * Other bits shows dirtieness of its particular outputs:
+ * - 1-st bit for 0-th output
+ * - 2-nd bit for 1-st output
+ * - etc
+ *
+ * An outcome limitation is that a native node must not have more than 7 output
+ * pins.
+ */
+typedef uint8_t DirtyFlags;
 
-    // TODO: optimize, we should choose a proper type with a minimal enough capacity
-    typedef uint16_t DirtyFlags;
+typedef unsigned long TimeMs;
+typedef void (*EvalFuncPtr)(Context ctx);
 
-    typedef unsigned long TimeMs;
-    typedef void (*EvalFuncPtr)(NodeId nid, void* state);
+typedef xod::List<char>::ListPtr XString;
 
-    typedef xod::List<char>::ListPtr XString;
+/*
+ * Each input stores a reference to its upstream node so that we can get values
+ * on input pins. Having a direct pointer to the value is not enough because we
+ * want to know dirty’ness as well. So we have to use this structure instead of
+ * a pointer.
+ */
+struct UpstreamPinRef {
+    // Upstream node ID
+    NodeId nodeId;
+    // Index of the upstream node’s output.
+    // Use 3 bits as it just enough to store values 0..7
+    uint16_t pinIndex : 3;
+    // Byte offset in a storage of the upstream node where the actual pin value
+    // is stored
+    uint16_t storageOffset : 13;
+};
+
+/*
+ * Input descriptor is a metaprogramming structure used to enforce an
+ * input’s type and store its wiring data location as a zero-RAM constant.
+ *
+ * A specialized descriptor is required by `getValue` function. Every
+ * input of every type node gets its own descriptor in generated code that
+ * can be accessed as input_FOO. Where FOO is a pin identifier.
+ */
+template<typename ValueT_, size_t wiringOffset>
+struct InputDescriptor {
+    typedef ValueT_ ValueT;
+    enum {
+        WIRING_OFFSET = wiringOffset
+    };
+};
+
+/*
+ * Output descriptor serve the same purpose as InputDescriptor but for
+ * ouputs.
+ *
+ * In addition to wiring data location it keeps storage data location (where
+ * actual value is stored) and own zero-based index among outputs of a particular
+ * node
+ */
+template<typename ValueT_, size_t wiringOffset, size_t storageOffset, uint8_t index>
+struct OutputDescriptor {
+    typedef ValueT_ ValueT;
+    enum {
+        WIRING_OFFSET = wiringOffset,
+        STORAGE_OFFSET = storageOffset,
+        INDEX = index
+    };
+};
+
+//----------------------------------------------------------------------------
+// Forward declarations
+//----------------------------------------------------------------------------
+extern void* const g_storages[NODE_COUNT];
+extern const void* const g_wiring[NODE_COUNT];
+extern DirtyFlags g_dirtyFlags[NODE_COUNT];
+
+// TODO: get rid of an extra indirection layer completely
+// would save 2 bytes per node
+extern NodeId g_topology[NODE_COUNT];
+
+// TODO: replace with a compact list
+extern TimeMs g_schedule[NODE_COUNT];
+
+void clearTimeout(NodeId nid);
+
+//----------------------------------------------------------------------------
+// Engine (private API)
+//----------------------------------------------------------------------------
+
+void* getStoragePtr(NodeId nid, size_t offset) {
+    return (uint8_t*)pgm_read_ptr(&g_storages[nid]) + offset;
+}
+
+template<typename T>
+T getStorageValue(NodeId nid, size_t offset) {
+    return *reinterpret_cast<T*>(getStoragePtr(nid, offset));
+}
+
+void* getWiringPgmPtr(NodeId nid, size_t offset) {
+    return (uint8_t*)pgm_read_ptr(&g_wiring[nid]) + offset;
+}
+
+template<typename T>
+T getWiringValue(NodeId nid, size_t offset) {
+    T result;
+    memcpy_P(&result, getWiringPgmPtr(nid, offset), sizeof(T));
+    return result;
+}
+
+bool isOutputDirty(NodeId nid, uint8_t index) {
+    return g_dirtyFlags[nid] & (1 << (index + 1));
+}
+
+bool isInputDirtyImpl(NodeId nid, size_t wiringOffset) {
+    UpstreamPinRef ref = getWiringValue<UpstreamPinRef>(nid, wiringOffset);
+    if (ref.nodeId == NO_NODE)
+        return false;
+
+    return isOutputDirty(ref.nodeId, ref.pinIndex);
+}
+
+template<typename InputT>
+bool isInputDirty(NodeId nid) {
+    return isInputDirtyImpl(nid, InputT::WIRING_OFFSET);
+}
+
+void markPinDirty(NodeId nid, uint8_t index) {
+    g_dirtyFlags[nid] |= 1 << (index + 1);
+}
+
+void markNodeDirty(NodeId nid) {
+    g_dirtyFlags[nid] |= 0x1;
+}
+
+bool isNodeDirty(NodeId nid) {
+    return g_dirtyFlags[nid] & 0x1;
+}
+
+template<typename T>
+T getOutputValueImpl(NodeId nid, size_t storageOffset) {
+    return getStorageValue<T>(nid, storageOffset);
+}
+
+template<typename T>
+T getInputValueImpl(NodeId nid, size_t wiringOffset) {
+    UpstreamPinRef ref = getWiringValue<UpstreamPinRef>(nid, wiringOffset);
+    if (ref.nodeId == NO_NODE)
+        return (T)0;
+
+    return getOutputValueImpl<T>(ref.nodeId, ref.storageOffset);
+}
+
+template<typename T>
+void emitValueImpl(
+        NodeId nid,
+        size_t storageOffset,
+        size_t wiringOffset,
+        uint8_t index,
+        T value) {
+
+    // Store new value and make the node itself dirty
+    T* storedValue = reinterpret_cast<T*>(getStoragePtr(nid, storageOffset));
+    *storedValue = value;
+    markPinDirty(nid, index);
+
+    // Notify downstream nodes about changes
+    // NB: linked nodes array is in PGM space
+    const NodeId* pDownstreamNid = getWiringValue<const NodeId*>(nid, wiringOffset);
+    NodeId downstreamNid = pgm_read_nodeid(pDownstreamNid);
+
+    while (downstreamNid != NO_NODE) {
+        markNodeDirty(downstreamNid);
+        downstreamNid = pgm_read_nodeid(pDownstreamNid++);
+    }
+}
+
+void evaluateNode(NodeId nid) {
+    XOD_TRACE_F("eval #");
+    XOD_TRACE_LN(nid);
+    EvalFuncPtr eval = getWiringValue<EvalFuncPtr>(nid, 0);
+    eval(nid);
+}
+
+void runTransaction() {
+    XOD_TRACE_F("Transaction started, t=");
+    XOD_TRACE_LN(millis());
+    for (NodeId nid : g_topology) {
+        if (isNodeDirty(nid))
+            evaluateNode(nid);
+    }
+
+    memset(g_dirtyFlags, 0, sizeof(g_dirtyFlags));
+    XOD_TRACE_F("Transaction completed, t=");
+    XOD_TRACE_LN(millis());
+}
+
+void idle() {
+    TimeMs now = millis();
+    for (NodeId nid = 0; nid < NODE_COUNT; ++nid) {
+        TimeMs t = g_schedule[nid];
+        if (t && t <= now) {
+            markNodeDirty(nid);
+            clearTimeout(nid);
+            return;
+        }
+    }
 }
 
 //----------------------------------------------------------------------------
-// Engine
+// Public API (can be used by native nodes’ `evaluate` functions)
 //----------------------------------------------------------------------------
-namespace xod {
-    extern void* storages[NODE_COUNT];
-    extern EvalFuncPtr evaluationFuncs[NODE_COUNT];
-    extern DirtyFlags dirtyFlags[NODE_COUNT];
-    extern NodeId topology[NODE_COUNT];
 
-    // TODO: replace with a compact list
-    extern TimeMs schedule[NODE_COUNT];
-
-    template<typename T>
-    struct OutputPin {
-        T value;
-        // Keep outgoing link list with terminating `NO_NODE`
-        NodeId* links;
-    };
-
-    struct PinRef {
-        NodeId nodeId;
-        PinKey pinKey;
-    };
-
-    /*
-     * Input descriptor is a metaprogramming structure used to enforce an
-     * input’s type and store its PinKey as a zero-memory constant.
-     *
-     * A specialized descriptor is required by `getValue` function. Every
-     * input of every type node gets its own descriptor in generated code that
-     * can be accessed as input_FOO. Where FOO is a pin identifier.
-     */
-    template<typename ValueT_, size_t offsetInStorage>
-    struct InputDescriptor {
-        typedef ValueT_ ValueT;
-        enum Offset : PinKey {
-            KEY = offsetInStorage
-        };
-    };
-
-    /*
-     * Output descriptor serve the same purpose as InputDescriptor but for
-     * ouputs.
-     */
-    template<typename ValueT_, size_t offsetInStorage, int index>
-    struct OutputDescriptor {
-        typedef ValueT_ ValueT;
-        enum Offset : PinKey {
-            KEY = offsetInStorage | (index << PIN_KEY_OFFSET_BITS)
-        };
-    };
-
-    void* pinPtr(void* storage, PinKey key) {
-        const size_t offset = key & ~(PinKey(-1) << PIN_KEY_OFFSET_BITS);
-        return (uint8_t*)storage + offset;
-    }
-
-    DirtyFlags dirtyPinBit(PinKey key) {
-        const PinKey nbit = (key >> PIN_KEY_OFFSET_BITS) + 1;
-        return 1 << nbit;
-    }
-
-    bool isOutputDirty(NodeId nid, PinKey key) {
-        return dirtyFlags[nid] & dirtyPinBit(key);
-    }
-
-    bool isInputDirtyImpl(NodeId nid, PinKey key) {
-        PinRef* ref = (PinRef*)pinPtr(storages[nid], key);
-        if (ref->nodeId == NO_NODE)
-            return false;
-
-        return isOutputDirty(ref->nodeId, ref->pinKey);
-    }
-
-    template<typename InputT>
-    bool isInputDirty(NodeId nid) {
-        return isInputDirtyImpl(nid, InputT::KEY);
-    }
-
-    void markPinDirty(NodeId nid, PinKey key) {
-        dirtyFlags[nid] |= dirtyPinBit(key);
-    }
-
-    void markNodeDirty(NodeId nid) {
-        dirtyFlags[nid] |= 0x1;
-    }
-
-    bool isNodeDirty(NodeId nid) {
-        return dirtyFlags[nid] & 0x1;
-    }
-
-    TimeMs transactionTime() {
-        return millis();
-    }
-
-    void setTimeout(NodeId nid, TimeMs timeout) {
-        schedule[nid] = transactionTime() + timeout;
-    }
-
-    void clearTimeout(NodeId nid) {
-        schedule[nid] = 0;
-    }
-
-    template<typename T>
-    T getValueImpl(NodeId nid, PinKey key) {
-        PinRef* ref = (PinRef*)pinPtr(storages[nid], key);
-        if (ref->nodeId == NO_NODE)
-            return (T)0;
-
-        return *(T*)pinPtr(storages[ref->nodeId], ref->pinKey);
-    }
-
-    template<typename InputT>
-    typename InputT::ValueT getValue(NodeId nid) {
-        return getValueImpl<typename InputT::ValueT>(nid, InputT::KEY);
-    }
-
-    template<typename T>
-    void emitValueImpl(NodeId nid, PinKey key, T value) {
-        OutputPin<T>* outputPin = (OutputPin<T>*)pinPtr(storages[nid], key);
-
-        outputPin->value = value;
-        markPinDirty(nid, key);
-
-        NodeId* linkedNode = outputPin->links;
-        while (*linkedNode != NO_NODE) {
-            markNodeDirty(*linkedNode++);
-        }
-    }
-
-    template<typename OutputT>
-    void emitValue(NodeId nid, typename OutputT::ValueT value) {
-        emitValueImpl(nid, OutputT::KEY, value);
-    }
-
-    template<typename T>
-    void reemitValueImpl(NodeId nid, PinKey key) {
-        OutputPin<T>* outputPin = (OutputPin<T>*)pinPtr(storages[nid], key);
-        emitValueImpl<T>(nid, key, outputPin->value);
-    }
-
-    template<typename OutputT>
-    void reemitValue(NodeId nid) {
-        reemitValueImpl<typename OutputT::ValueT>(nid, OutputT::KEY);
-    }
-
-    void evaluateNode(NodeId nid) {
-        XOD_TRACE_F("eval #");
-        XOD_TRACE_LN(nid);
-        EvalFuncPtr eval = evaluationFuncs[nid];
-        eval(nid, storages[nid]);
-    }
-
-    void runTransaction() {
-        XOD_TRACE_F("Transaction started, t=");
-        XOD_TRACE_LN(millis());
-        for (NodeId nid : topology) {
-            if (isNodeDirty(nid))
-                evaluateNode(nid);
-        }
-
-        memset(dirtyFlags, 0, sizeof(dirtyFlags));
-        XOD_TRACE_F("Transaction completed, t=");
-        XOD_TRACE_LN(millis());
-    }
-
-    void idle() {
-        TimeMs now = millis();
-        for (NodeId nid = 0; nid < NODE_COUNT; ++nid) {
-            TimeMs t = schedule[nid];
-            if (t && t <= now) {
-                markNodeDirty(nid);
-                clearTimeout(nid);
-                return;
-            }
-        }
-    }
+template<typename InputT>
+typename InputT::ValueT getValue(NodeId nid) {
+    return getInputValueImpl<typename InputT::ValueT>(nid, InputT::WIRING_OFFSET);
 }
+
+template<typename OutputT>
+void emitValue(NodeId nid, typename OutputT::ValueT value) {
+    emitValueImpl(
+            nid,
+            OutputT::STORAGE_OFFSET,
+            OutputT::WIRING_OFFSET,
+            OutputT::INDEX,
+            value);
+}
+
+TimeMs transactionTime() {
+    return millis();
+}
+
+void setTimeout(NodeId nid, TimeMs timeout) {
+    g_schedule[nid] = transactionTime() + timeout;
+}
+
+void clearTimeout(NodeId nid) {
+    g_schedule[nid] = 0;
+}
+
+} // namespace xod
 
 //----------------------------------------------------------------------------
 // Entry point
@@ -896,7 +954,7 @@ void setup() {
 #ifdef XOD_DEBUG
     DEBUG_SERIAL.begin(9600);
 #endif
-    XOD_TRACE_FLN("Program started");
+    XOD_TRACE_FLN("\n\nProgram started");
 }
 
 void loop() {
@@ -925,19 +983,24 @@ struct State {
 
 struct Storage {
     State state;
-    PinRef input_IVAL;
-    PinRef input_RST;
-    OutputPin<Logic> output_TICK;
+    Logic output_TICK;
+};
+
+struct Wiring {
+    EvalFuncPtr eval;
+    UpstreamPinRef input_IVAL;
+    UpstreamPinRef input_RST;
+    const NodeId* output_TICK;
 };
 
 State* getState(NodeId nid) {
-    return reinterpret_cast<State*>(storages[nid]);
+    return reinterpret_cast<State*>(getStoragePtr(nid, 0));
 }
 
-using input_IVAL = InputDescriptor<Number, offsetof(Storage, input_IVAL)>;
-using input_RST = InputDescriptor<Logic, offsetof(Storage, input_RST)>;
+using input_IVAL = InputDescriptor<Number, offsetof(Wiring, input_IVAL)>;
+using input_RST = InputDescriptor<Logic, offsetof(Wiring, input_RST)>;
 
-using output_TICK = OutputDescriptor<Logic, offsetof(Storage, output_TICK), 0>;
+using output_TICK = OutputDescriptor<Logic, offsetof(Wiring, output_TICK), offsetof(Storage, output_TICK), 0>;
 
 void evaluate(Context ctx) {
     State* state = getState(ctx);
@@ -974,21 +1037,26 @@ struct State {
 
 struct Storage {
     State state;
-    PinRef input_SET;
-    PinRef input_TGL;
-    PinRef input_RST;
-    OutputPin<Logic> output_MEM;
+    Logic output_MEM;
+};
+
+struct Wiring {
+    EvalFuncPtr eval;
+    UpstreamPinRef input_SET;
+    UpstreamPinRef input_TGL;
+    UpstreamPinRef input_RST;
+    const NodeId* output_MEM;
 };
 
 State* getState(NodeId nid) {
-    return reinterpret_cast<State*>(storages[nid]);
+    return reinterpret_cast<State*>(getStoragePtr(nid, 0));
 }
 
-using input_SET = InputDescriptor<Logic, offsetof(Storage, input_SET)>;
-using input_TGL = InputDescriptor<Logic, offsetof(Storage, input_TGL)>;
-using input_RST = InputDescriptor<Logic, offsetof(Storage, input_RST)>;
+using input_SET = InputDescriptor<Logic, offsetof(Wiring, input_SET)>;
+using input_TGL = InputDescriptor<Logic, offsetof(Wiring, input_TGL)>;
+using input_RST = InputDescriptor<Logic, offsetof(Wiring, input_RST)>;
 
-using output_MEM = OutputDescriptor<Logic, offsetof(Storage, output_MEM), 0>;
+using output_MEM = OutputDescriptor<Logic, offsetof(Wiring, output_MEM), offsetof(Storage, output_MEM), 0>;
 
 void evaluate(Context ctx) {
     State* state = getState(ctx);
@@ -1021,16 +1089,20 @@ struct State {
 
 struct Storage {
     State state;
-    PinRef input_PORT;
-    PinRef input_SIG;
+};
+
+struct Wiring {
+    EvalFuncPtr eval;
+    UpstreamPinRef input_PORT;
+    UpstreamPinRef input_SIG;
 };
 
 State* getState(NodeId nid) {
-    return reinterpret_cast<State*>(storages[nid]);
+    return reinterpret_cast<State*>(getStoragePtr(nid, 0));
 }
 
-using input_PORT = InputDescriptor<Number, offsetof(Storage, input_PORT)>;
-using input_SIG = InputDescriptor<Logic, offsetof(Storage, input_SIG)>;
+using input_PORT = InputDescriptor<Number, offsetof(Wiring, input_PORT)>;
+using input_SIG = InputDescriptor<Logic, offsetof(Wiring, input_SIG)>;
 
 void evaluate(Context ctx) {
     State* state = getState(ctx);
@@ -1057,17 +1129,21 @@ struct State {};
 
 struct Storage {
     State state;
-    OutputPin<Number> output_VAL;
+    Number output_VAL;
+};
+
+struct Wiring {
+    EvalFuncPtr eval;
+    const NodeId* output_VAL;
 };
 
 State* getState(NodeId nid) {
-    return reinterpret_cast<State*>(storages[nid]);
+    return reinterpret_cast<State*>(getStoragePtr(nid, 0));
 }
 
-using output_VAL = OutputDescriptor<Number, offsetof(Storage, output_VAL), 0>;
+using output_VAL = OutputDescriptor<Number, offsetof(Wiring, output_VAL), offsetof(Storage, output_VAL), 0>;
 
 void evaluate(Context ctx) {
-  reemitValue<output_VAL>(ctx);
 }
 
 } // namespace xod__core__constant_number
@@ -1084,58 +1160,40 @@ void evaluate(Context ctx) {
 
 namespace xod {
 
-    NodeId links_0_TICK[] = { 1, NO_NODE };
+    //-------------------------------------------------------------------------
+    // Dynamic data
+    //-------------------------------------------------------------------------
+
+    // Storage of #0 xod/core/clock
     xod__core__clock::Storage storage_0 = {
         { }, // state
-        { NodeId(3), xod__core__constant_number::output_VAL::KEY }, // input_IVAL
-        { NO_NODE, 0 }, // input_RST
-        { false, links_0_TICK } // output_TICK
+        false // output_TICK
     };
 
-    NodeId links_1_MEM[] = { 2, NO_NODE };
+    // Storage of #1 xod/core/flip_flop
     xod__core__flip_flop::Storage storage_1 = {
         { }, // state
-        { NO_NODE, 0 }, // input_SET
-        { NodeId(0), xod__core__clock::output_TICK::KEY }, // input_TGL
-        { NO_NODE, 0 }, // input_RST
-        { false, links_1_MEM } // output_MEM
+        false // output_MEM
     };
 
+    // Storage of #2 xod/core/digital_output
     xod__core__digital_output::Storage storage_2 = {
         { }, // state
-        { NodeId(4), xod__core__constant_number::output_VAL::KEY }, // input_PORT
-        { NodeId(1), xod__core__flip_flop::output_MEM::KEY }, // input_SIG
     };
 
-    NodeId links_3_VAL[] = { 0, NO_NODE };
+    // Storage of #3 xod/core/constant_number
     xod__core__constant_number::Storage storage_3 = {
         { }, // state
-        { 0.25, links_3_VAL } // output_VAL
+        0.25 // output_VAL
     };
 
-    NodeId links_4_VAL[] = { 2, NO_NODE };
+    // Storage of #4 xod/core/constant_number
     xod__core__constant_number::Storage storage_4 = {
         { }, // state
-        { 13, links_4_VAL } // output_VAL
+        13 // output_VAL
     };
 
-    void* storages[NODE_COUNT] = {
-        &storage_0,
-        &storage_1,
-        &storage_2,
-        &storage_3,
-        &storage_4
-    };
-
-    EvalFuncPtr evaluationFuncs[NODE_COUNT] = {
-        (EvalFuncPtr)&xod__core__clock::evaluate,
-        (EvalFuncPtr)&xod__core__flip_flop::evaluate,
-        (EvalFuncPtr)&xod__core__digital_output::evaluate,
-        (EvalFuncPtr)&xod__core__constant_number::evaluate,
-        (EvalFuncPtr)&xod__core__constant_number::evaluate
-    };
-
-    DirtyFlags dirtyFlags[NODE_COUNT] = {
+    DirtyFlags g_dirtyFlags[NODE_COUNT] = {
         DirtyFlags(253),
         DirtyFlags(255),
         DirtyFlags(255),
@@ -1143,9 +1201,89 @@ namespace xod {
         DirtyFlags(255)
     };
 
-    NodeId topology[NODE_COUNT] = {
-        3, 4, 0, 1, 2
+    TimeMs g_schedule[NODE_COUNT] = { 0 };
+
+    //-------------------------------------------------------------------------
+    // Static (immutable) data
+    //-------------------------------------------------------------------------
+
+    // Wiring of #0 xod/core/clock
+    const NodeId outLinks_0_TICK[] PROGMEM = { 1, NO_NODE };
+    const xod__core__clock::Wiring wiring_0 PROGMEM = {
+        &xod__core__clock::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        { NodeId(3),
+            xod__core__constant_number::output_VAL::INDEX,
+            xod__core__constant_number::output_VAL::STORAGE_OFFSET }, // input_IVAL
+        { NO_NODE, 0, 0 }, // input_RST
+        // outputs (NodeId list binding)
+        outLinks_0_TICK // output_TICK
     };
 
-    TimeMs schedule[NODE_COUNT] = { 0 };
+    // Wiring of #1 xod/core/flip_flop
+    const NodeId outLinks_1_MEM[] PROGMEM = { 2, NO_NODE };
+    const xod__core__flip_flop::Wiring wiring_1 PROGMEM = {
+        &xod__core__flip_flop::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        { NO_NODE, 0, 0 }, // input_SET
+        { NodeId(0),
+            xod__core__clock::output_TICK::INDEX,
+            xod__core__clock::output_TICK::STORAGE_OFFSET }, // input_TGL
+        { NO_NODE, 0, 0 }, // input_RST
+        // outputs (NodeId list binding)
+        outLinks_1_MEM // output_MEM
+    };
+
+    // Wiring of #2 xod/core/digital_output
+    const xod__core__digital_output::Wiring wiring_2 PROGMEM = {
+        &xod__core__digital_output::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        { NodeId(4),
+            xod__core__constant_number::output_VAL::INDEX,
+            xod__core__constant_number::output_VAL::STORAGE_OFFSET }, // input_PORT
+        { NodeId(1),
+            xod__core__flip_flop::output_MEM::INDEX,
+            xod__core__flip_flop::output_MEM::STORAGE_OFFSET }, // input_SIG
+        // outputs (NodeId list binding)
+    };
+
+    // Wiring of #3 xod/core/constant_number
+    const NodeId outLinks_3_VAL[] PROGMEM = { 0, NO_NODE };
+    const xod__core__constant_number::Wiring wiring_3 PROGMEM = {
+        &xod__core__constant_number::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        // outputs (NodeId list binding)
+        outLinks_3_VAL // output_VAL
+    };
+
+    // Wiring of #4 xod/core/constant_number
+    const NodeId outLinks_4_VAL[] PROGMEM = { 2, NO_NODE };
+    const xod__core__constant_number::Wiring wiring_4 PROGMEM = {
+        &xod__core__constant_number::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        // outputs (NodeId list binding)
+        outLinks_4_VAL // output_VAL
+    };
+
+    // PGM array with pointers to PGM wiring information structs
+    const void* const g_wiring[NODE_COUNT] PROGMEM = {
+        &wiring_0,
+        &wiring_1,
+        &wiring_2,
+        &wiring_3,
+        &wiring_4
+    };
+
+    // PGM array with pointers to RAM-located storages
+    void* const g_storages[NODE_COUNT] PROGMEM = {
+        &storage_0,
+        &storage_1,
+        &storage_2,
+        &storage_3,
+        &storage_4
+    };
+
+    NodeId g_topology[NODE_COUNT] = {
+        3, 4, 0, 1, 2
+    };
 }

--- a/packages/xod-fs/yarn.lock
+++ b/packages/xod-fs/yarn.lock
@@ -346,10 +346,6 @@ ramda@>=0.15.0, ramda@^0.23.0:
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.23.0.tgz#ccd13fff73497a93974e3e86327bfd87bd6e8e2b"
 
-ramda@^0.22.1:
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.22.1.tgz#031da0c3df417c5b33c96234757eb37033f36a0e"
-
 randexp@^0.4.2:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.5.tgz#ffe3a80c3f666cd71e6b008e477e584c1a32ff3e"
@@ -413,7 +409,7 @@ sanctuary-type-classes@2.0.x:
   dependencies:
     sanctuary-type-identifiers "1.0.x"
 
-sanctuary-type-identifiers@1.0.x, sanctuary-type-identifiers@^1.0.0:
+sanctuary-type-identifiers@1.0.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/sanctuary-type-identifiers/-/sanctuary-type-identifiers-1.0.0.tgz#e8f359f006cb5e624cfb8464603fc114608bde9f"
 
@@ -424,10 +420,6 @@ shelljs@^0.7.7:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
-
-shortid@^2.2.6:
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.8.tgz#033b117d6a2e975804f6f0969dbe7d3d0b355131"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -452,24 +444,3 @@ universalify@^0.1.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-
-xod-func-tools@^0.11.0-dev, xod-func-tools@^0.12.1:
-  version "0.11.0-dev"
-  resolved "https://registry.yarnpkg.com/xod-func-tools/-/xod-func-tools-0.11.0-dev.tgz#816d47bae459a7a81d122b437cc4ca9e8b48b414"
-  dependencies:
-    hm-def "^0.2.0"
-    ramda "^0.22.1"
-    ramda-fantasy "^0.7.0"
-    sanctuary-def "^0.9.0"
-    sanctuary-type-identifiers "^1.0.0"
-
-xod-project@^0.12.1:
-  version "0.11.0-dev"
-  resolved "https://registry.yarnpkg.com/xod-project/-/xod-project-0.11.0-dev.tgz#098ad2e808c376ca505034e7b8be72b3013ccae2"
-  dependencies:
-    hm-def "^0.2.0"
-    ramda "^0.23.0"
-    ramda-fantasy "^0.7.0"
-    sanctuary-def "^0.9.0"
-    shortid "^2.2.6"
-    xod-func-tools "^0.11.0-dev"

--- a/workspace/blink/__fixtures__/arduino.cpp
+++ b/workspace/blink/__fixtures__/arduino.cpp
@@ -16,7 +16,7 @@
 
 #include <Arduino.h>
 #include <inttypes.h>
-
+#include <avr/pgmspace.h>
 
 // ============================================================================
 //
@@ -666,226 +666,284 @@ template <typename T> class List {
 #endif
 
 //----------------------------------------------------------------------------
+// PGM space utilities
+//----------------------------------------------------------------------------
+#define pgm_read_nodeid(address) (pgm_read_word(address))
+
+/*
+ * Workaround for bugs:
+ * https://github.com/arduino/ArduinoCore-sam/pull/43
+ * https://github.com/arduino/ArduinoCore-samd/pull/253
+ * Remove after the PRs merge
+ */
+#if !defined(ARDUINO_ARCH_AVR) && defined(pgm_read_ptr)
+#  undef pgm_read_ptr
+#  define pgm_read_ptr(addr) (*(const void **)(addr))
+#endif
+
+namespace xod {
+//----------------------------------------------------------------------------
 // Type definitions
 //----------------------------------------------------------------------------
-#define PIN_KEY_OFFSET_BITS     (16 - MAX_OUTPUT_COUNT)
 #define NO_NODE                 ((NodeId)-1)
 
-namespace xod {
-    typedef double Number;
-    typedef bool Logic;
+typedef double Number;
+typedef bool Logic;
 
-    // TODO: optimize, we should choose uint8_t if there are less than 255 nodes in total
-    // and uint32_t if there are more than 65535
-    typedef uint16_t NodeId;
+#if NODE_COUNT < 256
+typedef uint8_t NodeId;
+#elif NODE_COUNT < 65536
+typedef uint16_t NodeId;
+#else
+typedef uint32_t NodeId;
+#endif
 
-    typedef NodeId Context;
+/*
+ * Context is a handle passed to each node `evaluate` function. Currently, it’s
+ * alias for NodeId but likely will be changed in future to support list
+ * lifting and other features
+ */
+typedef NodeId Context;
 
-    /*
-     * PinKey is an address value used to find input’s or output’s data within
-     * node’s Storage.
-     *
-     * For inputs its value is simply an offset in bytes from the beginning of
-     * Storage structure instance. There will be a PinRef pointing to an upstream
-     * output at this address.
-     *
-     * For outputs the pin key consists of two parts ORed bitwise. Least
-     * significant bits (count defined by `PIN_KEY_OFFSET_BITS`) define an offset
-     * from the beginning of node’s Storage where output data could be found. It
-     * would be an OutputPin structure. Most significant bits define an index
-     * number of that output among all outputs of the node. The index is used to
-     * work with dirty flags bit-value.
-     */
-    // TODO: optimize, we should choose a proper type with a minimal enough capacity
-    typedef uint16_t PinKey;
+/*
+ * LSB of a dirty flag shows whether a particular node is dirty or not
+ * Other bits shows dirtieness of its particular outputs:
+ * - 1-st bit for 0-th output
+ * - 2-nd bit for 1-st output
+ * - etc
+ *
+ * An outcome limitation is that a native node must not have more than 7 output
+ * pins.
+ */
+typedef uint8_t DirtyFlags;
 
-    // TODO: optimize, we should choose a proper type with a minimal enough capacity
-    typedef uint16_t DirtyFlags;
+typedef unsigned long TimeMs;
+typedef void (*EvalFuncPtr)(Context ctx);
 
-    typedef unsigned long TimeMs;
-    typedef void (*EvalFuncPtr)(NodeId nid, void* state);
+typedef xod::List<char>::ListPtr XString;
 
-    typedef xod::List<char>::ListPtr XString;
+/*
+ * Each input stores a reference to its upstream node so that we can get values
+ * on input pins. Having a direct pointer to the value is not enough because we
+ * want to know dirty’ness as well. So we have to use this structure instead of
+ * a pointer.
+ */
+struct UpstreamPinRef {
+    // Upstream node ID
+    NodeId nodeId;
+    // Index of the upstream node’s output.
+    // Use 3 bits as it just enough to store values 0..7
+    uint16_t pinIndex : 3;
+    // Byte offset in a storage of the upstream node where the actual pin value
+    // is stored
+    uint16_t storageOffset : 13;
+};
+
+/*
+ * Input descriptor is a metaprogramming structure used to enforce an
+ * input’s type and store its wiring data location as a zero-RAM constant.
+ *
+ * A specialized descriptor is required by `getValue` function. Every
+ * input of every type node gets its own descriptor in generated code that
+ * can be accessed as input_FOO. Where FOO is a pin identifier.
+ */
+template<typename ValueT_, size_t wiringOffset>
+struct InputDescriptor {
+    typedef ValueT_ ValueT;
+    enum {
+        WIRING_OFFSET = wiringOffset
+    };
+};
+
+/*
+ * Output descriptor serve the same purpose as InputDescriptor but for
+ * ouputs.
+ *
+ * In addition to wiring data location it keeps storage data location (where
+ * actual value is stored) and own zero-based index among outputs of a particular
+ * node
+ */
+template<typename ValueT_, size_t wiringOffset, size_t storageOffset, uint8_t index>
+struct OutputDescriptor {
+    typedef ValueT_ ValueT;
+    enum {
+        WIRING_OFFSET = wiringOffset,
+        STORAGE_OFFSET = storageOffset,
+        INDEX = index
+    };
+};
+
+//----------------------------------------------------------------------------
+// Forward declarations
+//----------------------------------------------------------------------------
+extern void* const g_storages[NODE_COUNT];
+extern const void* const g_wiring[NODE_COUNT];
+extern DirtyFlags g_dirtyFlags[NODE_COUNT];
+
+// TODO: get rid of an extra indirection layer completely
+// would save 2 bytes per node
+extern NodeId g_topology[NODE_COUNT];
+
+// TODO: replace with a compact list
+extern TimeMs g_schedule[NODE_COUNT];
+
+void clearTimeout(NodeId nid);
+
+//----------------------------------------------------------------------------
+// Engine (private API)
+//----------------------------------------------------------------------------
+
+void* getStoragePtr(NodeId nid, size_t offset) {
+    return (uint8_t*)pgm_read_ptr(&g_storages[nid]) + offset;
+}
+
+template<typename T>
+T getStorageValue(NodeId nid, size_t offset) {
+    return *reinterpret_cast<T*>(getStoragePtr(nid, offset));
+}
+
+void* getWiringPgmPtr(NodeId nid, size_t offset) {
+    return (uint8_t*)pgm_read_ptr(&g_wiring[nid]) + offset;
+}
+
+template<typename T>
+T getWiringValue(NodeId nid, size_t offset) {
+    T result;
+    memcpy_P(&result, getWiringPgmPtr(nid, offset), sizeof(T));
+    return result;
+}
+
+bool isOutputDirty(NodeId nid, uint8_t index) {
+    return g_dirtyFlags[nid] & (1 << (index + 1));
+}
+
+bool isInputDirtyImpl(NodeId nid, size_t wiringOffset) {
+    UpstreamPinRef ref = getWiringValue<UpstreamPinRef>(nid, wiringOffset);
+    if (ref.nodeId == NO_NODE)
+        return false;
+
+    return isOutputDirty(ref.nodeId, ref.pinIndex);
+}
+
+template<typename InputT>
+bool isInputDirty(NodeId nid) {
+    return isInputDirtyImpl(nid, InputT::WIRING_OFFSET);
+}
+
+void markPinDirty(NodeId nid, uint8_t index) {
+    g_dirtyFlags[nid] |= 1 << (index + 1);
+}
+
+void markNodeDirty(NodeId nid) {
+    g_dirtyFlags[nid] |= 0x1;
+}
+
+bool isNodeDirty(NodeId nid) {
+    return g_dirtyFlags[nid] & 0x1;
+}
+
+template<typename T>
+T getOutputValueImpl(NodeId nid, size_t storageOffset) {
+    return getStorageValue<T>(nid, storageOffset);
+}
+
+template<typename T>
+T getInputValueImpl(NodeId nid, size_t wiringOffset) {
+    UpstreamPinRef ref = getWiringValue<UpstreamPinRef>(nid, wiringOffset);
+    if (ref.nodeId == NO_NODE)
+        return (T)0;
+
+    return getOutputValueImpl<T>(ref.nodeId, ref.storageOffset);
+}
+
+template<typename T>
+void emitValueImpl(
+        NodeId nid,
+        size_t storageOffset,
+        size_t wiringOffset,
+        uint8_t index,
+        T value) {
+
+    // Store new value and make the node itself dirty
+    T* storedValue = reinterpret_cast<T*>(getStoragePtr(nid, storageOffset));
+    *storedValue = value;
+    markPinDirty(nid, index);
+
+    // Notify downstream nodes about changes
+    // NB: linked nodes array is in PGM space
+    const NodeId* pDownstreamNid = getWiringValue<const NodeId*>(nid, wiringOffset);
+    NodeId downstreamNid = pgm_read_nodeid(pDownstreamNid);
+
+    while (downstreamNid != NO_NODE) {
+        markNodeDirty(downstreamNid);
+        downstreamNid = pgm_read_nodeid(pDownstreamNid++);
+    }
+}
+
+void evaluateNode(NodeId nid) {
+    XOD_TRACE_F("eval #");
+    XOD_TRACE_LN(nid);
+    EvalFuncPtr eval = getWiringValue<EvalFuncPtr>(nid, 0);
+    eval(nid);
+}
+
+void runTransaction() {
+    XOD_TRACE_F("Transaction started, t=");
+    XOD_TRACE_LN(millis());
+    for (NodeId nid : g_topology) {
+        if (isNodeDirty(nid))
+            evaluateNode(nid);
+    }
+
+    memset(g_dirtyFlags, 0, sizeof(g_dirtyFlags));
+    XOD_TRACE_F("Transaction completed, t=");
+    XOD_TRACE_LN(millis());
+}
+
+void idle() {
+    TimeMs now = millis();
+    for (NodeId nid = 0; nid < NODE_COUNT; ++nid) {
+        TimeMs t = g_schedule[nid];
+        if (t && t <= now) {
+            markNodeDirty(nid);
+            clearTimeout(nid);
+            return;
+        }
+    }
 }
 
 //----------------------------------------------------------------------------
-// Engine
+// Public API (can be used by native nodes’ `evaluate` functions)
 //----------------------------------------------------------------------------
-namespace xod {
-    extern void* storages[NODE_COUNT];
-    extern EvalFuncPtr evaluationFuncs[NODE_COUNT];
-    extern DirtyFlags dirtyFlags[NODE_COUNT];
-    extern NodeId topology[NODE_COUNT];
 
-    // TODO: replace with a compact list
-    extern TimeMs schedule[NODE_COUNT];
-
-    template<typename T>
-    struct OutputPin {
-        T value;
-        // Keep outgoing link list with terminating `NO_NODE`
-        NodeId* links;
-    };
-
-    struct PinRef {
-        NodeId nodeId;
-        PinKey pinKey;
-    };
-
-    /*
-     * Input descriptor is a metaprogramming structure used to enforce an
-     * input’s type and store its PinKey as a zero-memory constant.
-     *
-     * A specialized descriptor is required by `getValue` function. Every
-     * input of every type node gets its own descriptor in generated code that
-     * can be accessed as input_FOO. Where FOO is a pin identifier.
-     */
-    template<typename ValueT_, size_t offsetInStorage>
-    struct InputDescriptor {
-        typedef ValueT_ ValueT;
-        enum Offset : PinKey {
-            KEY = offsetInStorage
-        };
-    };
-
-    /*
-     * Output descriptor serve the same purpose as InputDescriptor but for
-     * ouputs.
-     */
-    template<typename ValueT_, size_t offsetInStorage, int index>
-    struct OutputDescriptor {
-        typedef ValueT_ ValueT;
-        enum Offset : PinKey {
-            KEY = offsetInStorage | (index << PIN_KEY_OFFSET_BITS)
-        };
-    };
-
-    void* pinPtr(void* storage, PinKey key) {
-        const size_t offset = key & ~(PinKey(-1) << PIN_KEY_OFFSET_BITS);
-        return (uint8_t*)storage + offset;
-    }
-
-    DirtyFlags dirtyPinBit(PinKey key) {
-        const PinKey nbit = (key >> PIN_KEY_OFFSET_BITS) + 1;
-        return 1 << nbit;
-    }
-
-    bool isOutputDirty(NodeId nid, PinKey key) {
-        return dirtyFlags[nid] & dirtyPinBit(key);
-    }
-
-    bool isInputDirtyImpl(NodeId nid, PinKey key) {
-        PinRef* ref = (PinRef*)pinPtr(storages[nid], key);
-        if (ref->nodeId == NO_NODE)
-            return false;
-
-        return isOutputDirty(ref->nodeId, ref->pinKey);
-    }
-
-    template<typename InputT>
-    bool isInputDirty(NodeId nid) {
-        return isInputDirtyImpl(nid, InputT::KEY);
-    }
-
-    void markPinDirty(NodeId nid, PinKey key) {
-        dirtyFlags[nid] |= dirtyPinBit(key);
-    }
-
-    void markNodeDirty(NodeId nid) {
-        dirtyFlags[nid] |= 0x1;
-    }
-
-    bool isNodeDirty(NodeId nid) {
-        return dirtyFlags[nid] & 0x1;
-    }
-
-    TimeMs transactionTime() {
-        return millis();
-    }
-
-    void setTimeout(NodeId nid, TimeMs timeout) {
-        schedule[nid] = transactionTime() + timeout;
-    }
-
-    void clearTimeout(NodeId nid) {
-        schedule[nid] = 0;
-    }
-
-    template<typename T>
-    T getValueImpl(NodeId nid, PinKey key) {
-        PinRef* ref = (PinRef*)pinPtr(storages[nid], key);
-        if (ref->nodeId == NO_NODE)
-            return (T)0;
-
-        return *(T*)pinPtr(storages[ref->nodeId], ref->pinKey);
-    }
-
-    template<typename InputT>
-    typename InputT::ValueT getValue(NodeId nid) {
-        return getValueImpl<typename InputT::ValueT>(nid, InputT::KEY);
-    }
-
-    template<typename T>
-    void emitValueImpl(NodeId nid, PinKey key, T value) {
-        OutputPin<T>* outputPin = (OutputPin<T>*)pinPtr(storages[nid], key);
-
-        outputPin->value = value;
-        markPinDirty(nid, key);
-
-        NodeId* linkedNode = outputPin->links;
-        while (*linkedNode != NO_NODE) {
-            markNodeDirty(*linkedNode++);
-        }
-    }
-
-    template<typename OutputT>
-    void emitValue(NodeId nid, typename OutputT::ValueT value) {
-        emitValueImpl(nid, OutputT::KEY, value);
-    }
-
-    template<typename T>
-    void reemitValueImpl(NodeId nid, PinKey key) {
-        OutputPin<T>* outputPin = (OutputPin<T>*)pinPtr(storages[nid], key);
-        emitValueImpl<T>(nid, key, outputPin->value);
-    }
-
-    template<typename OutputT>
-    void reemitValue(NodeId nid) {
-        reemitValueImpl<typename OutputT::ValueT>(nid, OutputT::KEY);
-    }
-
-    void evaluateNode(NodeId nid) {
-        XOD_TRACE_F("eval #");
-        XOD_TRACE_LN(nid);
-        EvalFuncPtr eval = evaluationFuncs[nid];
-        eval(nid, storages[nid]);
-    }
-
-    void runTransaction() {
-        XOD_TRACE_F("Transaction started, t=");
-        XOD_TRACE_LN(millis());
-        for (NodeId nid : topology) {
-            if (isNodeDirty(nid))
-                evaluateNode(nid);
-        }
-
-        memset(dirtyFlags, 0, sizeof(dirtyFlags));
-        XOD_TRACE_F("Transaction completed, t=");
-        XOD_TRACE_LN(millis());
-    }
-
-    void idle() {
-        TimeMs now = millis();
-        for (NodeId nid = 0; nid < NODE_COUNT; ++nid) {
-            TimeMs t = schedule[nid];
-            if (t && t <= now) {
-                markNodeDirty(nid);
-                clearTimeout(nid);
-                return;
-            }
-        }
-    }
+template<typename InputT>
+typename InputT::ValueT getValue(NodeId nid) {
+    return getInputValueImpl<typename InputT::ValueT>(nid, InputT::WIRING_OFFSET);
 }
+
+template<typename OutputT>
+void emitValue(NodeId nid, typename OutputT::ValueT value) {
+    emitValueImpl(
+            nid,
+            OutputT::STORAGE_OFFSET,
+            OutputT::WIRING_OFFSET,
+            OutputT::INDEX,
+            value);
+}
+
+TimeMs transactionTime() {
+    return millis();
+}
+
+void setTimeout(NodeId nid, TimeMs timeout) {
+    g_schedule[nid] = transactionTime() + timeout;
+}
+
+void clearTimeout(NodeId nid) {
+    g_schedule[nid] = 0;
+}
+
+} // namespace xod
 
 //----------------------------------------------------------------------------
 // Entry point
@@ -896,7 +954,7 @@ void setup() {
 #ifdef XOD_DEBUG
     DEBUG_SERIAL.begin(9600);
 #endif
-    XOD_TRACE_FLN("Program started");
+    XOD_TRACE_FLN("\n\nProgram started");
 }
 
 void loop() {
@@ -925,19 +983,24 @@ struct State {
 
 struct Storage {
     State state;
-    PinRef input_IVAL;
-    PinRef input_RST;
-    OutputPin<Logic> output_TICK;
+    Logic output_TICK;
+};
+
+struct Wiring {
+    EvalFuncPtr eval;
+    UpstreamPinRef input_IVAL;
+    UpstreamPinRef input_RST;
+    const NodeId* output_TICK;
 };
 
 State* getState(NodeId nid) {
-    return reinterpret_cast<State*>(storages[nid]);
+    return reinterpret_cast<State*>(getStoragePtr(nid, 0));
 }
 
-using input_IVAL = InputDescriptor<Number, offsetof(Storage, input_IVAL)>;
-using input_RST = InputDescriptor<Logic, offsetof(Storage, input_RST)>;
+using input_IVAL = InputDescriptor<Number, offsetof(Wiring, input_IVAL)>;
+using input_RST = InputDescriptor<Logic, offsetof(Wiring, input_RST)>;
 
-using output_TICK = OutputDescriptor<Logic, offsetof(Storage, output_TICK), 0>;
+using output_TICK = OutputDescriptor<Logic, offsetof(Wiring, output_TICK), offsetof(Storage, output_TICK), 0>;
 
 void evaluate(Context ctx) {
     State* state = getState(ctx);
@@ -974,16 +1037,20 @@ struct State {
 
 struct Storage {
     State state;
-    PinRef input_PORT;
-    PinRef input_SIG;
+};
+
+struct Wiring {
+    EvalFuncPtr eval;
+    UpstreamPinRef input_PORT;
+    UpstreamPinRef input_SIG;
 };
 
 State* getState(NodeId nid) {
-    return reinterpret_cast<State*>(storages[nid]);
+    return reinterpret_cast<State*>(getStoragePtr(nid, 0));
 }
 
-using input_PORT = InputDescriptor<Number, offsetof(Storage, input_PORT)>;
-using input_SIG = InputDescriptor<Logic, offsetof(Storage, input_SIG)>;
+using input_PORT = InputDescriptor<Number, offsetof(Wiring, input_PORT)>;
+using input_SIG = InputDescriptor<Logic, offsetof(Wiring, input_SIG)>;
 
 void evaluate(Context ctx) {
     State* state = getState(ctx);
@@ -1012,21 +1079,26 @@ struct State {
 
 struct Storage {
     State state;
-    PinRef input_SET;
-    PinRef input_TGL;
-    PinRef input_RST;
-    OutputPin<Logic> output_MEM;
+    Logic output_MEM;
+};
+
+struct Wiring {
+    EvalFuncPtr eval;
+    UpstreamPinRef input_SET;
+    UpstreamPinRef input_TGL;
+    UpstreamPinRef input_RST;
+    const NodeId* output_MEM;
 };
 
 State* getState(NodeId nid) {
-    return reinterpret_cast<State*>(storages[nid]);
+    return reinterpret_cast<State*>(getStoragePtr(nid, 0));
 }
 
-using input_SET = InputDescriptor<Logic, offsetof(Storage, input_SET)>;
-using input_TGL = InputDescriptor<Logic, offsetof(Storage, input_TGL)>;
-using input_RST = InputDescriptor<Logic, offsetof(Storage, input_RST)>;
+using input_SET = InputDescriptor<Logic, offsetof(Wiring, input_SET)>;
+using input_TGL = InputDescriptor<Logic, offsetof(Wiring, input_TGL)>;
+using input_RST = InputDescriptor<Logic, offsetof(Wiring, input_RST)>;
 
-using output_MEM = OutputDescriptor<Logic, offsetof(Storage, output_MEM), 0>;
+using output_MEM = OutputDescriptor<Logic, offsetof(Wiring, output_MEM), offsetof(Storage, output_MEM), 0>;
 
 void evaluate(Context ctx) {
     State* state = getState(ctx);
@@ -1057,17 +1129,21 @@ struct State {};
 
 struct Storage {
     State state;
-    OutputPin<Number> output_VAL;
+    Number output_VAL;
+};
+
+struct Wiring {
+    EvalFuncPtr eval;
+    const NodeId* output_VAL;
 };
 
 State* getState(NodeId nid) {
-    return reinterpret_cast<State*>(storages[nid]);
+    return reinterpret_cast<State*>(getStoragePtr(nid, 0));
 }
 
-using output_VAL = OutputDescriptor<Number, offsetof(Storage, output_VAL), 0>;
+using output_VAL = OutputDescriptor<Number, offsetof(Wiring, output_VAL), offsetof(Storage, output_VAL), 0>;
 
 void evaluate(Context ctx) {
-  reemitValue<output_VAL>(ctx);
 }
 
 } // namespace xod__core__constant_number
@@ -1084,58 +1160,40 @@ void evaluate(Context ctx) {
 
 namespace xod {
 
-    NodeId links_0_TICK[] = { 2, NO_NODE };
+    //-------------------------------------------------------------------------
+    // Dynamic data
+    //-------------------------------------------------------------------------
+
+    // Storage of #0 xod/core/clock
     xod__core__clock::Storage storage_0 = {
         { }, // state
-        { NodeId(3), xod__core__constant_number::output_VAL::KEY }, // input_IVAL
-        { NO_NODE, 0 }, // input_RST
-        { false, links_0_TICK } // output_TICK
+        false // output_TICK
     };
 
+    // Storage of #1 xod/core/digital_output
     xod__core__digital_output::Storage storage_1 = {
         { }, // state
-        { NodeId(4), xod__core__constant_number::output_VAL::KEY }, // input_PORT
-        { NodeId(2), xod__core__flip_flop::output_MEM::KEY }, // input_SIG
     };
 
-    NodeId links_2_MEM[] = { 1, NO_NODE };
+    // Storage of #2 xod/core/flip_flop
     xod__core__flip_flop::Storage storage_2 = {
         { }, // state
-        { NO_NODE, 0 }, // input_SET
-        { NodeId(0), xod__core__clock::output_TICK::KEY }, // input_TGL
-        { NO_NODE, 0 }, // input_RST
-        { false, links_2_MEM } // output_MEM
+        false // output_MEM
     };
 
-    NodeId links_3_VAL[] = { 0, NO_NODE };
+    // Storage of #3 xod/core/constant_number
     xod__core__constant_number::Storage storage_3 = {
         { }, // state
-        { 0.25, links_3_VAL } // output_VAL
+        0.25 // output_VAL
     };
 
-    NodeId links_4_VAL[] = { 1, NO_NODE };
+    // Storage of #4 xod/core/constant_number
     xod__core__constant_number::Storage storage_4 = {
         { }, // state
-        { 13, links_4_VAL } // output_VAL
+        13 // output_VAL
     };
 
-    void* storages[NODE_COUNT] = {
-        &storage_0,
-        &storage_1,
-        &storage_2,
-        &storage_3,
-        &storage_4
-    };
-
-    EvalFuncPtr evaluationFuncs[NODE_COUNT] = {
-        (EvalFuncPtr)&xod__core__clock::evaluate,
-        (EvalFuncPtr)&xod__core__digital_output::evaluate,
-        (EvalFuncPtr)&xod__core__flip_flop::evaluate,
-        (EvalFuncPtr)&xod__core__constant_number::evaluate,
-        (EvalFuncPtr)&xod__core__constant_number::evaluate
-    };
-
-    DirtyFlags dirtyFlags[NODE_COUNT] = {
+    DirtyFlags g_dirtyFlags[NODE_COUNT] = {
         DirtyFlags(253),
         DirtyFlags(255),
         DirtyFlags(255),
@@ -1143,9 +1201,89 @@ namespace xod {
         DirtyFlags(255)
     };
 
-    NodeId topology[NODE_COUNT] = {
-        3, 4, 0, 2, 1
+    TimeMs g_schedule[NODE_COUNT] = { 0 };
+
+    //-------------------------------------------------------------------------
+    // Static (immutable) data
+    //-------------------------------------------------------------------------
+
+    // Wiring of #0 xod/core/clock
+    const NodeId outLinks_0_TICK[] PROGMEM = { 2, NO_NODE };
+    const xod__core__clock::Wiring wiring_0 PROGMEM = {
+        &xod__core__clock::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        { NodeId(3),
+            xod__core__constant_number::output_VAL::INDEX,
+            xod__core__constant_number::output_VAL::STORAGE_OFFSET }, // input_IVAL
+        { NO_NODE, 0, 0 }, // input_RST
+        // outputs (NodeId list binding)
+        outLinks_0_TICK // output_TICK
     };
 
-    TimeMs schedule[NODE_COUNT] = { 0 };
+    // Wiring of #1 xod/core/digital_output
+    const xod__core__digital_output::Wiring wiring_1 PROGMEM = {
+        &xod__core__digital_output::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        { NodeId(4),
+            xod__core__constant_number::output_VAL::INDEX,
+            xod__core__constant_number::output_VAL::STORAGE_OFFSET }, // input_PORT
+        { NodeId(2),
+            xod__core__flip_flop::output_MEM::INDEX,
+            xod__core__flip_flop::output_MEM::STORAGE_OFFSET }, // input_SIG
+        // outputs (NodeId list binding)
+    };
+
+    // Wiring of #2 xod/core/flip_flop
+    const NodeId outLinks_2_MEM[] PROGMEM = { 1, NO_NODE };
+    const xod__core__flip_flop::Wiring wiring_2 PROGMEM = {
+        &xod__core__flip_flop::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        { NO_NODE, 0, 0 }, // input_SET
+        { NodeId(0),
+            xod__core__clock::output_TICK::INDEX,
+            xod__core__clock::output_TICK::STORAGE_OFFSET }, // input_TGL
+        { NO_NODE, 0, 0 }, // input_RST
+        // outputs (NodeId list binding)
+        outLinks_2_MEM // output_MEM
+    };
+
+    // Wiring of #3 xod/core/constant_number
+    const NodeId outLinks_3_VAL[] PROGMEM = { 0, NO_NODE };
+    const xod__core__constant_number::Wiring wiring_3 PROGMEM = {
+        &xod__core__constant_number::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        // outputs (NodeId list binding)
+        outLinks_3_VAL // output_VAL
+    };
+
+    // Wiring of #4 xod/core/constant_number
+    const NodeId outLinks_4_VAL[] PROGMEM = { 1, NO_NODE };
+    const xod__core__constant_number::Wiring wiring_4 PROGMEM = {
+        &xod__core__constant_number::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        // outputs (NodeId list binding)
+        outLinks_4_VAL // output_VAL
+    };
+
+    // PGM array with pointers to PGM wiring information structs
+    const void* const g_wiring[NODE_COUNT] PROGMEM = {
+        &wiring_0,
+        &wiring_1,
+        &wiring_2,
+        &wiring_3,
+        &wiring_4
+    };
+
+    // PGM array with pointers to RAM-located storages
+    void* const g_storages[NODE_COUNT] PROGMEM = {
+        &storage_0,
+        &storage_1,
+        &storage_2,
+        &storage_3,
+        &storage_4
+    };
+
+    NodeId g_topology[NODE_COUNT] = {
+        3, 4, 0, 2, 1
+    };
 }

--- a/workspace/lcd-time/__fixtures__/arduino.cpp
+++ b/workspace/lcd-time/__fixtures__/arduino.cpp
@@ -16,7 +16,7 @@
 
 #include <Arduino.h>
 #include <inttypes.h>
-
+#include <avr/pgmspace.h>
 
 // ============================================================================
 //
@@ -666,226 +666,284 @@ template <typename T> class List {
 #endif
 
 //----------------------------------------------------------------------------
+// PGM space utilities
+//----------------------------------------------------------------------------
+#define pgm_read_nodeid(address) (pgm_read_word(address))
+
+/*
+ * Workaround for bugs:
+ * https://github.com/arduino/ArduinoCore-sam/pull/43
+ * https://github.com/arduino/ArduinoCore-samd/pull/253
+ * Remove after the PRs merge
+ */
+#if !defined(ARDUINO_ARCH_AVR) && defined(pgm_read_ptr)
+#  undef pgm_read_ptr
+#  define pgm_read_ptr(addr) (*(const void **)(addr))
+#endif
+
+namespace xod {
+//----------------------------------------------------------------------------
 // Type definitions
 //----------------------------------------------------------------------------
-#define PIN_KEY_OFFSET_BITS     (16 - MAX_OUTPUT_COUNT)
 #define NO_NODE                 ((NodeId)-1)
 
-namespace xod {
-    typedef double Number;
-    typedef bool Logic;
+typedef double Number;
+typedef bool Logic;
 
-    // TODO: optimize, we should choose uint8_t if there are less than 255 nodes in total
-    // and uint32_t if there are more than 65535
-    typedef uint16_t NodeId;
+#if NODE_COUNT < 256
+typedef uint8_t NodeId;
+#elif NODE_COUNT < 65536
+typedef uint16_t NodeId;
+#else
+typedef uint32_t NodeId;
+#endif
 
-    typedef NodeId Context;
+/*
+ * Context is a handle passed to each node `evaluate` function. Currently, it’s
+ * alias for NodeId but likely will be changed in future to support list
+ * lifting and other features
+ */
+typedef NodeId Context;
 
-    /*
-     * PinKey is an address value used to find input’s or output’s data within
-     * node’s Storage.
-     *
-     * For inputs its value is simply an offset in bytes from the beginning of
-     * Storage structure instance. There will be a PinRef pointing to an upstream
-     * output at this address.
-     *
-     * For outputs the pin key consists of two parts ORed bitwise. Least
-     * significant bits (count defined by `PIN_KEY_OFFSET_BITS`) define an offset
-     * from the beginning of node’s Storage where output data could be found. It
-     * would be an OutputPin structure. Most significant bits define an index
-     * number of that output among all outputs of the node. The index is used to
-     * work with dirty flags bit-value.
-     */
-    // TODO: optimize, we should choose a proper type with a minimal enough capacity
-    typedef uint16_t PinKey;
+/*
+ * LSB of a dirty flag shows whether a particular node is dirty or not
+ * Other bits shows dirtieness of its particular outputs:
+ * - 1-st bit for 0-th output
+ * - 2-nd bit for 1-st output
+ * - etc
+ *
+ * An outcome limitation is that a native node must not have more than 7 output
+ * pins.
+ */
+typedef uint8_t DirtyFlags;
 
-    // TODO: optimize, we should choose a proper type with a minimal enough capacity
-    typedef uint16_t DirtyFlags;
+typedef unsigned long TimeMs;
+typedef void (*EvalFuncPtr)(Context ctx);
 
-    typedef unsigned long TimeMs;
-    typedef void (*EvalFuncPtr)(NodeId nid, void* state);
+typedef xod::List<char>::ListPtr XString;
 
-    typedef xod::List<char>::ListPtr XString;
+/*
+ * Each input stores a reference to its upstream node so that we can get values
+ * on input pins. Having a direct pointer to the value is not enough because we
+ * want to know dirty’ness as well. So we have to use this structure instead of
+ * a pointer.
+ */
+struct UpstreamPinRef {
+    // Upstream node ID
+    NodeId nodeId;
+    // Index of the upstream node’s output.
+    // Use 3 bits as it just enough to store values 0..7
+    uint16_t pinIndex : 3;
+    // Byte offset in a storage of the upstream node where the actual pin value
+    // is stored
+    uint16_t storageOffset : 13;
+};
+
+/*
+ * Input descriptor is a metaprogramming structure used to enforce an
+ * input’s type and store its wiring data location as a zero-RAM constant.
+ *
+ * A specialized descriptor is required by `getValue` function. Every
+ * input of every type node gets its own descriptor in generated code that
+ * can be accessed as input_FOO. Where FOO is a pin identifier.
+ */
+template<typename ValueT_, size_t wiringOffset>
+struct InputDescriptor {
+    typedef ValueT_ ValueT;
+    enum {
+        WIRING_OFFSET = wiringOffset
+    };
+};
+
+/*
+ * Output descriptor serve the same purpose as InputDescriptor but for
+ * ouputs.
+ *
+ * In addition to wiring data location it keeps storage data location (where
+ * actual value is stored) and own zero-based index among outputs of a particular
+ * node
+ */
+template<typename ValueT_, size_t wiringOffset, size_t storageOffset, uint8_t index>
+struct OutputDescriptor {
+    typedef ValueT_ ValueT;
+    enum {
+        WIRING_OFFSET = wiringOffset,
+        STORAGE_OFFSET = storageOffset,
+        INDEX = index
+    };
+};
+
+//----------------------------------------------------------------------------
+// Forward declarations
+//----------------------------------------------------------------------------
+extern void* const g_storages[NODE_COUNT];
+extern const void* const g_wiring[NODE_COUNT];
+extern DirtyFlags g_dirtyFlags[NODE_COUNT];
+
+// TODO: get rid of an extra indirection layer completely
+// would save 2 bytes per node
+extern NodeId g_topology[NODE_COUNT];
+
+// TODO: replace with a compact list
+extern TimeMs g_schedule[NODE_COUNT];
+
+void clearTimeout(NodeId nid);
+
+//----------------------------------------------------------------------------
+// Engine (private API)
+//----------------------------------------------------------------------------
+
+void* getStoragePtr(NodeId nid, size_t offset) {
+    return (uint8_t*)pgm_read_ptr(&g_storages[nid]) + offset;
+}
+
+template<typename T>
+T getStorageValue(NodeId nid, size_t offset) {
+    return *reinterpret_cast<T*>(getStoragePtr(nid, offset));
+}
+
+void* getWiringPgmPtr(NodeId nid, size_t offset) {
+    return (uint8_t*)pgm_read_ptr(&g_wiring[nid]) + offset;
+}
+
+template<typename T>
+T getWiringValue(NodeId nid, size_t offset) {
+    T result;
+    memcpy_P(&result, getWiringPgmPtr(nid, offset), sizeof(T));
+    return result;
+}
+
+bool isOutputDirty(NodeId nid, uint8_t index) {
+    return g_dirtyFlags[nid] & (1 << (index + 1));
+}
+
+bool isInputDirtyImpl(NodeId nid, size_t wiringOffset) {
+    UpstreamPinRef ref = getWiringValue<UpstreamPinRef>(nid, wiringOffset);
+    if (ref.nodeId == NO_NODE)
+        return false;
+
+    return isOutputDirty(ref.nodeId, ref.pinIndex);
+}
+
+template<typename InputT>
+bool isInputDirty(NodeId nid) {
+    return isInputDirtyImpl(nid, InputT::WIRING_OFFSET);
+}
+
+void markPinDirty(NodeId nid, uint8_t index) {
+    g_dirtyFlags[nid] |= 1 << (index + 1);
+}
+
+void markNodeDirty(NodeId nid) {
+    g_dirtyFlags[nid] |= 0x1;
+}
+
+bool isNodeDirty(NodeId nid) {
+    return g_dirtyFlags[nid] & 0x1;
+}
+
+template<typename T>
+T getOutputValueImpl(NodeId nid, size_t storageOffset) {
+    return getStorageValue<T>(nid, storageOffset);
+}
+
+template<typename T>
+T getInputValueImpl(NodeId nid, size_t wiringOffset) {
+    UpstreamPinRef ref = getWiringValue<UpstreamPinRef>(nid, wiringOffset);
+    if (ref.nodeId == NO_NODE)
+        return (T)0;
+
+    return getOutputValueImpl<T>(ref.nodeId, ref.storageOffset);
+}
+
+template<typename T>
+void emitValueImpl(
+        NodeId nid,
+        size_t storageOffset,
+        size_t wiringOffset,
+        uint8_t index,
+        T value) {
+
+    // Store new value and make the node itself dirty
+    T* storedValue = reinterpret_cast<T*>(getStoragePtr(nid, storageOffset));
+    *storedValue = value;
+    markPinDirty(nid, index);
+
+    // Notify downstream nodes about changes
+    // NB: linked nodes array is in PGM space
+    const NodeId* pDownstreamNid = getWiringValue<const NodeId*>(nid, wiringOffset);
+    NodeId downstreamNid = pgm_read_nodeid(pDownstreamNid);
+
+    while (downstreamNid != NO_NODE) {
+        markNodeDirty(downstreamNid);
+        downstreamNid = pgm_read_nodeid(pDownstreamNid++);
+    }
+}
+
+void evaluateNode(NodeId nid) {
+    XOD_TRACE_F("eval #");
+    XOD_TRACE_LN(nid);
+    EvalFuncPtr eval = getWiringValue<EvalFuncPtr>(nid, 0);
+    eval(nid);
+}
+
+void runTransaction() {
+    XOD_TRACE_F("Transaction started, t=");
+    XOD_TRACE_LN(millis());
+    for (NodeId nid : g_topology) {
+        if (isNodeDirty(nid))
+            evaluateNode(nid);
+    }
+
+    memset(g_dirtyFlags, 0, sizeof(g_dirtyFlags));
+    XOD_TRACE_F("Transaction completed, t=");
+    XOD_TRACE_LN(millis());
+}
+
+void idle() {
+    TimeMs now = millis();
+    for (NodeId nid = 0; nid < NODE_COUNT; ++nid) {
+        TimeMs t = g_schedule[nid];
+        if (t && t <= now) {
+            markNodeDirty(nid);
+            clearTimeout(nid);
+            return;
+        }
+    }
 }
 
 //----------------------------------------------------------------------------
-// Engine
+// Public API (can be used by native nodes’ `evaluate` functions)
 //----------------------------------------------------------------------------
-namespace xod {
-    extern void* storages[NODE_COUNT];
-    extern EvalFuncPtr evaluationFuncs[NODE_COUNT];
-    extern DirtyFlags dirtyFlags[NODE_COUNT];
-    extern NodeId topology[NODE_COUNT];
 
-    // TODO: replace with a compact list
-    extern TimeMs schedule[NODE_COUNT];
-
-    template<typename T>
-    struct OutputPin {
-        T value;
-        // Keep outgoing link list with terminating `NO_NODE`
-        NodeId* links;
-    };
-
-    struct PinRef {
-        NodeId nodeId;
-        PinKey pinKey;
-    };
-
-    /*
-     * Input descriptor is a metaprogramming structure used to enforce an
-     * input’s type and store its PinKey as a zero-memory constant.
-     *
-     * A specialized descriptor is required by `getValue` function. Every
-     * input of every type node gets its own descriptor in generated code that
-     * can be accessed as input_FOO. Where FOO is a pin identifier.
-     */
-    template<typename ValueT_, size_t offsetInStorage>
-    struct InputDescriptor {
-        typedef ValueT_ ValueT;
-        enum Offset : PinKey {
-            KEY = offsetInStorage
-        };
-    };
-
-    /*
-     * Output descriptor serve the same purpose as InputDescriptor but for
-     * ouputs.
-     */
-    template<typename ValueT_, size_t offsetInStorage, int index>
-    struct OutputDescriptor {
-        typedef ValueT_ ValueT;
-        enum Offset : PinKey {
-            KEY = offsetInStorage | (index << PIN_KEY_OFFSET_BITS)
-        };
-    };
-
-    void* pinPtr(void* storage, PinKey key) {
-        const size_t offset = key & ~(PinKey(-1) << PIN_KEY_OFFSET_BITS);
-        return (uint8_t*)storage + offset;
-    }
-
-    DirtyFlags dirtyPinBit(PinKey key) {
-        const PinKey nbit = (key >> PIN_KEY_OFFSET_BITS) + 1;
-        return 1 << nbit;
-    }
-
-    bool isOutputDirty(NodeId nid, PinKey key) {
-        return dirtyFlags[nid] & dirtyPinBit(key);
-    }
-
-    bool isInputDirtyImpl(NodeId nid, PinKey key) {
-        PinRef* ref = (PinRef*)pinPtr(storages[nid], key);
-        if (ref->nodeId == NO_NODE)
-            return false;
-
-        return isOutputDirty(ref->nodeId, ref->pinKey);
-    }
-
-    template<typename InputT>
-    bool isInputDirty(NodeId nid) {
-        return isInputDirtyImpl(nid, InputT::KEY);
-    }
-
-    void markPinDirty(NodeId nid, PinKey key) {
-        dirtyFlags[nid] |= dirtyPinBit(key);
-    }
-
-    void markNodeDirty(NodeId nid) {
-        dirtyFlags[nid] |= 0x1;
-    }
-
-    bool isNodeDirty(NodeId nid) {
-        return dirtyFlags[nid] & 0x1;
-    }
-
-    TimeMs transactionTime() {
-        return millis();
-    }
-
-    void setTimeout(NodeId nid, TimeMs timeout) {
-        schedule[nid] = transactionTime() + timeout;
-    }
-
-    void clearTimeout(NodeId nid) {
-        schedule[nid] = 0;
-    }
-
-    template<typename T>
-    T getValueImpl(NodeId nid, PinKey key) {
-        PinRef* ref = (PinRef*)pinPtr(storages[nid], key);
-        if (ref->nodeId == NO_NODE)
-            return (T)0;
-
-        return *(T*)pinPtr(storages[ref->nodeId], ref->pinKey);
-    }
-
-    template<typename InputT>
-    typename InputT::ValueT getValue(NodeId nid) {
-        return getValueImpl<typename InputT::ValueT>(nid, InputT::KEY);
-    }
-
-    template<typename T>
-    void emitValueImpl(NodeId nid, PinKey key, T value) {
-        OutputPin<T>* outputPin = (OutputPin<T>*)pinPtr(storages[nid], key);
-
-        outputPin->value = value;
-        markPinDirty(nid, key);
-
-        NodeId* linkedNode = outputPin->links;
-        while (*linkedNode != NO_NODE) {
-            markNodeDirty(*linkedNode++);
-        }
-    }
-
-    template<typename OutputT>
-    void emitValue(NodeId nid, typename OutputT::ValueT value) {
-        emitValueImpl(nid, OutputT::KEY, value);
-    }
-
-    template<typename T>
-    void reemitValueImpl(NodeId nid, PinKey key) {
-        OutputPin<T>* outputPin = (OutputPin<T>*)pinPtr(storages[nid], key);
-        emitValueImpl<T>(nid, key, outputPin->value);
-    }
-
-    template<typename OutputT>
-    void reemitValue(NodeId nid) {
-        reemitValueImpl<typename OutputT::ValueT>(nid, OutputT::KEY);
-    }
-
-    void evaluateNode(NodeId nid) {
-        XOD_TRACE_F("eval #");
-        XOD_TRACE_LN(nid);
-        EvalFuncPtr eval = evaluationFuncs[nid];
-        eval(nid, storages[nid]);
-    }
-
-    void runTransaction() {
-        XOD_TRACE_F("Transaction started, t=");
-        XOD_TRACE_LN(millis());
-        for (NodeId nid : topology) {
-            if (isNodeDirty(nid))
-                evaluateNode(nid);
-        }
-
-        memset(dirtyFlags, 0, sizeof(dirtyFlags));
-        XOD_TRACE_F("Transaction completed, t=");
-        XOD_TRACE_LN(millis());
-    }
-
-    void idle() {
-        TimeMs now = millis();
-        for (NodeId nid = 0; nid < NODE_COUNT; ++nid) {
-            TimeMs t = schedule[nid];
-            if (t && t <= now) {
-                markNodeDirty(nid);
-                clearTimeout(nid);
-                return;
-            }
-        }
-    }
+template<typename InputT>
+typename InputT::ValueT getValue(NodeId nid) {
+    return getInputValueImpl<typename InputT::ValueT>(nid, InputT::WIRING_OFFSET);
 }
+
+template<typename OutputT>
+void emitValue(NodeId nid, typename OutputT::ValueT value) {
+    emitValueImpl(
+            nid,
+            OutputT::STORAGE_OFFSET,
+            OutputT::WIRING_OFFSET,
+            OutputT::INDEX,
+            value);
+}
+
+TimeMs transactionTime() {
+    return millis();
+}
+
+void setTimeout(NodeId nid, TimeMs timeout) {
+    g_schedule[nid] = transactionTime() + timeout;
+}
+
+void clearTimeout(NodeId nid) {
+    g_schedule[nid] = 0;
+}
+
+} // namespace xod
 
 //----------------------------------------------------------------------------
 // Entry point
@@ -896,7 +954,7 @@ void setup() {
 #ifdef XOD_DEBUG
     DEBUG_SERIAL.begin(9600);
 #endif
-    XOD_TRACE_FLN("Program started");
+    XOD_TRACE_FLN("\n\nProgram started");
 }
 
 void loop() {
@@ -924,17 +982,22 @@ struct State {
 
 struct Storage {
     State state;
-    PinRef input_UPD;
-    OutputPin<Number> output_TIME;
+    Number output_TIME;
+};
+
+struct Wiring {
+    EvalFuncPtr eval;
+    UpstreamPinRef input_UPD;
+    const NodeId* output_TIME;
 };
 
 State* getState(NodeId nid) {
-    return reinterpret_cast<State*>(storages[nid]);
+    return reinterpret_cast<State*>(getStoragePtr(nid, 0));
 }
 
-using input_UPD = InputDescriptor<Logic, offsetof(Storage, input_UPD)>;
+using input_UPD = InputDescriptor<Logic, offsetof(Wiring, input_UPD)>;
 
-using output_TIME = OutputDescriptor<Number, offsetof(Storage, output_TIME), 0>;
+using output_TIME = OutputDescriptor<Number, offsetof(Wiring, output_TIME), offsetof(Storage, output_TIME), 0>;
 
 void evaluate(Context ctx) {
     emitValue<output_TIME>(ctx, millis() / 1000.f);
@@ -960,28 +1023,32 @@ struct State {
 
 struct Storage {
     State state;
-    PinRef input_RS;
-    PinRef input_EN;
-    PinRef input_D4;
-    PinRef input_D5;
-    PinRef input_D6;
-    PinRef input_D7;
-    PinRef input_L1;
-    PinRef input_L2;
+};
+
+struct Wiring {
+    EvalFuncPtr eval;
+    UpstreamPinRef input_RS;
+    UpstreamPinRef input_EN;
+    UpstreamPinRef input_D4;
+    UpstreamPinRef input_D5;
+    UpstreamPinRef input_D6;
+    UpstreamPinRef input_D7;
+    UpstreamPinRef input_L1;
+    UpstreamPinRef input_L2;
 };
 
 State* getState(NodeId nid) {
-    return reinterpret_cast<State*>(storages[nid]);
+    return reinterpret_cast<State*>(getStoragePtr(nid, 0));
 }
 
-using input_RS = InputDescriptor<Number, offsetof(Storage, input_RS)>;
-using input_EN = InputDescriptor<Number, offsetof(Storage, input_EN)>;
-using input_D4 = InputDescriptor<Number, offsetof(Storage, input_D4)>;
-using input_D5 = InputDescriptor<Number, offsetof(Storage, input_D5)>;
-using input_D6 = InputDescriptor<Number, offsetof(Storage, input_D6)>;
-using input_D7 = InputDescriptor<Number, offsetof(Storage, input_D7)>;
-using input_L1 = InputDescriptor<XString, offsetof(Storage, input_L1)>;
-using input_L2 = InputDescriptor<XString, offsetof(Storage, input_L2)>;
+using input_RS = InputDescriptor<Number, offsetof(Wiring, input_RS)>;
+using input_EN = InputDescriptor<Number, offsetof(Wiring, input_EN)>;
+using input_D4 = InputDescriptor<Number, offsetof(Wiring, input_D4)>;
+using input_D5 = InputDescriptor<Number, offsetof(Wiring, input_D5)>;
+using input_D6 = InputDescriptor<Number, offsetof(Wiring, input_D6)>;
+using input_D7 = InputDescriptor<Number, offsetof(Wiring, input_D7)>;
+using input_L1 = InputDescriptor<XString, offsetof(Wiring, input_L1)>;
+using input_L2 = InputDescriptor<XString, offsetof(Wiring, input_L2)>;
 
 void printLine(LiquidCrystal* lcd, uint8_t lineIndex, XString str) {
     lcd->setCursor(0, lineIndex);
@@ -1025,17 +1092,22 @@ struct State {
 
 struct Storage {
     State state;
-    PinRef input_IN;
-    OutputPin<XString> output_OUT;
+    XString output_OUT;
+};
+
+struct Wiring {
+    EvalFuncPtr eval;
+    UpstreamPinRef input_IN;
+    const NodeId* output_OUT;
 };
 
 State* getState(NodeId nid) {
-    return reinterpret_cast<State*>(storages[nid]);
+    return reinterpret_cast<State*>(getStoragePtr(nid, 0));
 }
 
-using input_IN = InputDescriptor<Number, offsetof(Storage, input_IN)>;
+using input_IN = InputDescriptor<Number, offsetof(Wiring, input_IN)>;
 
-using output_OUT = OutputDescriptor<XString, offsetof(Storage, output_OUT), 0>;
+using output_OUT = OutputDescriptor<XString, offsetof(Wiring, output_OUT), offsetof(Storage, output_OUT), 0>;
 
 void evaluate(Context ctx) {
     char str[16];
@@ -1057,14 +1129,19 @@ struct State {
 
 struct Storage {
     State state;
-    OutputPin<Logic> output_TICK;
+    Logic output_TICK;
+};
+
+struct Wiring {
+    EvalFuncPtr eval;
+    const NodeId* output_TICK;
 };
 
 State* getState(NodeId nid) {
-    return reinterpret_cast<State*>(storages[nid]);
+    return reinterpret_cast<State*>(getStoragePtr(nid, 0));
 }
 
-using output_TICK = OutputDescriptor<Logic, offsetof(Storage, output_TICK), 0>;
+using output_TICK = OutputDescriptor<Logic, offsetof(Wiring, output_TICK), offsetof(Storage, output_TICK), 0>;
 
 void evaluate(Context ctx) {
     emitValue<output_TICK>(ctx, 1);
@@ -1082,17 +1159,21 @@ struct State {};
 
 struct Storage {
     State state;
-    OutputPin<Number> output_VAL;
+    Number output_VAL;
+};
+
+struct Wiring {
+    EvalFuncPtr eval;
+    const NodeId* output_VAL;
 };
 
 State* getState(NodeId nid) {
-    return reinterpret_cast<State*>(storages[nid]);
+    return reinterpret_cast<State*>(getStoragePtr(nid, 0));
 }
 
-using output_VAL = OutputDescriptor<Number, offsetof(Storage, output_VAL), 0>;
+using output_VAL = OutputDescriptor<Number, offsetof(Wiring, output_VAL), offsetof(Storage, output_VAL), 0>;
 
 void evaluate(Context ctx) {
-  reemitValue<output_VAL>(ctx);
 }
 
 } // namespace xod__core__constant_number
@@ -1106,17 +1187,21 @@ struct State {};
 
 struct Storage {
     State state;
-    OutputPin<XString> output_VAL;
+    XString output_VAL;
+};
+
+struct Wiring {
+    EvalFuncPtr eval;
+    const NodeId* output_VAL;
 };
 
 State* getState(NodeId nid) {
-    return reinterpret_cast<State*>(storages[nid]);
+    return reinterpret_cast<State*>(getStoragePtr(nid, 0));
 }
 
-using output_VAL = OutputDescriptor<XString, offsetof(Storage, output_VAL), 0>;
+using output_VAL = OutputDescriptor<XString, offsetof(Wiring, output_VAL), offsetof(Storage, output_VAL), 0>;
 
 void evaluate(Context ctx) {
-  reemitValue<output_VAL>(ctx);
 }
 
 } // namespace xod__core__constant_string
@@ -1133,109 +1218,76 @@ void evaluate(Context ctx) {
 
 namespace xod {
 
-    NodeId links_0_TIME[] = { 2, NO_NODE };
+    //-------------------------------------------------------------------------
+    // Dynamic data
+    //-------------------------------------------------------------------------
+
+    // Storage of #0 xod/core/system_time
     xod__core__system_time::Storage storage_0 = {
         { }, // state
-        { NodeId(3), xod__core__continuously::output_TICK::KEY }, // input_UPD
-        { 0, links_0_TIME } // output_TIME
+        0 // output_TIME
     };
 
+    // Storage of #1 xod/common_hardware/text_lcd_16x2
     xod__common_hardware__text_lcd_16x2::Storage storage_1 = {
         { }, // state
-        { NodeId(9), xod__core__constant_number::output_VAL::KEY }, // input_RS
-        { NodeId(8), xod__core__constant_number::output_VAL::KEY }, // input_EN
-        { NodeId(4), xod__core__constant_number::output_VAL::KEY }, // input_D4
-        { NodeId(7), xod__core__constant_number::output_VAL::KEY }, // input_D5
-        { NodeId(6), xod__core__constant_number::output_VAL::KEY }, // input_D6
-        { NodeId(10), xod__core__constant_number::output_VAL::KEY }, // input_D7
-        { NodeId(2), xod__core__cast_number_to_string::output_OUT::KEY }, // input_L1
-        { NodeId(5), xod__core__constant_string::output_VAL::KEY }, // input_L2
     };
 
-    NodeId links_2_OUT[] = { 1, NO_NODE };
+    // Storage of #2 xod/core/cast_number_to_string
     xod__core__cast_number_to_string::Storage storage_2 = {
         { }, // state
-        { NodeId(0), xod__core__system_time::output_TIME::KEY }, // input_IN
-        { ::xod::List<char>::empty(), links_2_OUT } // output_OUT
+        ::xod::List<char>::empty() // output_OUT
     };
 
-    NodeId links_3_TICK[] = { 0, NO_NODE };
+    // Storage of #3 xod/core/continuously
     xod__core__continuously::Storage storage_3 = {
         { }, // state
-        { ::xod::List<char>::fromPlainArray("CONTINUOUSLY", 12), links_3_TICK } // output_TICK
+        ::xod::List<char>::fromPlainArray("CONTINUOUSLY", 12) // output_TICK
     };
 
-    NodeId links_4_VAL[] = { 1, NO_NODE };
+    // Storage of #4 xod/core/constant_number
     xod__core__constant_number::Storage storage_4 = {
         { }, // state
-        { 10, links_4_VAL } // output_VAL
+        10 // output_VAL
     };
 
-    NodeId links_5_VAL[] = { 1, NO_NODE };
+    // Storage of #5 xod/core/constant_string
     xod__core__constant_string::Storage storage_5 = {
         { }, // state
-        { ::xod::List<char>::empty(), links_5_VAL } // output_VAL
+        ::xod::List<char>::empty() // output_VAL
     };
 
-    NodeId links_6_VAL[] = { 1, NO_NODE };
+    // Storage of #6 xod/core/constant_number
     xod__core__constant_number::Storage storage_6 = {
         { }, // state
-        { 12, links_6_VAL } // output_VAL
+        12 // output_VAL
     };
 
-    NodeId links_7_VAL[] = { 1, NO_NODE };
+    // Storage of #7 xod/core/constant_number
     xod__core__constant_number::Storage storage_7 = {
         { }, // state
-        { 11, links_7_VAL } // output_VAL
+        11 // output_VAL
     };
 
-    NodeId links_8_VAL[] = { 1, NO_NODE };
+    // Storage of #8 xod/core/constant_number
     xod__core__constant_number::Storage storage_8 = {
         { }, // state
-        { 9, links_8_VAL } // output_VAL
+        9 // output_VAL
     };
 
-    NodeId links_9_VAL[] = { 1, NO_NODE };
+    // Storage of #9 xod/core/constant_number
     xod__core__constant_number::Storage storage_9 = {
         { }, // state
-        { 8, links_9_VAL } // output_VAL
+        8 // output_VAL
     };
 
-    NodeId links_10_VAL[] = { 1, NO_NODE };
+    // Storage of #10 xod/core/constant_number
     xod__core__constant_number::Storage storage_10 = {
         { }, // state
-        { 13, links_10_VAL } // output_VAL
+        13 // output_VAL
     };
 
-    void* storages[NODE_COUNT] = {
-        &storage_0,
-        &storage_1,
-        &storage_2,
-        &storage_3,
-        &storage_4,
-        &storage_5,
-        &storage_6,
-        &storage_7,
-        &storage_8,
-        &storage_9,
-        &storage_10
-    };
-
-    EvalFuncPtr evaluationFuncs[NODE_COUNT] = {
-        (EvalFuncPtr)&xod__core__system_time::evaluate,
-        (EvalFuncPtr)&xod__common_hardware__text_lcd_16x2::evaluate,
-        (EvalFuncPtr)&xod__core__cast_number_to_string::evaluate,
-        (EvalFuncPtr)&xod__core__continuously::evaluate,
-        (EvalFuncPtr)&xod__core__constant_number::evaluate,
-        (EvalFuncPtr)&xod__core__constant_string::evaluate,
-        (EvalFuncPtr)&xod__core__constant_number::evaluate,
-        (EvalFuncPtr)&xod__core__constant_number::evaluate,
-        (EvalFuncPtr)&xod__core__constant_number::evaluate,
-        (EvalFuncPtr)&xod__core__constant_number::evaluate,
-        (EvalFuncPtr)&xod__core__constant_number::evaluate
-    };
-
-    DirtyFlags dirtyFlags[NODE_COUNT] = {
+    DirtyFlags g_dirtyFlags[NODE_COUNT] = {
         DirtyFlags(255),
         DirtyFlags(255),
         DirtyFlags(255),
@@ -1249,9 +1301,170 @@ namespace xod {
         DirtyFlags(255)
     };
 
-    NodeId topology[NODE_COUNT] = {
-        3, 4, 5, 6, 7, 8, 9, 10, 0, 2, 1
+    TimeMs g_schedule[NODE_COUNT] = { 0 };
+
+    //-------------------------------------------------------------------------
+    // Static (immutable) data
+    //-------------------------------------------------------------------------
+
+    // Wiring of #0 xod/core/system_time
+    const NodeId outLinks_0_TIME[] PROGMEM = { 2, NO_NODE };
+    const xod__core__system_time::Wiring wiring_0 PROGMEM = {
+        &xod__core__system_time::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        { NodeId(3),
+            xod__core__continuously::output_TICK::INDEX,
+            xod__core__continuously::output_TICK::STORAGE_OFFSET }, // input_UPD
+        // outputs (NodeId list binding)
+        outLinks_0_TIME // output_TIME
     };
 
-    TimeMs schedule[NODE_COUNT] = { 0 };
+    // Wiring of #1 xod/common_hardware/text_lcd_16x2
+    const xod__common_hardware__text_lcd_16x2::Wiring wiring_1 PROGMEM = {
+        &xod__common_hardware__text_lcd_16x2::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        { NodeId(9),
+            xod__core__constant_number::output_VAL::INDEX,
+            xod__core__constant_number::output_VAL::STORAGE_OFFSET }, // input_RS
+        { NodeId(8),
+            xod__core__constant_number::output_VAL::INDEX,
+            xod__core__constant_number::output_VAL::STORAGE_OFFSET }, // input_EN
+        { NodeId(4),
+            xod__core__constant_number::output_VAL::INDEX,
+            xod__core__constant_number::output_VAL::STORAGE_OFFSET }, // input_D4
+        { NodeId(7),
+            xod__core__constant_number::output_VAL::INDEX,
+            xod__core__constant_number::output_VAL::STORAGE_OFFSET }, // input_D5
+        { NodeId(6),
+            xod__core__constant_number::output_VAL::INDEX,
+            xod__core__constant_number::output_VAL::STORAGE_OFFSET }, // input_D6
+        { NodeId(10),
+            xod__core__constant_number::output_VAL::INDEX,
+            xod__core__constant_number::output_VAL::STORAGE_OFFSET }, // input_D7
+        { NodeId(2),
+            xod__core__cast_number_to_string::output_OUT::INDEX,
+            xod__core__cast_number_to_string::output_OUT::STORAGE_OFFSET }, // input_L1
+        { NodeId(5),
+            xod__core__constant_string::output_VAL::INDEX,
+            xod__core__constant_string::output_VAL::STORAGE_OFFSET }, // input_L2
+        // outputs (NodeId list binding)
+    };
+
+    // Wiring of #2 xod/core/cast_number_to_string
+    const NodeId outLinks_2_OUT[] PROGMEM = { 1, NO_NODE };
+    const xod__core__cast_number_to_string::Wiring wiring_2 PROGMEM = {
+        &xod__core__cast_number_to_string::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        { NodeId(0),
+            xod__core__system_time::output_TIME::INDEX,
+            xod__core__system_time::output_TIME::STORAGE_OFFSET }, // input_IN
+        // outputs (NodeId list binding)
+        outLinks_2_OUT // output_OUT
+    };
+
+    // Wiring of #3 xod/core/continuously
+    const NodeId outLinks_3_TICK[] PROGMEM = { 0, NO_NODE };
+    const xod__core__continuously::Wiring wiring_3 PROGMEM = {
+        &xod__core__continuously::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        // outputs (NodeId list binding)
+        outLinks_3_TICK // output_TICK
+    };
+
+    // Wiring of #4 xod/core/constant_number
+    const NodeId outLinks_4_VAL[] PROGMEM = { 1, NO_NODE };
+    const xod__core__constant_number::Wiring wiring_4 PROGMEM = {
+        &xod__core__constant_number::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        // outputs (NodeId list binding)
+        outLinks_4_VAL // output_VAL
+    };
+
+    // Wiring of #5 xod/core/constant_string
+    const NodeId outLinks_5_VAL[] PROGMEM = { 1, NO_NODE };
+    const xod__core__constant_string::Wiring wiring_5 PROGMEM = {
+        &xod__core__constant_string::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        // outputs (NodeId list binding)
+        outLinks_5_VAL // output_VAL
+    };
+
+    // Wiring of #6 xod/core/constant_number
+    const NodeId outLinks_6_VAL[] PROGMEM = { 1, NO_NODE };
+    const xod__core__constant_number::Wiring wiring_6 PROGMEM = {
+        &xod__core__constant_number::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        // outputs (NodeId list binding)
+        outLinks_6_VAL // output_VAL
+    };
+
+    // Wiring of #7 xod/core/constant_number
+    const NodeId outLinks_7_VAL[] PROGMEM = { 1, NO_NODE };
+    const xod__core__constant_number::Wiring wiring_7 PROGMEM = {
+        &xod__core__constant_number::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        // outputs (NodeId list binding)
+        outLinks_7_VAL // output_VAL
+    };
+
+    // Wiring of #8 xod/core/constant_number
+    const NodeId outLinks_8_VAL[] PROGMEM = { 1, NO_NODE };
+    const xod__core__constant_number::Wiring wiring_8 PROGMEM = {
+        &xod__core__constant_number::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        // outputs (NodeId list binding)
+        outLinks_8_VAL // output_VAL
+    };
+
+    // Wiring of #9 xod/core/constant_number
+    const NodeId outLinks_9_VAL[] PROGMEM = { 1, NO_NODE };
+    const xod__core__constant_number::Wiring wiring_9 PROGMEM = {
+        &xod__core__constant_number::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        // outputs (NodeId list binding)
+        outLinks_9_VAL // output_VAL
+    };
+
+    // Wiring of #10 xod/core/constant_number
+    const NodeId outLinks_10_VAL[] PROGMEM = { 1, NO_NODE };
+    const xod__core__constant_number::Wiring wiring_10 PROGMEM = {
+        &xod__core__constant_number::evaluate,
+        // inputs (UpstreamPinRef’s initializers)
+        // outputs (NodeId list binding)
+        outLinks_10_VAL // output_VAL
+    };
+
+    // PGM array with pointers to PGM wiring information structs
+    const void* const g_wiring[NODE_COUNT] PROGMEM = {
+        &wiring_0,
+        &wiring_1,
+        &wiring_2,
+        &wiring_3,
+        &wiring_4,
+        &wiring_5,
+        &wiring_6,
+        &wiring_7,
+        &wiring_8,
+        &wiring_9,
+        &wiring_10
+    };
+
+    // PGM array with pointers to RAM-located storages
+    void* const g_storages[NODE_COUNT] PROGMEM = {
+        &storage_0,
+        &storage_1,
+        &storage_2,
+        &storage_3,
+        &storage_4,
+        &storage_5,
+        &storage_6,
+        &storage_7,
+        &storage_8,
+        &storage_9,
+        &storage_10
+    };
+
+    NodeId g_topology[NODE_COUNT] = {
+        3, 4, 5, 6, 7, 8, 9, 10, 0, 2, 1
+    };
 }

--- a/workspace/lib/xod/core/constant-boolean/any.cpp
+++ b/workspace/lib/xod/core/constant-boolean/any.cpp
@@ -4,5 +4,4 @@ struct State {
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-    reemitValue<output_VAL>(ctx);
 }

--- a/workspace/lib/xod/core/constant-number/any.cpp
+++ b/workspace/lib/xod/core/constant-number/any.cpp
@@ -3,5 +3,4 @@ struct State {};
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-  reemitValue<output_VAL>(ctx);
 }

--- a/workspace/lib/xod/core/constant-string/any.cpp
+++ b/workspace/lib/xod/core/constant-string/any.cpp
@@ -3,5 +3,4 @@ struct State {};
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-  reemitValue<output_VAL>(ctx);
 }


### PR DESCRIPTION
Closes #732 

RAM consumption lowered 2× to 3×.

Also, C++ testing is now incorporated in Travis CI. The `.travis.yml` is slightly evolved to get better caching and log reporting.

I’ve tested `*fixtures*/*.cpp` on real hardware. Found no regressions.