### PR TITLE
Access outputs directly in C++ runtime

### DIFF
--- a/packages/xod-arduino/platform/runtime.cpp
+++ b/packages/xod-arduino/platform/runtime.cpp
@@ -205,10 +205,13 @@ extern DirtyFlags g_dirtyFlags[NODE_COUNT];
 extern TimeMs g_schedule[NODE_COUNT];
 
 void clearTimeout(NodeId nid);
+bool isTimedOut(NodeId nid);
 
 //----------------------------------------------------------------------------
 // Engine (private API)
 //----------------------------------------------------------------------------
+
+TimeMs g_transactionTime;
 
 void* getStoragePtr(NodeId nid, size_t offset) {
     return (uint8_t*)pgm_read_ptr(&g_storages[nid]) + offset;
@@ -274,6 +277,39 @@ T getInputValueImpl(NodeId nid, size_t wiringOffset) {
 }
 
 template<typename T>
+struct always_false {
+    enum { value = 0 };
+};
+
+// GetValue -- classical trick for partial function (API `xod::getValue`)
+// template specialization
+template<typename InputOutputT>
+struct GetValue {
+    static typename InputOutputT::ValueT getValue(Context ctx) {
+        static_assert(
+                always_false<InputOutputT>::value,
+                "You should provide an input_XXX or output_YYY argument " \
+                "in angle brackets of getValue"
+                );
+
+    }
+};
+
+template<typename ValueT, size_t wiringOffset>
+struct GetValue<InputDescriptor<ValueT, wiringOffset>> {
+    static ValueT getValue(Context ctx) {
+        return getInputValueImpl<ValueT>(ctx, wiringOffset);
+    }
+};
+
+template<typename ValueT, size_t wiringOffset, size_t storageOffset, uint8_t index>
+struct GetValue<OutputDescriptor<ValueT, wiringOffset, storageOffset, index>> {
+    static ValueT getValue(Context ctx) {
+        return getOutputValueImpl<ValueT>(ctx, storageOffset);
+    }
+};
+
+template<typename T>
 void emitValueImpl(
         NodeId nid,
         size_t storageOffset,
@@ -305,26 +341,37 @@ void evaluateNode(NodeId nid) {
 }
 
 void runTransaction() {
+    g_transactionTime = millis();
+
     XOD_TRACE_F("Transaction started, t=");
-    XOD_TRACE_LN(millis());
-    for (NodeId nid = 0; nid < NODE_COUNT; ++nid)
-        if (isNodeDirty(nid))
+    XOD_TRACE_LN(g_transactionTime);
+
+    for (NodeId nid = 0; nid < NODE_COUNT; ++nid) {
+        if (isNodeDirty(nid)) {
             evaluateNode(nid);
 
+            // If the schedule is stale, clear timeout so that
+            // the node would not be marked dirty again in idle
+            if (isTimedOut(nid))
+                clearTimeout(nid);
+        }
+    }
+
+    // Clear dirtieness for all nodes and pins
     memset(g_dirtyFlags, 0, sizeof(g_dirtyFlags));
+
     XOD_TRACE_F("Transaction completed, t=");
     XOD_TRACE_LN(millis());
 }
 
 void idle() {
+    // Mark timed out nodes dirty. Do not reset schedule here to give
+    // a chance for a node to get a reasonable result from `isTimedOut`
     TimeMs now = millis();
     for (NodeId nid = 0; nid < NODE_COUNT; ++nid) {
         TimeMs t = g_schedule[nid];
-        if (t && t <= now) {
+        if (t && t < now)
             markNodeDirty(nid);
-            clearTimeout(nid);
-            return;
-        }
     }
 }
 
@@ -332,9 +379,9 @@ void idle() {
 // Public API (can be used by native nodes’ `evaluate` functions)
 //----------------------------------------------------------------------------
 
-template<typename InputT>
-typename InputT::ValueT getValue(NodeId nid) {
-    return getInputValueImpl<typename InputT::ValueT>(nid, InputT::WIRING_OFFSET);
+template<typename InputOutputT>
+typename InputOutputT::ValueT getValue(Context ctx) {
+    return GetValue<InputOutputT>::getValue(ctx);
 }
 
 template<typename OutputT>
@@ -348,7 +395,7 @@ void emitValue(NodeId nid, typename OutputT::ValueT value) {
 }
 
 TimeMs transactionTime() {
-    return millis();
+    return g_transactionTime;
 }
 
 void setTimeout(NodeId nid, TimeMs timeout) {
@@ -357,6 +404,10 @@ void setTimeout(NodeId nid, TimeMs timeout) {
 
 void clearTimeout(NodeId nid) {
     g_schedule[nid] = 0;
+}
+
+bool isTimedOut(NodeId nid) {
+    return g_schedule[nid] < transactionTime();
 }
 
 } // namespace xod

--- a/packages/xod-arduino/tools/test-avr-size.sh
+++ b/packages/xod-arduino/tools/test-avr-size.sh
@@ -25,10 +25,10 @@ AVR Memory Usage
 ----------------
 Device: atmega328p
 
-Program:    2568 bytes (7.8% Full)
+Program:    2602 bytes (7.9% Full)
 (.text + .data + .bootloader)
 
-Data:         54 bytes (2.6% Full)
+Data:         58 bytes (2.8% Full)
 (.data + .bss + .noinit)"
 
 if [[ $AVR_SIZE_OUTPUT =~ "$EXPECTED_OUTPUT" ]]; then

--- a/workspace/blink/__fixtures__/arduino.cpp
+++ b/workspace/blink/__fixtures__/arduino.cpp
@@ -844,10 +844,13 @@ extern DirtyFlags g_dirtyFlags[NODE_COUNT];
 extern TimeMs g_schedule[NODE_COUNT];
 
 void clearTimeout(NodeId nid);
+bool isTimedOut(NodeId nid);
 
 //----------------------------------------------------------------------------
 // Engine (private API)
 //----------------------------------------------------------------------------
+
+TimeMs g_transactionTime;
 
 void* getStoragePtr(NodeId nid, size_t offset) {
     return (uint8_t*)pgm_read_ptr(&g_storages[nid]) + offset;
@@ -913,6 +916,39 @@ T getInputValueImpl(NodeId nid, size_t wiringOffset) {
 }
 
 template<typename T>
+struct always_false {
+    enum { value = 0 };
+};
+
+// GetValue -- classical trick for partial function (API `xod::getValue`)
+// template specialization
+template<typename InputOutputT>
+struct GetValue {
+    static typename InputOutputT::ValueT getValue(Context ctx) {
+        static_assert(
+                always_false<InputOutputT>::value,
+                "You should provide an input_XXX or output_YYY argument " \
+                "in angle brackets of getValue"
+                );
+
+    }
+};
+
+template<typename ValueT, size_t wiringOffset>
+struct GetValue<InputDescriptor<ValueT, wiringOffset>> {
+    static ValueT getValue(Context ctx) {
+        return getInputValueImpl<ValueT>(ctx, wiringOffset);
+    }
+};
+
+template<typename ValueT, size_t wiringOffset, size_t storageOffset, uint8_t index>
+struct GetValue<OutputDescriptor<ValueT, wiringOffset, storageOffset, index>> {
+    static ValueT getValue(Context ctx) {
+        return getOutputValueImpl<ValueT>(ctx, storageOffset);
+    }
+};
+
+template<typename T>
 void emitValueImpl(
         NodeId nid,
         size_t storageOffset,
@@ -944,26 +980,37 @@ void evaluateNode(NodeId nid) {
 }
 
 void runTransaction() {
+    g_transactionTime = millis();
+
     XOD_TRACE_F("Transaction started, t=");
-    XOD_TRACE_LN(millis());
-    for (NodeId nid = 0; nid < NODE_COUNT; ++nid)
-        if (isNodeDirty(nid))
+    XOD_TRACE_LN(g_transactionTime);
+
+    for (NodeId nid = 0; nid < NODE_COUNT; ++nid) {
+        if (isNodeDirty(nid)) {
             evaluateNode(nid);
 
+            // If the schedule is stale, clear timeout so that
+            // the node would not be marked dirty again in idle
+            if (isTimedOut(nid))
+                clearTimeout(nid);
+        }
+    }
+
+    // Clear dirtieness for all nodes and pins
     memset(g_dirtyFlags, 0, sizeof(g_dirtyFlags));
+
     XOD_TRACE_F("Transaction completed, t=");
     XOD_TRACE_LN(millis());
 }
 
 void idle() {
+    // Mark timed out nodes dirty. Do not reset schedule here to give
+    // a chance for a node to get a reasonable result from `isTimedOut`
     TimeMs now = millis();
     for (NodeId nid = 0; nid < NODE_COUNT; ++nid) {
         TimeMs t = g_schedule[nid];
-        if (t && t <= now) {
+        if (t && t < now)
             markNodeDirty(nid);
-            clearTimeout(nid);
-            return;
-        }
     }
 }
 
@@ -971,9 +1018,9 @@ void idle() {
 // Public API (can be used by native nodes’ `evaluate` functions)
 //----------------------------------------------------------------------------
 
-template<typename InputT>
-typename InputT::ValueT getValue(NodeId nid) {
-    return getInputValueImpl<typename InputT::ValueT>(nid, InputT::WIRING_OFFSET);
+template<typename InputOutputT>
+typename InputOutputT::ValueT getValue(Context ctx) {
+    return GetValue<InputOutputT>::getValue(ctx);
 }
 
 template<typename OutputT>
@@ -987,7 +1034,7 @@ void emitValue(NodeId nid, typename OutputT::ValueT value) {
 }
 
 TimeMs transactionTime() {
-    return millis();
+    return g_transactionTime;
 }
 
 void setTimeout(NodeId nid, TimeMs timeout) {
@@ -996,6 +1043,10 @@ void setTimeout(NodeId nid, TimeMs timeout) {
 
 void clearTimeout(NodeId nid) {
     g_schedule[nid] = 0;
+}
+
+bool isTimedOut(NodeId nid) {
+    return g_schedule[nid] < transactionTime();
 }
 
 } // namespace xod
@@ -1129,7 +1180,6 @@ void evaluate(Context ctx) {
 namespace xod__core__flip_flop {
 
 struct State {
-    bool state = false;
 };
 
 struct Storage {
@@ -1156,20 +1206,20 @@ using input_RST = InputDescriptor<Logic, offsetof(Wiring, input_RST)>;
 using output_MEM = OutputDescriptor<Logic, offsetof(Wiring, output_MEM), offsetof(Storage, output_MEM), 0>;
 
 void evaluate(Context ctx) {
-    State* state = getState(ctx);
-    bool newState = state->state;
+    bool oldState = getValue<output_MEM>(ctx);
+    bool newState = oldState;
+
     if (isInputDirty<input_TGL>(ctx)) {
-        newState = !state->state;
+        newState = !oldState;
     } else if (isInputDirty<input_SET>(ctx)) {
         newState = true;
     } else {
         newState = false;
     }
 
-    if (newState == state->state)
+    if (newState == oldState)
         return;
 
-    state->state = newState;
     emitValue<output_MEM>(ctx, newState);
 }
 

--- a/workspace/lcd-time/__fixtures__/arduino.cpp
+++ b/workspace/lcd-time/__fixtures__/arduino.cpp
@@ -844,10 +844,13 @@ extern DirtyFlags g_dirtyFlags[NODE_COUNT];
 extern TimeMs g_schedule[NODE_COUNT];
 
 void clearTimeout(NodeId nid);
+bool isTimedOut(NodeId nid);
 
 //----------------------------------------------------------------------------
 // Engine (private API)
 //----------------------------------------------------------------------------
+
+TimeMs g_transactionTime;
 
 void* getStoragePtr(NodeId nid, size_t offset) {
     return (uint8_t*)pgm_read_ptr(&g_storages[nid]) + offset;
@@ -913,6 +916,39 @@ T getInputValueImpl(NodeId nid, size_t wiringOffset) {
 }
 
 template<typename T>
+struct always_false {
+    enum { value = 0 };
+};
+
+// GetValue -- classical trick for partial function (API `xod::getValue`)
+// template specialization
+template<typename InputOutputT>
+struct GetValue {
+    static typename InputOutputT::ValueT getValue(Context ctx) {
+        static_assert(
+                always_false<InputOutputT>::value,
+                "You should provide an input_XXX or output_YYY argument " \
+                "in angle brackets of getValue"
+                );
+
+    }
+};
+
+template<typename ValueT, size_t wiringOffset>
+struct GetValue<InputDescriptor<ValueT, wiringOffset>> {
+    static ValueT getValue(Context ctx) {
+        return getInputValueImpl<ValueT>(ctx, wiringOffset);
+    }
+};
+
+template<typename ValueT, size_t wiringOffset, size_t storageOffset, uint8_t index>
+struct GetValue<OutputDescriptor<ValueT, wiringOffset, storageOffset, index>> {
+    static ValueT getValue(Context ctx) {
+        return getOutputValueImpl<ValueT>(ctx, storageOffset);
+    }
+};
+
+template<typename T>
 void emitValueImpl(
         NodeId nid,
         size_t storageOffset,
@@ -944,26 +980,37 @@ void evaluateNode(NodeId nid) {
 }
 
 void runTransaction() {
+    g_transactionTime = millis();
+
     XOD_TRACE_F("Transaction started, t=");
-    XOD_TRACE_LN(millis());
-    for (NodeId nid = 0; nid < NODE_COUNT; ++nid)
-        if (isNodeDirty(nid))
+    XOD_TRACE_LN(g_transactionTime);
+
+    for (NodeId nid = 0; nid < NODE_COUNT; ++nid) {
+        if (isNodeDirty(nid)) {
             evaluateNode(nid);
 
+            // If the schedule is stale, clear timeout so that
+            // the node would not be marked dirty again in idle
+            if (isTimedOut(nid))
+                clearTimeout(nid);
+        }
+    }
+
+    // Clear dirtieness for all nodes and pins
     memset(g_dirtyFlags, 0, sizeof(g_dirtyFlags));
+
     XOD_TRACE_F("Transaction completed, t=");
     XOD_TRACE_LN(millis());
 }
 
 void idle() {
+    // Mark timed out nodes dirty. Do not reset schedule here to give
+    // a chance for a node to get a reasonable result from `isTimedOut`
     TimeMs now = millis();
     for (NodeId nid = 0; nid < NODE_COUNT; ++nid) {
         TimeMs t = g_schedule[nid];
-        if (t && t <= now) {
+        if (t && t < now)
             markNodeDirty(nid);
-            clearTimeout(nid);
-            return;
-        }
     }
 }
 
@@ -971,9 +1018,9 @@ void idle() {
 // Public API (can be used by native nodes’ `evaluate` functions)
 //----------------------------------------------------------------------------
 
-template<typename InputT>
-typename InputT::ValueT getValue(NodeId nid) {
-    return getInputValueImpl<typename InputT::ValueT>(nid, InputT::WIRING_OFFSET);
+template<typename InputOutputT>
+typename InputOutputT::ValueT getValue(Context ctx) {
+    return GetValue<InputOutputT>::getValue(ctx);
 }
 
 template<typename OutputT>
@@ -987,7 +1034,7 @@ void emitValue(NodeId nid, typename OutputT::ValueT value) {
 }
 
 TimeMs transactionTime() {
-    return millis();
+    return g_transactionTime;
 }
 
 void setTimeout(NodeId nid, TimeMs timeout) {
@@ -996,6 +1043,10 @@ void setTimeout(NodeId nid, TimeMs timeout) {
 
 void clearTimeout(NodeId nid) {
     g_schedule[nid] = 0;
+}
+
+bool isTimedOut(NodeId nid) {
+    return g_schedule[nid] < transactionTime();
 }
 
 } // namespace xod

--- a/workspace/lib/xod/common-hardware/button/patch.xodp
+++ b/workspace/lib/xod/common-hardware/button/patch.xodp
@@ -2,25 +2,25 @@
   "description": "Reads a generic button or another mechanical switch. It is expected that the button is normally high, i.e. it is pulled up with a resistor. The node provides signal debounce with 20 ms settle delay.",
   "links": [
     {
-      "id": "B1fDfkF8W",
+      "id": "ByvswoBtW",
       "input": {
         "nodeId": "BkHBM1FLb",
         "pinKey": "ry3zLA_Bv1Z"
       },
       "output": {
-        "nodeId": "rkl8GkKUb",
-        "pinKey": "Sk7EARu8-"
+        "nodeId": "BypVzytU-",
+        "pinKey": "B1gI0urv1W"
       }
     },
     {
-      "id": "S1xwfyYUW",
+      "id": "HJ9jvsrFW",
       "input": {
-        "nodeId": "rkl8GkKUb",
-        "pinKey": "S101C0OU-"
+        "nodeId": "BJ--G1tI-",
+        "pinKey": "__in__"
       },
       "output": {
-        "nodeId": "BypVzytU-",
-        "pinKey": "B1gI0urv1W"
+        "nodeId": "rkl8GkKUb",
+        "pinKey": "Sk7EARu8-"
       }
     },
     {
@@ -35,10 +35,10 @@
       }
     },
     {
-      "id": "rJ2BG1tLW",
+      "id": "rk_jDiBtW",
       "input": {
-        "nodeId": "BJ--G1tI-",
-        "pinKey": "__in__"
+        "nodeId": "rkl8GkKUb",
+        "pinKey": "S101C0OU-"
       },
       "output": {
         "nodeId": "BkHBM1FLb",
@@ -63,16 +63,16 @@
       "id": "BJ--G1tI-",
       "label": "PRS",
       "position": {
-        "x": 138,
-        "y": 432
+        "x": 136,
+        "y": 408
       },
       "type": "xod/patch-nodes/output-boolean"
     },
     {
       "id": "BkHBM1FLb",
       "position": {
-        "x": 138,
-        "y": 328
+        "x": 136,
+        "y": 204
       },
       "type": "xod/core/not"
     },
@@ -84,8 +84,8 @@
       "id": "ByG3ZyKLW",
       "label": "UPD",
       "position": {
-        "x": 266,
-        "y": 16
+        "x": 170,
+        "y": 0
       },
       "type": "xod/patch-nodes/input-pulse"
     },
@@ -94,16 +94,16 @@
       "id": "ByNiWkt8Z",
       "label": "PORT",
       "position": {
-        "x": 10,
-        "y": 16
+        "x": 136,
+        "y": 0
       },
       "type": "xod/patch-nodes/input-number"
     },
     {
       "id": "BypVzytU-",
       "position": {
-        "x": 138,
-        "y": 120
+        "x": 136,
+        "y": 102
       },
       "type": "xod/core/digital-input"
     },
@@ -113,8 +113,8 @@
       },
       "id": "rkl8GkKUb",
       "position": {
-        "x": 138,
-        "y": 224
+        "x": 136,
+        "y": 306
       },
       "type": "xod/core/debounce-boolean"
     }

--- a/workspace/lib/xod/core/buffer/any.cpp
+++ b/workspace/lib/xod/core/buffer/any.cpp
@@ -1,5 +1,4 @@
 struct State {
-    Number value;
 };
 
 {{ GENERATED_CODE }}
@@ -8,11 +7,5 @@ void evaluate(Context ctx) {
     if (!isInputDirty<input_UPD>(ctx))
         return;
 
-    State* state = getState(ctx);
-    auto newValue = getValue<input_NEW>(ctx);
-    if (newValue == state->value)
-        return;
-
-    state->value = newValue;
-    emitValue<output_MEM>(ctx, newValue);
+    emitValue<output_MEM>(ctx, getValue<input_NEW>(ctx));
 }

--- a/workspace/lib/xod/core/count/any.cpp
+++ b/workspace/lib/xod/core/count/any.cpp
@@ -1,19 +1,16 @@
 
 struct State {
-    Number count = 0;
 };
 
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-    State* state = getState(ctx);
+    Number count = getValue<output_OUT>(ctx);
 
-    if (isInputDirty<input_RST>(ctx)) {
-        state->count = 0;
-    } else if (isInputDirty<input_INC>(ctx)) {
-        auto step = getValue<input_STEP>(ctx);
-        state->count += step;
-    }
+    if (isInputDirty<input_RST>(ctx))
+        count = 0;
+    else if (isInputDirty<input_INC>(ctx))
+        count += getValue<input_STEP>(ctx);
 
-    emitValue<output_OUT>(ctx, state->count);
+    emitValue<output_OUT>(ctx, count);
 }

--- a/workspace/lib/xod/core/debounce-boolean/any.cpp
+++ b/workspace/lib/xod/core/debounce-boolean/any.cpp
@@ -12,9 +12,9 @@ void evaluate(Context ctx) {
         state->state = x;
         TimeMs dt = getValue<input_Ts>(ctx) * 1000;
         setTimeout(ctx, dt);
-    } else if (!isInputDirty<input_ST>(ctx) && !isInputDirty<input_Ts>(ctx)) {
-        // TODO: implement XOD core function isTimedOut(ctx) to know for
-        // sure that we’re here because of time elapsed
+    }
+
+    if (isTimedOut(ctx)) {
         emitValue<output_OUT>(ctx, x);
     }
 }

--- a/workspace/lib/xod/core/fade/any.cpp
+++ b/workspace/lib/xod/core/fade/any.cpp
@@ -1,5 +1,4 @@
 struct State {
-    Number position;
     TimeMs lastUpdateTime;
 };
 
@@ -13,7 +12,7 @@ void evaluate(Context ctx) {
 
     TimeMs now = transactionTime();
     Number target = getValue<input_TARG>(ctx);
-    Number position = state->position;
+    Number position = getValue<output_OUT>(ctx);
 
     if (target == position) {
         // Already done. Store timestamp anyway so that an animation to a new
@@ -33,6 +32,5 @@ void evaluate(Context ctx) {
     }
 
     emitValue<output_OUT>(ctx, position);
-    state->position = position;
     state->lastUpdateTime = now;
 }

--- a/workspace/lib/xod/core/flip-flop/any.cpp
+++ b/workspace/lib/xod/core/flip-flop/any.cpp
@@ -1,23 +1,22 @@
 struct State {
-    bool state = false;
 };
 
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-    State* state = getState(ctx);
-    bool newState = state->state;
+    bool oldState = getValue<output_MEM>(ctx);
+    bool newState = oldState;
+
     if (isInputDirty<input_TGL>(ctx)) {
-        newState = !state->state;
+        newState = !oldState;
     } else if (isInputDirty<input_SET>(ctx)) {
         newState = true;
     } else {
         newState = false;
     }
 
-    if (newState == state->state)
+    if (newState == oldState)
         return;
 
-    state->state = newState;
     emitValue<output_MEM>(ctx, newState);
 }

--- a/workspace/two-button-switch/__fixtures__/arduino.cpp
+++ b/workspace/two-button-switch/__fixtures__/arduino.cpp
@@ -844,10 +844,13 @@ extern DirtyFlags g_dirtyFlags[NODE_COUNT];
 extern TimeMs g_schedule[NODE_COUNT];
 
 void clearTimeout(NodeId nid);
+bool isTimedOut(NodeId nid);
 
 //----------------------------------------------------------------------------
 // Engine (private API)
 //----------------------------------------------------------------------------
+
+TimeMs g_transactionTime;
 
 void* getStoragePtr(NodeId nid, size_t offset) {
     return (uint8_t*)pgm_read_ptr(&g_storages[nid]) + offset;
@@ -913,6 +916,39 @@ T getInputValueImpl(NodeId nid, size_t wiringOffset) {
 }
 
 template<typename T>
+struct always_false {
+    enum { value = 0 };
+};
+
+// GetValue -- classical trick for partial function (API `xod::getValue`)
+// template specialization
+template<typename InputOutputT>
+struct GetValue {
+    static typename InputOutputT::ValueT getValue(Context ctx) {
+        static_assert(
+                always_false<InputOutputT>::value,
+                "You should provide an input_XXX or output_YYY argument " \
+                "in angle brackets of getValue"
+                );
+
+    }
+};
+
+template<typename ValueT, size_t wiringOffset>
+struct GetValue<InputDescriptor<ValueT, wiringOffset>> {
+    static ValueT getValue(Context ctx) {
+        return getInputValueImpl<ValueT>(ctx, wiringOffset);
+    }
+};
+
+template<typename ValueT, size_t wiringOffset, size_t storageOffset, uint8_t index>
+struct GetValue<OutputDescriptor<ValueT, wiringOffset, storageOffset, index>> {
+    static ValueT getValue(Context ctx) {
+        return getOutputValueImpl<ValueT>(ctx, storageOffset);
+    }
+};
+
+template<typename T>
 void emitValueImpl(
         NodeId nid,
         size_t storageOffset,
@@ -944,26 +980,37 @@ void evaluateNode(NodeId nid) {
 }
 
 void runTransaction() {
+    g_transactionTime = millis();
+
     XOD_TRACE_F("Transaction started, t=");
-    XOD_TRACE_LN(millis());
-    for (NodeId nid = 0; nid < NODE_COUNT; ++nid)
-        if (isNodeDirty(nid))
+    XOD_TRACE_LN(g_transactionTime);
+
+    for (NodeId nid = 0; nid < NODE_COUNT; ++nid) {
+        if (isNodeDirty(nid)) {
             evaluateNode(nid);
 
+            // If the schedule is stale, clear timeout so that
+            // the node would not be marked dirty again in idle
+            if (isTimedOut(nid))
+                clearTimeout(nid);
+        }
+    }
+
+    // Clear dirtieness for all nodes and pins
     memset(g_dirtyFlags, 0, sizeof(g_dirtyFlags));
+
     XOD_TRACE_F("Transaction completed, t=");
     XOD_TRACE_LN(millis());
 }
 
 void idle() {
+    // Mark timed out nodes dirty. Do not reset schedule here to give
+    // a chance for a node to get a reasonable result from `isTimedOut`
     TimeMs now = millis();
     for (NodeId nid = 0; nid < NODE_COUNT; ++nid) {
         TimeMs t = g_schedule[nid];
-        if (t && t <= now) {
+        if (t && t < now)
             markNodeDirty(nid);
-            clearTimeout(nid);
-            return;
-        }
     }
 }
 
@@ -971,9 +1018,9 @@ void idle() {
 // Public API (can be used by native nodes’ `evaluate` functions)
 //----------------------------------------------------------------------------
 
-template<typename InputT>
-typename InputT::ValueT getValue(NodeId nid) {
-    return getInputValueImpl<typename InputT::ValueT>(nid, InputT::WIRING_OFFSET);
+template<typename InputOutputT>
+typename InputOutputT::ValueT getValue(Context ctx) {
+    return GetValue<InputOutputT>::getValue(ctx);
 }
 
 template<typename OutputT>
@@ -987,7 +1034,7 @@ void emitValue(NodeId nid, typename OutputT::ValueT value) {
 }
 
 TimeMs transactionTime() {
-    return millis();
+    return g_transactionTime;
 }
 
 void setTimeout(NodeId nid, TimeMs timeout) {
@@ -996,6 +1043,10 @@ void setTimeout(NodeId nid, TimeMs timeout) {
 
 void clearTimeout(NodeId nid) {
     g_schedule[nid] = 0;
+}
+
+bool isTimedOut(NodeId nid) {
+    return g_schedule[nid] < transactionTime();
 }
 
 } // namespace xod
@@ -1126,7 +1177,6 @@ void evaluate(Context ctx) {
 namespace xod__core__flip_flop {
 
 struct State {
-    bool state = false;
 };
 
 struct Storage {
@@ -1153,20 +1203,20 @@ using input_RST = InputDescriptor<Logic, offsetof(Wiring, input_RST)>;
 using output_MEM = OutputDescriptor<Logic, offsetof(Wiring, output_MEM), offsetof(Storage, output_MEM), 0>;
 
 void evaluate(Context ctx) {
-    State* state = getState(ctx);
-    bool newState = state->state;
+    bool oldState = getValue<output_MEM>(ctx);
+    bool newState = oldState;
+
     if (isInputDirty<input_TGL>(ctx)) {
-        newState = !state->state;
+        newState = !oldState;
     } else if (isInputDirty<input_SET>(ctx)) {
         newState = true;
     } else {
         newState = false;
     }
 
-    if (newState == state->state)
+    if (newState == oldState)
         return;
 
-    state->state = newState;
     emitValue<output_MEM>(ctx, newState);
 }
 


### PR DESCRIPTION
Fixes #737 

Also in this PR:

- Implement `isTimedOut`, freeze `transactionTime` value for the whole transaction span as stated in docs
- Fix false firing of `xod/common-hardware/button` on start

It was expected that RAM consumption will be lower after switching from own state to output storage. And it is. However, the size test fixture is a simple blink. It had 1 byte (bool) of own storage saved (the memory of flip-flop). On the other side, extra 4 bytes were consumed by `g_transactionTime`. Thus the final firmware size increased a bit on this particular singular case.