### PR TITLE
Fix format-number C++ implementation, enforce linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "doc:fz": "cd docs && make",
     "electron-dist": "electron-builder --publish always --projectDir ./packages/xod-client-electron",
     "lerna": "lerna",
-    "lint": "eslint packages/*/src packages/*/test packages/*/test-func --ext js,jsx",
+    "lint": "eslint packages/*/src packages/*/test packages/*/test-func --ext js,jsx --max-warnings 0",
     "start:spectron-repl": "./tools/spectron-repl",
     "start:xod-client-electron": "lerna run start --scope xod-client-electron",
     "storybook": "lerna run storybook --stream --scope xod-client",

--- a/packages/xod-client/src/editor/containers/Patch/modes/selecting.jsx
+++ b/packages/xod-client/src/editor/containers/Patch/modes/selecting.jsx
@@ -143,8 +143,6 @@ const selectingMode = {
     api.props.actions.deleteSelection();
   },
   onSelectAll({ props }, event) {
-    console.log('onSelectAll');
-
     if (isInput(event)) return;
 
     event.preventDefault();

--- a/workspace/__lib__/xod/core/format-number/any.cpp
+++ b/workspace/__lib__/xod/core/format-number/any.cpp
@@ -1,13 +1,15 @@
 struct State {
+    char str[16];
+    CStringView view;
+    State() : view(str) { }
 };
 
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-    char str[16];
+    auto state = getState(ctx);
     auto num = getValue<input_NUM>(ctx);
     auto dig = getValue<input_DIG>(ctx);
-    dtostrf(num, 0, dig, str);
-    auto xstr = ::xod::List<char>::fromPlainArray(str, strlen(str));
-    emitValue<output_STR>(ctx, xstr);
+    dtostrf(num, 0, dig, state->str);
+    emitValue<output_STR>(ctx, XString(&state->view));
 }


### PR DESCRIPTION
Few hotfixes in a single PR:

* Forgot to migrate `format-number` node implementation to the new string interface
* Remove a forgotten `console.log`. It showed up as a warning and thus passed the CI
* Enforce linter to treat warnings as errors