### PR TITLE
Provide C dtostrf function for all platforms

### DIFF
--- a/packages/xod-client-electron/test-func/fixtures/blink.cpp
+++ b/packages/xod-client-electron/test-func/fixtures/blink.cpp
@@ -681,6 +681,66 @@ template <typename T> class List {
 #  define pgm_read_ptr(addr) (*(const void **)(addr))
 #endif
 
+//----------------------------------------------------------------------------
+// Compatibilities
+//----------------------------------------------------------------------------
+
+#if !defined(ARDUINO_ARCH_AVR)
+/*
+ * Provide dtostrf function for non-AVR platforms. Although many platforms
+ * provide a stub many others do not. And the stub is based on `sprintf`
+ * which doesn’t work with floating point formatters on some platforms
+ * (e.g. Arduino M0).
+ *
+ * This is an implementation based on `fcvt` standard function. Taken here:
+ * https://forum.arduino.cc/index.php?topic=368720.msg2542614#msg2542614
+ */
+char *dtostrf(double val, int width, unsigned int prec, char *sout) {
+    int decpt, sign, reqd, pad;
+    const char *s, *e;
+    char *p;
+    s = fcvt(val, prec, &decpt, &sign);
+    if (prec == 0 && decpt == 0) {
+        s = (*s < '5') ? "0" : "1";
+        reqd = 1;
+    } else {
+        reqd = strlen(s);
+        if (reqd > decpt) reqd++;
+        if (decpt == 0) reqd++;
+    }
+    if (sign) reqd++;
+    p = sout;
+    e = p + reqd;
+    pad = width - reqd;
+    if (pad > 0) {
+        e += pad;
+        while (pad-- > 0) *p++ = ' ';
+    }
+    if (sign) *p++ = '-';
+    if (decpt <= 0 && prec > 0) {
+        *p++ = '0';
+        *p++ = '.';
+        e++;
+        while ( decpt < 0 ) {
+            decpt++;
+            *p++ = '0';
+        }
+    }
+    while (p < e) {
+        *p++ = *s++;
+        if (p == e) break;
+        if (--decpt == 0) *p++ = '.';
+    }
+    if (width < 0) {
+        pad = (reqd + width) * -1;
+        while (pad-- > 0) *p++ = ' ';
+    }
+    *p = 0;
+    return sout;
+}
+#endif
+
+
 namespace xod {
 //----------------------------------------------------------------------------
 // Type definitions

--- a/workspace/blink/__fixtures__/arduino.cpp
+++ b/workspace/blink/__fixtures__/arduino.cpp
@@ -681,6 +681,66 @@ template <typename T> class List {
 #  define pgm_read_ptr(addr) (*(const void **)(addr))
 #endif
 
+//----------------------------------------------------------------------------
+// Compatibilities
+//----------------------------------------------------------------------------
+
+#if !defined(ARDUINO_ARCH_AVR)
+/*
+ * Provide dtostrf function for non-AVR platforms. Although many platforms
+ * provide a stub many others do not. And the stub is based on `sprintf`
+ * which doesn’t work with floating point formatters on some platforms
+ * (e.g. Arduino M0).
+ *
+ * This is an implementation based on `fcvt` standard function. Taken here:
+ * https://forum.arduino.cc/index.php?topic=368720.msg2542614#msg2542614
+ */
+char *dtostrf(double val, int width, unsigned int prec, char *sout) {
+    int decpt, sign, reqd, pad;
+    const char *s, *e;
+    char *p;
+    s = fcvt(val, prec, &decpt, &sign);
+    if (prec == 0 && decpt == 0) {
+        s = (*s < '5') ? "0" : "1";
+        reqd = 1;
+    } else {
+        reqd = strlen(s);
+        if (reqd > decpt) reqd++;
+        if (decpt == 0) reqd++;
+    }
+    if (sign) reqd++;
+    p = sout;
+    e = p + reqd;
+    pad = width - reqd;
+    if (pad > 0) {
+        e += pad;
+        while (pad-- > 0) *p++ = ' ';
+    }
+    if (sign) *p++ = '-';
+    if (decpt <= 0 && prec > 0) {
+        *p++ = '0';
+        *p++ = '.';
+        e++;
+        while ( decpt < 0 ) {
+            decpt++;
+            *p++ = '0';
+        }
+    }
+    while (p < e) {
+        *p++ = *s++;
+        if (p == e) break;
+        if (--decpt == 0) *p++ = '.';
+    }
+    if (width < 0) {
+        pad = (reqd + width) * -1;
+        while (pad-- > 0) *p++ = ' ';
+    }
+    *p = 0;
+    return sout;
+}
+#endif
+
+
 namespace xod {
 //----------------------------------------------------------------------------
 // Type definitions

--- a/workspace/lcd-time/__fixtures__/arduino.cpp
+++ b/workspace/lcd-time/__fixtures__/arduino.cpp
@@ -681,6 +681,66 @@ template <typename T> class List {
 #  define pgm_read_ptr(addr) (*(const void **)(addr))
 #endif
 
+//----------------------------------------------------------------------------
+// Compatibilities
+//----------------------------------------------------------------------------
+
+#if !defined(ARDUINO_ARCH_AVR)
+/*
+ * Provide dtostrf function for non-AVR platforms. Although many platforms
+ * provide a stub many others do not. And the stub is based on `sprintf`
+ * which doesn’t work with floating point formatters on some platforms
+ * (e.g. Arduino M0).
+ *
+ * This is an implementation based on `fcvt` standard function. Taken here:
+ * https://forum.arduino.cc/index.php?topic=368720.msg2542614#msg2542614
+ */
+char *dtostrf(double val, int width, unsigned int prec, char *sout) {
+    int decpt, sign, reqd, pad;
+    const char *s, *e;
+    char *p;
+    s = fcvt(val, prec, &decpt, &sign);
+    if (prec == 0 && decpt == 0) {
+        s = (*s < '5') ? "0" : "1";
+        reqd = 1;
+    } else {
+        reqd = strlen(s);
+        if (reqd > decpt) reqd++;
+        if (decpt == 0) reqd++;
+    }
+    if (sign) reqd++;
+    p = sout;
+    e = p + reqd;
+    pad = width - reqd;
+    if (pad > 0) {
+        e += pad;
+        while (pad-- > 0) *p++ = ' ';
+    }
+    if (sign) *p++ = '-';
+    if (decpt <= 0 && prec > 0) {
+        *p++ = '0';
+        *p++ = '.';
+        e++;
+        while ( decpt < 0 ) {
+            decpt++;
+            *p++ = '0';
+        }
+    }
+    while (p < e) {
+        *p++ = *s++;
+        if (p == e) break;
+        if (--decpt == 0) *p++ = '.';
+    }
+    if (width < 0) {
+        pad = (reqd + width) * -1;
+        while (pad-- > 0) *p++ = ' ';
+    }
+    *p = 0;
+    return sout;
+}
+#endif
+
+
 namespace xod {
 //----------------------------------------------------------------------------
 // Type definitions

--- a/workspace/two-button-switch/__fixtures__/arduino.cpp
+++ b/workspace/two-button-switch/__fixtures__/arduino.cpp
@@ -681,6 +681,66 @@ template <typename T> class List {
 #  define pgm_read_ptr(addr) (*(const void **)(addr))
 #endif
 
+//----------------------------------------------------------------------------
+// Compatibilities
+//----------------------------------------------------------------------------
+
+#if !defined(ARDUINO_ARCH_AVR)
+/*
+ * Provide dtostrf function for non-AVR platforms. Although many platforms
+ * provide a stub many others do not. And the stub is based on `sprintf`
+ * which doesn’t work with floating point formatters on some platforms
+ * (e.g. Arduino M0).
+ *
+ * This is an implementation based on `fcvt` standard function. Taken here:
+ * https://forum.arduino.cc/index.php?topic=368720.msg2542614#msg2542614
+ */
+char *dtostrf(double val, int width, unsigned int prec, char *sout) {
+    int decpt, sign, reqd, pad;
+    const char *s, *e;
+    char *p;
+    s = fcvt(val, prec, &decpt, &sign);
+    if (prec == 0 && decpt == 0) {
+        s = (*s < '5') ? "0" : "1";
+        reqd = 1;
+    } else {
+        reqd = strlen(s);
+        if (reqd > decpt) reqd++;
+        if (decpt == 0) reqd++;
+    }
+    if (sign) reqd++;
+    p = sout;
+    e = p + reqd;
+    pad = width - reqd;
+    if (pad > 0) {
+        e += pad;
+        while (pad-- > 0) *p++ = ' ';
+    }
+    if (sign) *p++ = '-';
+    if (decpt <= 0 && prec > 0) {
+        *p++ = '0';
+        *p++ = '.';
+        e++;
+        while ( decpt < 0 ) {
+            decpt++;
+            *p++ = '0';
+        }
+    }
+    while (p < e) {
+        *p++ = *s++;
+        if (p == e) break;
+        if (--decpt == 0) *p++ = '.';
+    }
+    if (width < 0) {
+        pad = (reqd + width) * -1;
+        while (pad-- > 0) *p++ = ' ';
+    }
+    *p = 0;
+    return sout;
+}
+#endif
+
+
 namespace xod {
 //----------------------------------------------------------------------------
 // Type definitions


### PR DESCRIPTION
Fixes #747 

Now the fixture project `lcd-time` should compile on every platform we show in the upload dialog drop down.