### PR TITLE
Fix broken isInput check when copying

### DIFF
--- a/packages/xod-client/src/editor/actions.js
+++ b/packages/xod-client/src/editor/actions.js
@@ -303,7 +303,7 @@ const getClipboardEntities = (state) => {
 };
 
 export const copyEntities = event => (dispatch, getState) => {
-  if (isInput(event)) return;
+  if (isInput(document.activeElement)) return;
 
   const state = getState();
 


### PR DESCRIPTION
Closes #886

Looks like a regression after some rebase. 🤔
It was ok in #861
