### PR TITLE
Make background for selected project browser item’s buttons non-transparent

### DIFF
--- a/packages/xod-client/src/core/styles/components/PatchGroupItem.scss
+++ b/packages/xod-client/src/core/styles/components/PatchGroupItem.scss
@@ -49,9 +49,9 @@
 
     .PatchGroupItem__hover-buttons {
       display: block;
-      background: transparent;
+      background: $sidebar-color-bg-selected;
       &:before {
-        background: transparent;
+        background: linear-gradient(to left, $sidebar-color-bg-selected, rgba(0, 0, 0, 0));
       }
     }
   }
@@ -62,6 +62,10 @@
 
     .PatchGroupItem__hover-buttons {
       display: block;
+      background-color: $sidebar-color-bg-hover;
+      &:before {
+        background: linear-gradient(to left, $sidebar-color-bg-hover, rgba(0, 0, 0, 0));
+      }
     }
   }
 


### PR DESCRIPTION
fixes this:
![screen shot 2017-08-31 at 20 13 59](https://user-images.githubusercontent.com/2527093/29936015-5e524aea-8e89-11e7-9699-55a4758227cd.png)
