### PR TITLE
Fix `watch` node C++ implementation for the new string interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.  See
 [standard-version](https://github.com/conventional-changelog/standard-version)
 for commit guidelines.
 
+## Not yet released
+
+### Bug fixes
+
+* [nodes] Fix regression. `xod/core/watch` compiles again.
+
 <a name="0.15.0"></a>
 ## 0.15.0 (2017-10-31)
 

--- a/workspace/__lib__/xod/core/watch/any.cpp
+++ b/workspace/__lib__/xod/core/watch/any.cpp
@@ -9,17 +9,15 @@ void evaluate(Context ctx) {
 
   auto line = getValue<input_IN>(ctx);
 
-  if (line) {
-      TimeMs tNow = transactionTime();
-      DEBUG_SERIAL.print(F("+XOD:"));
-      DEBUG_SERIAL.print(tNow);
-      DEBUG_SERIAL.print(':');
-      DEBUG_SERIAL.print(ctx);
-      DEBUG_SERIAL.print(':');
-      for (auto it = line->iterate(); it; ++it)
-          DEBUG_SERIAL.print((char)*it);
-      DEBUG_SERIAL.print('\r');
-      DEBUG_SERIAL.print('\n');
-      DEBUG_SERIAL.flush();
-  }
+  TimeMs tNow = transactionTime();
+  DEBUG_SERIAL.print(F("+XOD:"));
+  DEBUG_SERIAL.print(tNow);
+  DEBUG_SERIAL.print(':');
+  DEBUG_SERIAL.print(ctx);
+  DEBUG_SERIAL.print(':');
+  for (auto it = line->iterate(); it; ++it)
+      DEBUG_SERIAL.print((char)*it);
+  DEBUG_SERIAL.print('\r');
+  DEBUG_SERIAL.print('\n');
+  DEBUG_SERIAL.flush();
 }


### PR DESCRIPTION
Now it is a compile error to try to cast a string to bool.

P.S> We should really employ compilation tests in CI