### PR TITLE
Document mouse and keyboard shortcuts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ User’s guide
 * [Data Types](./guide/data-types/)
 * [Linking Rules](./guide/linking-rules/)
 * [Execution Model](./guide/execution-model/)
+* [Mouse and Keyboard Shortcuts](./guide/shortcuts/)
 
 Standard library node reference
 -------------------------------

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -9,3 +9,4 @@ User’s Guide
 * [Data Types](./data-types/)
 * [Linking Rules](./linking-rules/)
 * [Execution Model](./execution-model/)
+* [Mouse and Keyboard Shortcuts](./shortcuts/)

--- a/docs/guide/shortcuts/README.md
+++ b/docs/guide/shortcuts/README.md
@@ -1,0 +1,246 @@
+---
+title: Mouse and Keyboard Shortcuts
+---
+
+# Mouse and Keyboard Shortcuts
+
+For shortcuts the following convention is used:
+
+* <span class="ui label">C</span> — platform-neutral keyboard input;
+* <span class="ui blue label">Ctrl+C</span> — PC-only keyboard input;
+* <span class="ui grey label">⌘ C</span> — Mac-only keyboard input;
+* <span class="ui olive label">Click</span> — mouse input.
+
+## Project management
+
+<table class="ui celled table">
+  <thead>
+    <tr>
+      <th>Shortcut</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <span class="ui blue label">Ctrl+N</span> |
+        <span class="ui grey label">⌘ N</span>
+      </td>
+      <td>
+        New patch
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span class="ui blue label">Ctrl+Shift+N</span> |
+        <span class="ui grey label">⇧⌘ N</span>
+      </td>
+      <td>
+        New project
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span class="ui blue label">Ctrl+S</span> |
+        <span class="ui grey label">⌘ S</span>
+      </td>
+      <td>
+        Save project
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span class="ui blue label">Ctrl+O</span> |
+        <span class="ui grey label">⌘ O</span>
+      </td>
+      <td>
+        Open project
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Patch editing
+
+The shortcuts in the table below are active when the patch board is in focus.
+
+<table class="ui celled table">
+  <thead>
+    <tr>
+      <th>Shortcut</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <span class="ui blue label">Ctrl+C</span> |
+        <span class="ui grey label">⌘ C</span>
+      </td>
+      <td>
+        Copy selected entities (nodes, links, comments) to the clipboard
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span class="ui blue label">Ctrl+X</span> |
+        <span class="ui grey label">⌘ X</span>
+      </td>
+      <td>
+        Cut selected entities to the clipboard
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span class="ui blue label">Ctrl+V</span> |
+        <span class="ui grey label">⌘ V</span>
+      </td>
+      <td>
+        Paste from the clipboard
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span class="ui blue label">Ctrl+Z</span> |
+        <span class="ui grey label">⌘ Z</span>
+      </td>
+      <td>
+        Undo the last action
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span class="ui blue label">Ctrl+Shift+Z</span> |
+        <span class="ui grey label">⇧⌘ Z</span>
+      </td>
+      <td>
+        Redo the action undone
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span class="ui blue label">Delete</span> |
+        <span class="ui blue label">Backspace</span> |
+        <span class="ui grey label">⌫</span>
+      </td>
+      <td>
+        Delete selected entities
+      </td>
+    </tr>
+    <tr>
+      <td><span class="ui label">Escape</span></td>
+      <td>
+        Select none
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span class="ui olive label">Middle + Drag</span> |
+        <span style="white-space: nowrap"><span class="ui label">Space</span>+<span class="ui olive label">Left + Drag</span></span>
+      </td>
+      <td>
+        Pan the patch board
+      </td>
+    </tr>
+    <tr>
+      <td><span class="ui label" style="font-family: monospace">I</span> | <span class="ui olive label">Double-click</span></td>
+      <td>
+        Insert a node (invoke the quick search)
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Project browser
+
+<table class="ui celled table">
+  <thead>
+    <tr>
+      <th>Shortcut</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <span class="ui olive label">Drag-n-drop</span>
+      </td>
+      <td>
+        Add a node to the patch
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span class="ui olive label">Double-click</span>
+      </td>
+      <td>
+        Open the node as a patch in new tab
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## View
+
+<table class="ui celled table">
+  <thead>
+    <tr>
+      <th>Shortcut</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <span class="ui label">H</span>
+      </td>
+      <td>
+        Toggle the help bar
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span class="ui blue label">Ctrl+Shift+=</span> |
+        <span class="ui grey label">⌘ +</span>
+      </td>
+      <td>
+        Zoom in
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span class="ui blue label">Ctrl+-</span> |
+        <span class="ui grey label">⌘ -</span>
+      </td>
+      <td>
+        Zoom out
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span class="ui blue label">Ctrl+0</span> |
+        <span class="ui grey label">⌘ 0</span>
+      </td>
+      <td>
+        Default zoom
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span class="ui blue label">Ctrl+Shift+I</span> |
+        <span class="ui grey label">⌥⌘ I</span>
+      </td>
+      <td>
+        Open Electron/Browser developer tools
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <span class="ui label">Ctrl+H</span>
+      </td>
+      <td>
+        Toggle Redux developer tools (development builds only)
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/packages/xod-client-browser/src/containers/App.jsx
+++ b/packages/xod-client-browser/src/containers/App.jsx
@@ -203,6 +203,7 @@ class App extends client.App {
           },
           items.separator,
           link(items.documentation, { href: client.getUtmSiteUrl('/docs/', 'docs', 'menu') }),
+          link(items.shortcuts, { href: client.getUtmSiteUrl('/docs/guide/shortcuts/', 'docs', 'menu') }),
           link(items.forum, { href: client.getUtmForumUrl('menu') }),
         ]
       ),

--- a/packages/xod-client-electron/src/view/containers/App.jsx
+++ b/packages/xod-client-electron/src/view/containers/App.jsx
@@ -396,6 +396,9 @@ class App extends client.App {
           onClick(items.documentation, () => {
             shell.openExternal(client.getUtmSiteUrl('/docs/', 'docs', 'menu'));
           }),
+          onClick(items.shortcuts, () => {
+            shell.openExternal(client.getUtmSiteUrl('/docs/guide/shortcuts/', 'docs', 'menu'));
+          }),
           onClick(items.forum, () => {
             shell.openExternal(client.getUtmForumUrl('menu'));
           }),

--- a/packages/xod-client/src/utils/menu.js
+++ b/packages/xod-client/src/utils/menu.js
@@ -130,6 +130,10 @@ const rawItems = {
     key: 'documentation',
     label: 'Documentation',
   },
+  shortcuts: {
+    key: 'shortcuts',
+    label: 'Shortcuts',
+  },
   forum: {
     key: 'forum',
     label: 'Forum',


### PR DESCRIPTION
Ad-hoc PR sourced from a [forum thread](https://forum.xod.io/t/is-there-ui-documentation/109/7).

I intentionally left out some shortcuts because their future does not look clear. E.g. `Ctrl+R` to rename: does this operation ever deserve a shortcut or at least such “tasty” keystroke?! This is yet to be discussed. For now, only stable and vital combinations are included.

Also note that in case of the PR approval, #796 and #811 should have changes in docs as well.