### PR TITLE
Chore: verify Git repo is kept clean during CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ cache:
   pip: true
 
 before_install:
-- curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.1.0
+- curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.2.1
 - export PATH=$HOME/.yarn/bin:$PATH
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ install:
 - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     pip install --user -U platformio;
   fi
+- ./tools/verify-git-clean.sh; # catch forgotten yarn.lock bumps
 
 
 before_script: |
@@ -55,8 +56,10 @@ before_script: |
 
 script:
 - yarn build
+- ./tools/verify-git-clean.sh; # no build side-effects
 - yarn lint
 - yarn test
 - if [ "$TRAVIS_OS_NAME" == "linux" ]; then yarn test-cpp; fi
 - yarn test-func
+- ./tools/verify-git-clean.sh; # no test side-effects
 - travis_wait 50 ./tools/travis.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ init:
 
 install:
 - ps: Install-Product node 8.6.0 x64
-- npm install yarn@1.1.0 -g
+- npm install yarn@1.2.1 -g
 - yarn install
 
 build_script:

--- a/tools/verify-git-clean.sh
+++ b/tools/verify-git-clean.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+DIFF_COUNT=$(git status --porcelain | wc -l)
+if [[ "$DIFF_COUNT" != "0" ]]; then
+    echo "Respository unexpected changes:"
+    git status --short
+    exit $DIFF_COUNT
+fi


### PR DESCRIPTION
…so that we don’t forget to bump `yarn.lock` and keep `.gitignore` DX friendly.