### PR TITLE
Sort local patches alphabetically

### DIFF
--- a/packages/xod-client/src/projectBrowser/reducer.js
+++ b/packages/xod-client/src/projectBrowser/reducer.js
@@ -10,6 +10,7 @@ import {
 
 import {
   PATCH_DELETE,
+  PATCH_RENAME,
 } from '../project/actionTypes';
 
 const selectionReducer = (state, action) => {
@@ -18,6 +19,13 @@ const selectionReducer = (state, action) => {
     case PATCH_RENAME_REQUESTED:
     case PATCH_DELETE_REQUESTED:
       return action.payload.patchPath;
+
+    case PATCH_RENAME:
+      return R.when(
+        R.equals(action.payload.oldPatchPath),
+        R.always(action.payload.newPatchPath),
+        state
+      );
 
     case REMOVE_SELECTION: // TODO: deselect only if there are no open popups?
     case PATCH_DELETE:

--- a/packages/xod-client/src/projectBrowser/selectors.js
+++ b/packages/xod-client/src/projectBrowser/selectors.js
@@ -20,7 +20,10 @@ export const getProjectName = createSelector(
 
 export const getLocalPatches = createSelector(
   ProjectSelectors.getProject,
-  XP.listLocalPatches
+  R.compose(
+    R.sortBy(XP.getPatchPath),
+    XP.listLocalPatches
+  )
 );
 
 // TODO: this is not actually label anymore


### PR DESCRIPTION
A couple of small project browser tweaks:
- sort local patches alphabetically
- keep selection after renaming patch
