### PR TITLE
Make Inspector scrollable

### DIFF
--- a/packages/xod-client/src/core/styles/components/App.scss
+++ b/packages/xod-client/src/core/styles/components/App.scss
@@ -1,0 +1,13 @@
+#App {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+
+  position: absolute;
+  z-index: 1;
+
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}

--- a/packages/xod-client/src/core/styles/components/Debugger.scss
+++ b/packages/xod-client/src/core/styles/components/Debugger.scss
@@ -16,7 +16,7 @@
   position: absolute;
   z-index: 10;
   bottom: 0;
-  height: 200px;
+  height: 196px;
   width: 100%;
 
   color: $sidebar-color-text;

--- a/packages/xod-client/src/core/styles/components/Editor.scss
+++ b/packages/xod-client/src/core/styles/components/Editor.scss
@@ -1,0 +1,7 @@
+.Editor {
+  flex-grow: 1;
+
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}

--- a/packages/xod-client/src/core/styles/components/Inspector.scss
+++ b/packages/xod-client/src/core/styles/components/Inspector.scss
@@ -1,3 +1,7 @@
+.Inspector-container {
+   min-height: 0;
+   min-width: 0
+}
 
 .Inspector {
   display: block;
@@ -18,19 +22,19 @@
     padding: 14px 17px;
     color: $input-color-border; // TODO: separate color?
     cursor: default;
-  
+
     .nodeName, .patchName {
       color: $color-canvas-selected; // TODO: separate color?
     }
   }
-  
+
   .nodeType {
     padding-left: 16px;
     color: $sidebar-color-text;
     font-size: $font-size-s;
     cursor: default;
   }
-  
+
   .nodeHelp {
     display: block;
     position: absolute;
@@ -40,13 +44,13 @@
     height: 24px;
     border-radius: 50%;
     background-color: $input-color-bg;
-  
+
     &:hover {
       background-color: #555555;
       box-shadow: 0 0 3px 0 rgba(0,0,0,0.5);
     }
   }
-  
+
   .nodeHelpIcon {
     display: block;
     width: 24px;
@@ -177,6 +181,8 @@
 
   .inspectorTextInput {
     font-family: $font-family-condensed;
+    min-width: 100%;
+    max-width: 100%;
     width: 100%;
     height: 8em;
   }

--- a/packages/xod-client/src/core/styles/components/PatchWrapper.scss
+++ b/packages/xod-client/src/core/styles/components/PatchWrapper.scss
@@ -1,6 +1,10 @@
+.PatchWrapper-container {
+  flex-grow: 1;
+  position: relative;
+}
 .PatchWrapper {
   position: absolute;
-  top: 30px;
+  top: 0;
   right: 0;
   bottom: 0;
   left: 0;

--- a/packages/xod-client/src/core/styles/components/Sidebar.scss
+++ b/packages/xod-client/src/core/styles/components/Sidebar.scss
@@ -1,11 +1,13 @@
 .Sidebar {
-  position: absolute;
   width: $sidebar-width;
-  height: 100%;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
 
   background: $sidebar-color-bg;
 
   & > * {
+    flex: 1;
     border-bottom: 1px solid $sidebar-color-border;
   }
 

--- a/packages/xod-client/src/core/styles/components/Suggester.scss
+++ b/packages/xod-client/src/core/styles/components/Suggester.scss
@@ -2,6 +2,7 @@
   position: absolute;
   left: 50%;
   top: 5%;
+  z-index: 10;
 
   width: 400px;
   margin: 0 0 0 -200px;

--- a/packages/xod-client/src/core/styles/components/Workarea.scss
+++ b/packages/xod-client/src/core/styles/components/Workarea.scss
@@ -1,7 +1,10 @@
+.Workarea-container {
+  flex-grow: 1;
+}
+
 .Workarea {
-  position: absolute;
-  left: 0;
-  right: 0;
+  position: relative;
   height: 100%;
-  margin-left: 200px;
+  display: flex;
+  flex-direction: column;
 }

--- a/packages/xod-client/src/core/styles/main.scss
+++ b/packages/xod-client/src/core/styles/main.scss
@@ -13,11 +13,13 @@
   'base/base';
 
 @import
+  'components/App',
   'components/BackgroundLayer',
   'components/Button',
   'components/Breadcrumbs',
   'components/Comment',
   'components/Debugger',
+  'components/Editor',
   'components/Inspector',
   'components/Helpbar',
   'components/Link',

--- a/packages/xod-client/src/editor/containers/Editor.jsx
+++ b/packages/xod-client/src/editor/containers/Editor.jsx
@@ -140,10 +140,16 @@ class Editor extends React.Component {
     return (
       <HotKeys handlers={this.getHotkeyHandlers()} className="Editor">
         <Sidebar>
-          <FocusTrap onFocus={() => this.props.actions.setFocusedArea(FOCUS_AREAS.PROJECT_BROWSER)}>
+          <FocusTrap
+            className="ProjectBrowser-container"
+            onFocus={() => this.props.actions.setFocusedArea(FOCUS_AREAS.PROJECT_BROWSER)}
+          >
             <ProjectBrowser />
           </FocusTrap>
-          <FocusTrap onFocus={() => this.props.actions.setFocusedArea(FOCUS_AREAS.INSPECTOR)}>
+          <FocusTrap
+            className="Inspector-container"
+            onFocus={() => this.props.actions.setFocusedArea(FOCUS_AREAS.INSPECTOR)}
+          >
             <Inspector
               selection={selection}
               currentPatch={currentPatch}
@@ -152,7 +158,10 @@ class Editor extends React.Component {
             />
           </FocusTrap>
         </Sidebar>
-        <FocusTrap onFocus={() => this.props.actions.setFocusedArea(FOCUS_AREAS.WORKAREA)}>
+        <FocusTrap
+          className="Workarea-container"
+          onFocus={() => this.props.actions.setFocusedArea(FOCUS_AREAS.WORKAREA)}
+        >
           <Workarea>
             <Tabs />
             {DebugSessionStopButton}

--- a/packages/xod-client/src/editor/containers/Patch/index.jsx
+++ b/packages/xod-client/src/editor/containers/Patch/index.jsx
@@ -115,7 +115,10 @@ class Patch extends React.Component {
     const { currentMode } = this.state;
 
     return this.props.connectDropTarget(
-      <div ref={(r) => { this.dropTargetRootRef = r; }}>
+      <div
+        className="PatchWrapper-container"
+        ref={(r) => { this.dropTargetRootRef = r; }}
+      >
         {MODE_HANDLERS[currentMode].render(this.getApi(currentMode))}
       </div>
     );


### PR DESCRIPTION
It will close #819.
Also, I do a little refactoring of CSS-styles for some nearest DOM-elements.

I think that we could use a flex-box for a debugger & helpbar to prevent strange overlaying and some CSS-hacks (if helpbar is opened — change margin-left of the suggester).
It's easy, but I didn't do it, cause we still waiting for mock-ups of panel look from the designer....