### PR TITLE
Fix resizing of project browser on window resize

### DIFF
--- a/packages/xod-client/src/core/styles/components/PatchGroup.scss
+++ b/packages/xod-client/src/core/styles/components/PatchGroup.scss
@@ -55,3 +55,7 @@
     border-bottom: 1px solid $sidebar-color-border;
   }
 }
+
+.PatchGroup:first-child .PatchGroup__trigger {
+  border-top: 0;
+}

--- a/packages/xod-client/src/core/styles/components/PatchTypeSelector.scss
+++ b/packages/xod-client/src/core/styles/components/PatchTypeSelector.scss
@@ -1,4 +1,6 @@
 .PatchTypeSelector {
+  height: calc(100% - 30px); // 30px is a height of .ProjectBrowserToolbar
+
   .options {
     display: flex;
     list-style: none;
@@ -19,7 +21,7 @@
     user-select: none;
     border: 1px solid $sidebar-color-border;
     border-left: 0;
-    border-bottom: 0;
+    white-space: nowrap;
 
     &:first-child {
       border-left: 1px solid $sidebar-color-border;

--- a/packages/xod-client/src/core/styles/components/ProjectBrowser.scss
+++ b/packages/xod-client/src/core/styles/components/ProjectBrowser.scss
@@ -1,4 +1,9 @@
+.ProjectBrowser-container {
+  border-bottom: 1px solid #595959;
+}
+
 .ProjectBrowser {
+  height: 100%;
 
   &:focus {
     box-shadow: none;
@@ -6,7 +11,6 @@
   }
 
   .patches-list {
-    height: 326px;
     background-color: $sidebar-color-bg;
   }
 }

--- a/packages/xod-client/src/core/styles/components/Sidebar.scss
+++ b/packages/xod-client/src/core/styles/components/Sidebar.scss
@@ -7,8 +7,7 @@
   background: $sidebar-color-bg;
 
   & > * {
-    flex: 1;
-    border-bottom: 1px solid $sidebar-color-border;
+    height: 50%;
   }
 
   .title {

--- a/packages/xod-client/src/projectBrowser/containers/ProjectBrowser.jsx
+++ b/packages/xod-client/src/projectBrowser/containers/ProjectBrowser.jsx
@@ -255,7 +255,8 @@ class ProjectBrowser extends React.Component {
       : R.of(patchType);
 
     return (
-      <CustomScroll>
+      // "calc(100% - 30px)" cause patch filtering buttons are 30px height
+      <CustomScroll heightRelativeToParent="calc(100% - 30px)">
         <div className="patches-list">
           {rendererKeys.map(k => this.patchRenderers[k]())}
         </div>


### PR DESCRIPTION
It fixes #840.
It's a bit hacky (using `calc` in the CSS), but to avoid using `calc` we have to rewrite few components and make a HOC from FocusTrap... Cause that is a large amount of work, I fixed it this way.

If you have any ideas how to avoid using `calc` without big refactoring — feel free to write a comment :)