### PR TITLE
fix(xod-client): switch from getPatchByPathUnsafe to safe version in getPatchForHelpbar selector

### DIFF
--- a/packages/xod-client/src/core/selectors.js
+++ b/packages/xod-client/src/core/selectors.js
@@ -40,7 +40,7 @@ export const getPatchForHelpbar = createSelector(
     const maybeSelectedPathInProjectBrowser = Maybe(selectedPatchPath);
 
     return R.compose(
-      R.map(patchPath => XP.getPatchByPathUnsafe(patchPath, project)),
+      R.chain(patchPath => XP.getPatchByPath(patchPath, project)),
       R.apply(fallbackMaybe), // TODO: works with only two sources
       R.when(
         () => focusedArea === FOCUS_AREAS.PROJECT_BROWSER,


### PR DESCRIPTION
Closes #763

Very silly mistake introduced in #751 🙈