### PR TITLE
Add ‘Select All’ command to desktop IDE

### DIFF
--- a/packages/xod-client-electron/src/view/containers/App.jsx
+++ b/packages/xod-client-electron/src/view/containers/App.jsx
@@ -54,6 +54,7 @@ const onContextMenu = (event) => {
     items.cut,
     items.copy,
     items.paste,
+    items.selectall,
   ]);
 
   const node = event.target;
@@ -370,6 +371,7 @@ class App extends client.App {
           items.cut,
           items.copy,
           items.paste,
+          items.selectall,
           items.separator,
           onClick(items.insertNode, () => this.props.actions.showSuggester(null)),
           onClick(items.insertComment, this.props.actions.addComment),

--- a/packages/xod-client/src/utils/constants.js
+++ b/packages/xod-client/src/utils/constants.js
@@ -20,6 +20,7 @@ export const COMMAND = {
   CUT: 'cut',
   COPY: 'copy',
   PASTE: 'paste',
+  SELECT_ALL: 'selectall',
 
   SAVE_PROJECT: 'saveProject',
 
@@ -66,6 +67,7 @@ export const ELECTRON_ACCELERATOR = {
   [COMMAND.CUT]: 'CmdOrCtrl+X',
   [COMMAND.COPY]: 'CmdOrCtrl+C',
   [COMMAND.PASTE]: 'CmdOrCtrl+V',
+  [COMMAND.SELECT_ALL]: 'CmdOrCtrl+A',
 
   [COMMAND.SAVE_PROJECT]: 'CmdOrCtrl+S',
 

--- a/packages/xod-client/src/utils/menu.js
+++ b/packages/xod-client/src/utils/menu.js
@@ -80,6 +80,12 @@ const rawItems = {
     command: COMMAND.PASTE,
     role: 'paste',
   },
+  selectall: {
+    key: 'selectall',
+    label: 'Select All',
+    command: COMMAND.SELECT_ALL,
+    role: 'selectall',
+  },
   projectPreferences: {
     key: 'projectPreferences',
     label: 'Project preferences',


### PR DESCRIPTION
Because we could not select all text in an input before :(