### PR TITLE
Add nodes for DS1307 RTC reading and writing

### DIFF
--- a/docs/reference/supported-hardware/index.yaml
+++ b/docs/reference/supported-hardware/index.yaml
@@ -475,3 +475,29 @@
           sku: DFR0175
           flavor: Brk
           url: https://www.dfrobot.com/product-593.html
+
+- section: "Clock (RTC)"
+  parts:
+    - part: DS1307, DS1337, DS1338, DS3231
+      kind: Real Time Clock
+      vendor: Maxim
+      nodes:
+        - xod/common-hardware/ds1307-rtc-read
+        - xod/common-hardware/ds1307-rtc-write
+      shopping:
+        - shop: Adafruit
+          sku: "#3013"
+          flavor: Brk
+          url: https://www.adafruit.com/product/3013
+        - shop: Adafruit
+          sku: "#3296"
+          flavor: Brk
+          url: https://www.adafruit.com/product/3296
+        - shop: Seeed
+          sku: 101020013
+          flavor: Mod
+          url: https://www.seeedstudio.com/Grove-RTC-p-758.html
+        - shop: SparkFun
+          sku: BOB-12708
+          flavor: Brk
+          url: https://www.sparkfun.com/products/12708

--- a/workspace/__lib__/xod/bits/bcd-to-dec/patch.xodp
+++ b/workspace/__lib__/xod/bits/bcd-to-dec/patch.xodp
@@ -1,0 +1,130 @@
+{
+  "description": "Converts a packed binary coded decimal byte into a byte value in range [0, 99]",
+  "links": [
+    {
+      "id": "B1F1jOxgz",
+      "input": {
+        "nodeId": "S12C5_elM",
+        "pinKey": "SkUn_Olef"
+      },
+      "output": {
+        "nodeId": "B1OZ_uxlf",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "ByATcdexz",
+      "input": {
+        "nodeId": "SJJzOullz",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "B1d65uelM",
+        "pinKey": "SyomIRurDJ-"
+      }
+    },
+    {
+      "id": "HyjTcdggG",
+      "input": {
+        "nodeId": "B1d65uelM",
+        "pinKey": "BJnQUR_BwyZ"
+      },
+      "output": {
+        "nodeId": "BJ1p9dggf",
+        "pinKey": "BkQzLCurwJZ"
+      }
+    },
+    {
+      "id": "SyBTcdglG",
+      "input": {
+        "nodeId": "BJ1p9dggf",
+        "pinKey": "B1GfLR_SPk-"
+      },
+      "output": {
+        "nodeId": "rkojcOgxz",
+        "pinKey": "rJ2LddxlG"
+      }
+    },
+    {
+      "id": "rJbnqOlgz",
+      "input": {
+        "nodeId": "rkojcOgxz",
+        "pinKey": "rkXLOulgz"
+      },
+      "output": {
+        "nodeId": "B1OZ_uxlf",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "rkjJi_elz",
+      "input": {
+        "nodeId": "B1d65uelM",
+        "pinKey": "HkqmLAOrD1W"
+      },
+      "output": {
+        "nodeId": "S12C5_elM",
+        "pinKey": "S1YR_dgeG"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "id": "B1OZ_uxlf",
+      "position": {
+        "x": 34,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "B1d65uelM",
+      "position": {
+        "x": 102,
+        "y": 306
+      },
+      "type": "xod/core/add"
+    },
+    {
+      "boundValues": {
+        "SJ4zUC_BD1-": 10
+      },
+      "id": "BJ1p9dggf",
+      "position": {
+        "x": 34,
+        "y": 204
+      },
+      "type": "xod/core/multiply"
+    },
+    {
+      "boundValues": {
+        "ByjTuuxef": 15
+      },
+      "id": "S12C5_elM",
+      "position": {
+        "x": 136,
+        "y": 102
+      },
+      "type": "@/bitwise-and"
+    },
+    {
+      "id": "SJJzOullz",
+      "position": {
+        "x": 102,
+        "y": 408
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "boundValues": {
+        "BkvUuuleG": 4
+      },
+      "id": "rkojcOgxz",
+      "position": {
+        "x": 34,
+        "y": 102
+      },
+      "type": "@/shift-right"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/bits/bitwise-and/patch.cpp
+++ b/workspace/__lib__/xod/bits/bitwise-and/patch.cpp
@@ -1,0 +1,11 @@
+
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    uint8_t in1 = (uint8_t)getValue<input_IN1>(ctx);
+    uint8_t in2 = (uint8_t)getValue<input_IN2>(ctx);
+    emitValue<output_OUT>(ctx, in1 & in2);
+}

--- a/workspace/__lib__/xod/bits/bitwise-and/patch.xodp
+++ b/workspace/__lib__/xod/bits/bitwise-and/patch.xodp
@@ -1,0 +1,37 @@
+{
+  "description": "Computes bitwise AND of two bytes. A resulting bit at a particular position is 1 only if corresponding bits of inputs  are both 1.",
+  "nodes": [
+    {
+      "id": "ByjTuuxef",
+      "position": {
+        "x": 68,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "S1YR_dgeG",
+      "position": {
+        "x": 34,
+        "y": 306
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "S1_audxxf",
+      "position": {
+        "x": 34,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "id": "SkUn_Olef",
+      "position": {
+        "x": 34,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/input-number"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/bits/bitwise-not/patch.cpp
+++ b/workspace/__lib__/xod/bits/bitwise-not/patch.cpp
@@ -1,0 +1,10 @@
+
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    uint8_t x = (uint8_t)getValue<input_IN>(ctx);
+    emitValue<output_OUT>(ctx, ~x);
+}

--- a/workspace/__lib__/xod/bits/bitwise-not/patch.xodp
+++ b/workspace/__lib__/xod/bits/bitwise-not/patch.xodp
@@ -1,0 +1,29 @@
+{
+  "description": "Computes bitwise NOT of a byte. Also known as complement. A resulting bit at a particular position is 1 when input bit at the same position is 0, and vice versa.",
+  "nodes": [
+    {
+      "id": "Hk--zap-lf",
+      "position": {
+        "x": -1,
+        "y": 101
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "id": "SJzZfTTWgG",
+      "position": {
+        "x": -1,
+        "y": -1
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "rkgbMp6-lf",
+      "position": {
+        "x": -1,
+        "y": 203
+      },
+      "type": "xod/patch-nodes/output-number"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/bits/bitwise-or/patch.cpp
+++ b/workspace/__lib__/xod/bits/bitwise-or/patch.cpp
@@ -1,0 +1,11 @@
+
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    uint8_t in1 = (uint8_t)getValue<input_IN1>(ctx);
+    uint8_t in2 = (uint8_t)getValue<input_IN2>(ctx);
+    emitValue<output_OUT>(ctx, in1 | in2);
+}

--- a/workspace/__lib__/xod/bits/bitwise-or/patch.xodp
+++ b/workspace/__lib__/xod/bits/bitwise-or/patch.xodp
@@ -1,0 +1,37 @@
+{
+  "description": "Computes bitwise OR of two bytes. A resulting bit at a particular position is 0 only if corresponding bits of inputs  are both 0.",
+  "nodes": [
+    {
+      "id": "SkC1aTZeM",
+      "position": {
+        "x": 33,
+        "y": -1
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "r1-RyaTblz",
+      "position": {
+        "x": -1,
+        "y": 101
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "id": "r1zA16pbxM",
+      "position": {
+        "x": -1,
+        "y": -1
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "rkgRyT6beM",
+      "position": {
+        "x": -1,
+        "y": 203
+      },
+      "type": "xod/patch-nodes/output-number"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/bits/bitwise-xor/patch.cpp
+++ b/workspace/__lib__/xod/bits/bitwise-xor/patch.cpp
@@ -1,0 +1,11 @@
+
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    uint8_t in1 = (uint8_t)getValue<input_IN1>(ctx);
+    uint8_t in2 = (uint8_t)getValue<input_IN2>(ctx);
+    emitValue<output_OUT>(ctx, in1 ^ in2);
+}

--- a/workspace/__lib__/xod/bits/bitwise-xor/patch.xodp
+++ b/workspace/__lib__/xod/bits/bitwise-xor/patch.xodp
@@ -1,0 +1,37 @@
+{
+  "description": "Computes bitwise XOR of two bytes. A resulting bit at a particular position is 1 only if either of corresponding bits of inputs is 1 and another is 0.",
+  "nodes": [
+    {
+      "id": "BkbqIa6ZgM",
+      "position": {
+        "x": -1,
+        "y": 101
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "id": "HJe5Upp-eM",
+      "position": {
+        "x": -1,
+        "y": 203
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "SJq8pTZeM",
+      "position": {
+        "x": 33,
+        "y": -1
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "r1z9LT6ZeM",
+      "position": {
+        "x": -1,
+        "y": -1
+      },
+      "type": "xod/patch-nodes/input-number"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/bits/dec-to-bcd/patch.xodp
+++ b/workspace/__lib__/xod/bits/dec-to-bcd/patch.xodp
@@ -1,0 +1,149 @@
+{
+  "description": "Converts a byte value in range [0, 99] into a packed binary coded decimal byte",
+  "links": [
+    {
+      "id": "BJ5Cw2Wgf",
+      "input": {
+        "nodeId": "rJvRD3WeG",
+        "pinKey": "SkdIRuBD1b"
+      },
+      "output": {
+        "nodeId": "H12cvhZeG",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "ByIfd3Zez",
+      "input": {
+        "nodeId": "HkXfO3bef",
+        "pinKey": "HkjNO_xxz"
+      },
+      "output": {
+        "nodeId": "B1Axu3Wxf",
+        "pinKey": "rkWeUCdBDkZ"
+      }
+    },
+    {
+      "id": "H1dyQ0WxG",
+      "input": {
+        "nodeId": "B1gyXAWlz",
+        "pinKey": "r1zA16pbxM"
+      },
+      "output": {
+        "nodeId": "HkXfO3bef",
+        "pinKey": "SkEHO_lef"
+      }
+    },
+    {
+      "id": "HJeW_3bgf",
+      "input": {
+        "nodeId": "B1Axu3Wxf",
+        "pinKey": "SklxICdHP1b"
+      },
+      "output": {
+        "nodeId": "rJvRD3WeG",
+        "pinKey": "BkqLCOSw1W"
+      }
+    },
+    {
+      "id": "SkX6vhWlf",
+      "input": {
+        "nodeId": "Hy9hPhWxG",
+        "pinKey": "ryKV8d_1f"
+      },
+      "output": {
+        "nodeId": "H12cvhZeG",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "Sksk70WgM",
+      "input": {
+        "nodeId": "B1gyXAWlz",
+        "pinKey": "SkC1aTZeM"
+      },
+      "output": {
+        "nodeId": "Hy9hPhWxG",
+        "pinKey": "Hku_LuOyz"
+      }
+    },
+    {
+      "id": "rkt1mRbxf",
+      "input": {
+        "nodeId": "S1TsDnbgM",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "B1gyXAWlz",
+        "pinKey": "rkgRyT6beM"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "id": "B1Axu3Wxf",
+      "position": {
+        "x": 34,
+        "y": 204
+      },
+      "type": "xod/core/floor"
+    },
+    {
+      "id": "B1gyXAWlz",
+      "position": {
+        "x": 68,
+        "y": 408
+      },
+      "type": "@/bitwise-or"
+    },
+    {
+      "id": "H12cvhZeG",
+      "position": {
+        "x": 34,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "boundValues": {
+        "HylHuulxf": 4
+      },
+      "id": "HkXfO3bef",
+      "position": {
+        "x": 34,
+        "y": 306
+      },
+      "type": "@/shift-left"
+    },
+    {
+      "boundValues": {
+        "BJvrLOuyz": 10
+      },
+      "id": "Hy9hPhWxG",
+      "position": {
+        "x": 102,
+        "y": 102
+      },
+      "type": "xod/core/modulo"
+    },
+    {
+      "id": "S1TsDnbgM",
+      "position": {
+        "x": 68,
+        "y": 510
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "boundValues": {
+        "BytUCdHD1-": 10
+      },
+      "id": "rJvRD3WeG",
+      "position": {
+        "x": 34,
+        "y": 102
+      },
+      "type": "xod/core/divide"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/bits/project.xod
+++ b/workspace/__lib__/xod/bits/project.xod
@@ -1,0 +1,9 @@
+{
+  "authors": [
+    "XOD"
+  ],
+  "description": "Low-level bits and bytes operations",
+  "license": "AGPL-3.0",
+  "name": "bits",
+  "version": "0.15.1"
+}

--- a/workspace/__lib__/xod/bits/shift-left/patch.cpp
+++ b/workspace/__lib__/xod/bits/shift-left/patch.cpp
@@ -1,0 +1,11 @@
+
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    uint8_t x = (uint8_t)getValue<input_BYTE>(ctx);
+    uint8_t n = (uint8_t)getValue<input_N>(ctx);
+    emitValue<output_OUT>(ctx, x << n);
+}

--- a/workspace/__lib__/xod/bits/shift-left/patch.xodp
+++ b/workspace/__lib__/xod/bits/shift-left/patch.xodp
@@ -1,0 +1,39 @@
+{
+  "description": "Performs logical left-shift of `BYTE` by `N` bits.",
+  "nodes": [
+    {
+      "id": "HkjNO_xxz",
+      "label": "BYTE",
+      "position": {
+        "x": 34,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "HylHuulxf",
+      "label": "N",
+      "position": {
+        "x": 68,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "SkEHO_lef",
+      "position": {
+        "x": 34,
+        "y": 306
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "SygauOggG",
+      "position": {
+        "x": 34,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/bits/shift-right/patch.cpp
+++ b/workspace/__lib__/xod/bits/shift-right/patch.cpp
@@ -1,0 +1,11 @@
+
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    uint8_t x = (uint8_t)getValue<input_BYTE>(ctx);
+    uint8_t n = (uint8_t)getValue<input_N>(ctx);
+    emitValue<output_OUT>(ctx, x >> n);
+}

--- a/workspace/__lib__/xod/bits/shift-right/patch.xodp
+++ b/workspace/__lib__/xod/bits/shift-right/patch.xodp
@@ -1,0 +1,39 @@
+{
+  "description": "Performs logical right-shift of `BYTE` by `N` bits. Sign bit is not copied.",
+  "nodes": [
+    {
+      "id": "BkvUuuleG",
+      "label": "N",
+      "position": {
+        "x": 68,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "HyV6_ugef",
+      "position": {
+        "x": 34,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "id": "rJ2LddxlG",
+      "position": {
+        "x": 34,
+        "y": 306
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "rkXLOulgz",
+      "label": "BYTE",
+      "position": {
+        "x": 34,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/input-number"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/common-hardware/ds1307-rtc-read/patch.xodp
+++ b/workspace/__lib__/xod/common-hardware/ds1307-rtc-read/patch.xodp
@@ -1,0 +1,618 @@
+{
+  "description": "Reads a date/time value from a DS1307, DS1337, DS1338, or DS3231real-time clock IC",
+  "links": [
+    {
+      "id": "B1b_ZtgxM",
+      "input": {
+        "nodeId": "Bkepv-tlef",
+        "pinKey": "B1OZ_uxlf"
+      },
+      "output": {
+        "nodeId": "Hy2QFOlgM",
+        "pinKey": "S1YR_dgeG"
+      }
+    },
+    {
+      "id": "BJDeUOelz",
+      "input": {
+        "nodeId": "HJXx8dgxf",
+        "pinKey": "SkylK_Ed-"
+      },
+      "output": {
+        "nodeId": "SyXRHdelG",
+        "pinKey": "Sk7BudNdZ"
+      }
+    },
+    {
+      "id": "BJbpHdgez",
+      "input": {
+        "nodeId": "HJRnrulxG",
+        "pinKey": "S1dKPuVdW"
+      },
+      "output": {
+        "nodeId": "BkrqBdlef",
+        "pinKey": "HJbjB_Nd-"
+      }
+    },
+    {
+      "id": "BkPZwdgez",
+      "input": {
+        "nodeId": "S1wevuxlz",
+        "pinKey": "SkylK_Ed-"
+      },
+      "output": {
+        "nodeId": "ByeWI_llM",
+        "pinKey": "rypZF_Nub"
+      }
+    },
+    {
+      "id": "BkZXbTGgG",
+      "input": {
+        "nodeId": "SJdz-pMlz",
+        "pinKey": "BJnQUR_BwyZ"
+      },
+      "output": {
+        "nodeId": "Sym8WYlgG",
+        "pinKey": "SJJzOullz"
+      }
+    },
+    {
+      "id": "ByNcWYggG",
+      "input": {
+        "nodeId": "Sym8WYlgG",
+        "pinKey": "B1OZ_uxlf"
+      },
+      "output": {
+        "nodeId": "S1ngP_xxM",
+        "pinKey": "SkplYdVO-"
+      }
+    },
+    {
+      "id": "ByO8FOlgz",
+      "input": {
+        "nodeId": "rJHIt_geG",
+        "pinKey": "SkUn_Olef"
+      },
+      "output": {
+        "nodeId": "S1wevuxlz",
+        "pinKey": "SkplYdVO-"
+      }
+    },
+    {
+      "id": "H196rdglf",
+      "input": {
+        "nodeId": "SyuaBOxlM",
+        "pinKey": "Sk2oU_Vdb"
+      },
+      "output": {
+        "nodeId": "HJRnrulxG",
+        "pinKey": "SJB3vO4uZ"
+      }
+    },
+    {
+      "id": "H1CAHOgxG",
+      "input": {
+        "nodeId": "SyXRHdelG",
+        "pinKey": "B1Eb_dVuW"
+      },
+      "output": {
+        "nodeId": "r1MmSdlgM",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "H1NKWKlxM",
+      "input": {
+        "nodeId": "Hy-_00Olgf",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "B1nP-Kxgz",
+        "pinKey": "SJJzOullz"
+      }
+    },
+    {
+      "id": "H1xiSOgez",
+      "input": {
+        "nodeId": "BkrqBdlef",
+        "pinKey": "BJfKruVdb"
+      },
+      "output": {
+        "nodeId": "r1o7Hdlgf",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HJiZvuleM",
+      "input": {
+        "nodeId": "ByqeDOxxf",
+        "pinKey": "SkylK_Ed-"
+      },
+      "output": {
+        "nodeId": "HJtxwuxeG",
+        "pinKey": "rypZF_Nub"
+      }
+    },
+    {
+      "id": "HJkc-txgM",
+      "input": {
+        "nodeId": "rJiSSuxlf",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "ByqDbYexz",
+        "pinKey": "SJJzOullz"
+      }
+    },
+    {
+      "id": "Hk8dZYxlz",
+      "input": {
+        "nodeId": "S16DbKeeG",
+        "pinKey": "B1OZ_uxlf"
+      },
+      "output": {
+        "nodeId": "ByeWI_llM",
+        "pinKey": "SkplYdVO-"
+      }
+    },
+    {
+      "id": "HkTY-tlxz",
+      "input": {
+        "nodeId": "BJ9Y-Yxez",
+        "pinKey": "B1OZ_uxlf"
+      },
+      "output": {
+        "nodeId": "ByqeDOxxf",
+        "pinKey": "SkplYdVO-"
+      }
+    },
+    {
+      "id": "Hy50rOxgM",
+      "input": {
+        "nodeId": "SyXRHdelG",
+        "pinKey": "SJjmdOVOW"
+      },
+      "output": {
+        "nodeId": "SyuaBOxlM",
+        "pinKey": "ryviw_EOb"
+      }
+    },
+    {
+      "id": "HyGQZaMef",
+      "input": {
+        "nodeId": "B1mHrOxxG",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "SJdz-pMlz",
+        "pinKey": "SyomIRurDJ-"
+      }
+    },
+    {
+      "id": "HypZDuxxz",
+      "input": {
+        "nodeId": "S1ngP_xxM",
+        "pinKey": "SkylK_Ed-"
+      },
+      "output": {
+        "nodeId": "ByqeDOxxf",
+        "pinKey": "rypZF_Nub"
+      }
+    },
+    {
+      "id": "S1W5WKlxf",
+      "input": {
+        "nodeId": "BkcHSuxxM",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "BJ9Y-Yxez",
+        "pinKey": "SJJzOullz"
+      }
+    },
+    {
+      "id": "SJTRCulxf",
+      "input": {
+        "nodeId": "HJtxwuxeG",
+        "pinKey": "SkylK_Ed-"
+      },
+      "output": {
+        "nodeId": "rJguRC_ggG",
+        "pinKey": "rypZF_Nub"
+      }
+    },
+    {
+      "id": "SyC0Cuxxz",
+      "input": {
+        "nodeId": "rJguRC_ggG",
+        "pinKey": "SkylK_Ed-"
+      },
+      "output": {
+        "nodeId": "S1wevuxlz",
+        "pinKey": "rypZF_Nub"
+      }
+    },
+    {
+      "id": "Sye4FdggG",
+      "input": {
+        "nodeId": "Hy2QFOlgM",
+        "pinKey": "SkUn_Olef"
+      },
+      "output": {
+        "nodeId": "HJXx8dgxf",
+        "pinKey": "SkplYdVO-"
+      }
+    },
+    {
+      "id": "SyzO-tggG",
+      "input": {
+        "nodeId": "r1THSOxeG",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "Bkepv-tlef",
+        "pinKey": "SJJzOullz"
+      }
+    },
+    {
+      "id": "r1T_ZFglz",
+      "input": {
+        "nodeId": "rJ2SBOlez",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "rkenwbYggM",
+        "pinKey": "SJJzOullz"
+      }
+    },
+    {
+      "id": "r1n_btgeG",
+      "input": {
+        "nodeId": "rkenwbYggM",
+        "pinKey": "B1OZ_uxlf"
+      },
+      "output": {
+        "nodeId": "rJHIt_geG",
+        "pinKey": "S1YR_dgeG"
+      }
+    },
+    {
+      "id": "r1uubFlxM",
+      "input": {
+        "nodeId": "HJl3HHOgxf",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "S16DbKeeG",
+        "pinKey": "SJJzOullz"
+      }
+    },
+    {
+      "id": "ry8ZL_xxf",
+      "input": {
+        "nodeId": "ByeWI_llM",
+        "pinKey": "SkylK_Ed-"
+      },
+      "output": {
+        "nodeId": "HJXx8dgxf",
+        "pinKey": "rypZF_Nub"
+      }
+    },
+    {
+      "id": "ryWKZtlgG",
+      "input": {
+        "nodeId": "B1nP-Kxgz",
+        "pinKey": "B1OZ_uxlf"
+      },
+      "output": {
+        "nodeId": "rJguRC_ggG",
+        "pinKey": "SkplYdVO-"
+      }
+    },
+    {
+      "id": "ryicSOelG",
+      "input": {
+        "nodeId": "BkrqBdlef",
+        "pinKey": "HkLOB_EuZ"
+      },
+      "output": {
+        "nodeId": "r1MmSdlgM",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "ryvY-KggM",
+      "input": {
+        "nodeId": "ByqDbYexz",
+        "pinKey": "B1OZ_uxlf"
+      },
+      "output": {
+        "nodeId": "HJtxwuxeG",
+        "pinKey": "SkplYdVO-"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "description": "Year value in [2000, 2099] range",
+      "id": "B1mHrOxxG",
+      "label": "YEAR",
+      "position": {
+        "x": -68,
+        "y": 1020
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "B1nP-Kxgz",
+      "position": {
+        "x": 238,
+        "y": 816
+      },
+      "type": "xod/bits/bcd-to-dec"
+    },
+    {
+      "id": "BJ9Y-Yxez",
+      "position": {
+        "x": 34,
+        "y": 816
+      },
+      "type": "xod/bits/bcd-to-dec"
+    },
+    {
+      "description": "Month value in [1, 12] range",
+      "id": "BkcHSuxxM",
+      "label": "MO",
+      "position": {
+        "x": 34,
+        "y": 1020
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "Bkepv-tlef",
+      "position": {
+        "x": 544,
+        "y": 816
+      },
+      "type": "xod/bits/bcd-to-dec"
+    },
+    {
+      "id": "BkrqBdlef",
+      "position": {
+        "x": 680,
+        "y": 204
+      },
+      "type": "xod/core/i2c-begin-transmission"
+    },
+    {
+      "id": "ByeWI_llM",
+      "position": {
+        "x": 442,
+        "y": 612
+      },
+      "type": "xod/core/i2c-read"
+    },
+    {
+      "id": "ByqDbYexz",
+      "position": {
+        "x": 136,
+        "y": 816
+      },
+      "type": "xod/bits/bcd-to-dec"
+    },
+    {
+      "id": "ByqeDOxxf",
+      "position": {
+        "x": 34,
+        "y": 612
+      },
+      "type": "xod/core/i2c-read"
+    },
+    {
+      "id": "HJRnrulxG",
+      "position": {
+        "x": 646,
+        "y": 306
+      },
+      "type": "xod/core/i2c-write"
+    },
+    {
+      "boundValues": {
+        "HyEhduNuZ": 0
+      },
+      "id": "HJXx8dgxf",
+      "position": {
+        "x": 544,
+        "y": 612
+      },
+      "type": "xod/core/i2c-read"
+    },
+    {
+      "description": "Minutes value in range [0, 59]",
+      "id": "HJl3HHOgxf",
+      "label": "MIN",
+      "position": {
+        "x": 442,
+        "y": 1020
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "HJtxwuxeG",
+      "position": {
+        "x": 136,
+        "y": 612
+      },
+      "type": "xod/core/i2c-read"
+    },
+    {
+      "description": "Week day value in range [1, 7]",
+      "id": "Hy-_00Olgf",
+      "label": "WD",
+      "position": {
+        "x": 238,
+        "y": 1020
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "boundValues": {
+        "ByjTuuxef": 127
+      },
+      "description": "MSB is a control bit",
+      "id": "Hy2QFOlgM",
+      "position": {
+        "x": 544,
+        "y": 714
+      },
+      "type": "xod/bits/bitwise-and"
+    },
+    {
+      "id": "S16DbKeeG",
+      "position": {
+        "x": 442,
+        "y": 816
+      },
+      "type": "xod/bits/bcd-to-dec"
+    },
+    {
+      "id": "S1ngP_xxM",
+      "position": {
+        "x": -68,
+        "y": 612
+      },
+      "type": "xod/core/i2c-read"
+    },
+    {
+      "id": "S1wevuxlz",
+      "position": {
+        "x": 340,
+        "y": 612
+      },
+      "type": "xod/core/i2c-read"
+    },
+    {
+      "boundValues": {
+        "HkqmLAOrD1W": 2000
+      },
+      "id": "SJdz-pMlz",
+      "position": {
+        "x": -68,
+        "y": 918
+      },
+      "type": "xod/core/add"
+    },
+    {
+      "boundValues": {
+        "Hk3Wdu4dZ": 7
+      },
+      "id": "SyXRHdelG",
+      "position": {
+        "x": 578,
+        "y": 510
+      },
+      "type": "xod/core/i2c-request"
+    },
+    {
+      "id": "Sym8WYlgG",
+      "position": {
+        "x": -68,
+        "y": 816
+      },
+      "type": "xod/bits/bcd-to-dec"
+    },
+    {
+      "id": "SyuaBOxlM",
+      "position": {
+        "x": 646,
+        "y": 408
+      },
+      "type": "xod/core/i2c-end-transmission"
+    },
+    {
+      "boundValues": {
+        "__out__": 104
+      },
+      "description": "I²C address of the IC",
+      "id": "r1MmSdlgM",
+      "label": "ADDR",
+      "position": {
+        "x": 578,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "description": "Seconds value in range [0, 59]",
+      "id": "r1THSOxeG",
+      "label": "SEC",
+      "position": {
+        "x": 544,
+        "y": 1020
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "boundValues": {
+        "__out__": "CONTINUOUSLY"
+      },
+      "description": "Triggers a new reading, i.e. date/time values update",
+      "id": "r1o7Hdlgf",
+      "label": "UPD",
+      "position": {
+        "x": 714,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "description": "Hours value in range [0, 23]",
+      "id": "rJ2SBOlez",
+      "label": "HOUR",
+      "position": {
+        "x": 340,
+        "y": 1020
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "boundValues": {
+        "ByjTuuxef": 63
+      },
+      "description": "MSB are control bits",
+      "id": "rJHIt_geG",
+      "position": {
+        "x": 340,
+        "y": 714
+      },
+      "type": "xod/bits/bitwise-and"
+    },
+    {
+      "id": "rJguRC_ggG",
+      "position": {
+        "x": 238,
+        "y": 612
+      },
+      "type": "xod/core/i2c-read"
+    },
+    {
+      "description": "Day value in range [1, 31]",
+      "id": "rJiSSuxlf",
+      "label": "DAY",
+      "position": {
+        "x": 136,
+        "y": 1020
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "rkenwbYggM",
+      "position": {
+        "x": 340,
+        "y": 816
+      },
+      "type": "xod/bits/bcd-to-dec"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/common-hardware/ds1307-rtc-write/patch.xodp
+++ b/workspace/__lib__/xod/common-hardware/ds1307-rtc-write/patch.xodp
@@ -1,0 +1,567 @@
+{
+  "description": "Writes a new date/time value to a DS1307, DS1337, DS1338, or DS3231 real-time clock IC. Useful as a throw-away node to setup the RTC once after you install a backup battery.",
+  "links": [
+    {
+      "id": "B1HFUnZgf",
+      "input": {
+        "nodeId": "HkMt83-xG",
+        "pinKey": "HkLOB_EuZ"
+      },
+      "output": {
+        "nodeId": "B1ENIh-eM",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "BJkIbTGxM",
+      "input": {
+        "nodeId": "r1UrbTzlf",
+        "pinKey": "ryKV8d_1f"
+      },
+      "output": {
+        "nodeId": "H1WQ8hZlf",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "Bk-CK3Zxf",
+      "input": {
+        "nodeId": "rJlHkD3Zgf",
+        "pinKey": "H1jODuEOW"
+      },
+      "output": {
+        "nodeId": "BJTpKhbeM",
+        "pinKey": "S1TsDnbgM"
+      }
+    },
+    {
+      "id": "Bk1ND2-xf",
+      "input": {
+        "nodeId": "BywsI3-lz",
+        "pinKey": "Sk2oU_Vdb"
+      },
+      "output": {
+        "nodeId": "HJWkD2-xG",
+        "pinKey": "SJB3vO4uZ"
+      }
+    },
+    {
+      "id": "Bk6wqhWlG",
+      "input": {
+        "nodeId": "Hy3RF2Zef",
+        "pinKey": "H12cvhZeG"
+      },
+      "output": {
+        "nodeId": "r1nQLhbez",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "H17Zwnblf",
+      "input": {
+        "nodeId": "HyVJP3bez",
+        "pinKey": "S1dKPuVdW"
+      },
+      "output": {
+        "nodeId": "SyryPhWgz",
+        "pinKey": "SJB3vO4uZ"
+      }
+    },
+    {
+      "id": "H1UWw2Zgf",
+      "input": {
+        "nodeId": "r1QyD2WgG",
+        "pinKey": "S1dKPuVdW"
+      },
+      "output": {
+        "nodeId": "B1eXyv2Zlf",
+        "pinKey": "SJB3vO4uZ"
+      }
+    },
+    {
+      "id": "H1W8Zazlz",
+      "input": {
+        "nodeId": "HJiJ9hbez",
+        "pinKey": "H12cvhZeG"
+      },
+      "output": {
+        "nodeId": "r1UrbTzlf",
+        "pinKey": "Hku_LuOyz"
+      }
+    },
+    {
+      "id": "H1Z_93WeM",
+      "input": {
+        "nodeId": "BJTpKhbeM",
+        "pinKey": "H12cvhZeG"
+      },
+      "output": {
+        "nodeId": "Hk678nbeG",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HJuWw3bef",
+      "input": {
+        "nodeId": "rJM1Dnbgz",
+        "pinKey": "S1dKPuVdW"
+      },
+      "output": {
+        "nodeId": "r1QyD2WgG",
+        "pinKey": "SJB3vO4uZ"
+      }
+    },
+    {
+      "id": "Hk_K82Zgf",
+      "input": {
+        "nodeId": "HkMt83-xG",
+        "pinKey": "BJfKruVdb"
+      },
+      "output": {
+        "nodeId": "B1h8InZgz",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HkeZw3-lG",
+      "input": {
+        "nodeId": "rJlHkD3Zgf",
+        "pinKey": "S1dKPuVdW"
+      },
+      "output": {
+        "nodeId": "SyupI2ZeM",
+        "pinKey": "SJB3vO4uZ"
+      }
+    },
+    {
+      "id": "S1Bm9hWxf",
+      "input": {
+        "nodeId": "HJWkD2-xG",
+        "pinKey": "H1jODuEOW"
+      },
+      "output": {
+        "nodeId": "HJiJ9hbez",
+        "pinKey": "S1TsDnbgM"
+      }
+    },
+    {
+      "id": "S1KLch-lf",
+      "input": {
+        "nodeId": "rkv1ch-eM",
+        "pinKey": "H12cvhZeG"
+      },
+      "output": {
+        "nodeId": "S1EQU3-lz",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "SJhLcn-lz",
+      "input": {
+        "nodeId": "ByEJc3ZlG",
+        "pinKey": "H12cvhZeG"
+      },
+      "output": {
+        "nodeId": "r1SQLh-gf",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "SJzWv3WgM",
+      "input": {
+        "nodeId": "SyryPhWgz",
+        "pinKey": "S1dKPuVdW"
+      },
+      "output": {
+        "nodeId": "rJlHkD3Zgf",
+        "pinKey": "SJB3vO4uZ"
+      }
+    },
+    {
+      "id": "Sk9ZwhbeG",
+      "input": {
+        "nodeId": "HJWkD2-xG",
+        "pinKey": "S1dKPuVdW"
+      },
+      "output": {
+        "nodeId": "rJM1Dnbgz",
+        "pinKey": "SJB3vO4uZ"
+      }
+    },
+    {
+      "id": "SknpI2blf",
+      "input": {
+        "nodeId": "SyupI2ZeM",
+        "pinKey": "S1dKPuVdW"
+      },
+      "output": {
+        "nodeId": "HkMt83-xG",
+        "pinKey": "HJbjB_Nd-"
+      }
+    },
+    {
+      "id": "SkwP9nbgz",
+      "input": {
+        "nodeId": "r1-1chZlG",
+        "pinKey": "H12cvhZeG"
+      },
+      "output": {
+        "nodeId": "SydXI2Wxz",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "r1BWw3Zxf",
+      "input": {
+        "nodeId": "B1eXyv2Zlf",
+        "pinKey": "S1dKPuVdW"
+      },
+      "output": {
+        "nodeId": "HyVJP3bez",
+        "pinKey": "SJB3vO4uZ"
+      }
+    },
+    {
+      "id": "r1CL5n-eM",
+      "input": {
+        "nodeId": "r1QyD2WgG",
+        "pinKey": "H1jODuEOW"
+      },
+      "output": {
+        "nodeId": "ByEJc3ZlG",
+        "pinKey": "S1TsDnbgM"
+      }
+    },
+    {
+      "id": "r1jI5hWeG",
+      "input": {
+        "nodeId": "rJM1Dnbgz",
+        "pinKey": "H1jODuEOW"
+      },
+      "output": {
+        "nodeId": "rkv1ch-eM",
+        "pinKey": "S1TsDnbgM"
+      }
+    },
+    {
+      "id": "r1jwcnZgz",
+      "input": {
+        "nodeId": "HyVJP3bez",
+        "pinKey": "H1jODuEOW"
+      },
+      "output": {
+        "nodeId": "HyRRF2ZgG",
+        "pinKey": "S1TsDnbgM"
+      }
+    },
+    {
+      "id": "ryOwchWgf",
+      "input": {
+        "nodeId": "B1eXyv2Zlf",
+        "pinKey": "H1jODuEOW"
+      },
+      "output": {
+        "nodeId": "r1-1chZlG",
+        "pinKey": "S1TsDnbgM"
+      }
+    },
+    {
+      "id": "ryhn82Zez",
+      "input": {
+        "nodeId": "SkH2Ih-ef",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "BywsI3-lz",
+        "pinKey": "ryviw_EOb"
+      }
+    },
+    {
+      "id": "ryk_chWxf",
+      "input": {
+        "nodeId": "SyryPhWgz",
+        "pinKey": "H1jODuEOW"
+      },
+      "output": {
+        "nodeId": "Hy3RF2Zef",
+        "pinKey": "S1TsDnbgM"
+      }
+    },
+    {
+      "id": "rytDqh-xM",
+      "input": {
+        "nodeId": "HyRRF2ZgG",
+        "pinKey": "H12cvhZeG"
+      },
+      "output": {
+        "nodeId": "SyjmLn-lz",
+        "pinKey": "__out__"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "boundValues": {
+        "__out__": 104
+      },
+      "description": "I²C address of the IC",
+      "id": "B1ENIh-eM",
+      "label": "ADDR",
+      "position": {
+        "x": 408,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "B1eXyv2Zlf",
+      "position": {
+        "x": -34,
+        "y": 306
+      },
+      "type": "xod/core/i2c-write"
+    },
+    {
+      "boundValues": {
+        "__out__": "ON_BOOT"
+      },
+      "description": "Trigger a new write of the date/time data provided",
+      "id": "B1h8InZgz",
+      "label": "W",
+      "position": {
+        "x": 442,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "id": "BJTpKhbeM",
+      "position": {
+        "x": 272,
+        "y": 204
+      },
+      "type": "xod/bits/dec-to-bcd"
+    },
+    {
+      "id": "ByEJc3ZlG",
+      "position": {
+        "x": -136,
+        "y": 204
+      },
+      "type": "xod/bits/dec-to-bcd"
+    },
+    {
+      "id": "BywsI3-lz",
+      "position": {
+        "x": -340,
+        "y": 408
+      },
+      "type": "xod/core/i2c-end-transmission"
+    },
+    {
+      "description": "Year value in [2000, 2099] range",
+      "id": "H1WQ8hZlf",
+      "label": "YEAR",
+      "position": {
+        "x": -340,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "HJWkD2-xG",
+      "position": {
+        "x": -340,
+        "y": 306
+      },
+      "type": "xod/core/i2c-write"
+    },
+    {
+      "id": "HJiJ9hbez",
+      "position": {
+        "x": -340,
+        "y": 204
+      },
+      "type": "xod/bits/dec-to-bcd"
+    },
+    {
+      "description": "Seconds value in range [0, 59]",
+      "id": "Hk678nbeG",
+      "label": "SEC",
+      "position": {
+        "x": 272,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "HkMt83-xG",
+      "position": {
+        "x": 408,
+        "y": 204
+      },
+      "type": "xod/core/i2c-begin-transmission"
+    },
+    {
+      "id": "Hy3RF2Zef",
+      "position": {
+        "x": 170,
+        "y": 204
+      },
+      "type": "xod/bits/dec-to-bcd"
+    },
+    {
+      "id": "HyRRF2ZgG",
+      "position": {
+        "x": 68,
+        "y": 204
+      },
+      "type": "xod/bits/dec-to-bcd"
+    },
+    {
+      "id": "HyVJP3bez",
+      "position": {
+        "x": 68,
+        "y": 306
+      },
+      "type": "xod/core/i2c-write"
+    },
+    {
+      "boundValues": {
+        "__out__": 1
+      },
+      "description": "Month value in [1, 12] range",
+      "id": "S1EQU3-lz",
+      "label": "MO",
+      "position": {
+        "x": -238,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "description": "Pulses when the write is done",
+      "id": "SkH2Ih-ef",
+      "label": "DONE",
+      "position": {
+        "x": -340,
+        "y": 510
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "boundValues": {
+        "__out__": 1
+      },
+      "description": "Week day value in range [1, 7]",
+      "id": "SydXI2Wxz",
+      "label": "WD",
+      "position": {
+        "x": -34,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "description": "Hours value in range [0, 23]",
+      "id": "SyjmLn-lz",
+      "label": "HOUR",
+      "position": {
+        "x": 68,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "SyryPhWgz",
+      "position": {
+        "x": 170,
+        "y": 306
+      },
+      "type": "xod/core/i2c-write"
+    },
+    {
+      "description": "Starting register address",
+      "id": "SyupI2ZeM",
+      "position": {
+        "x": 374,
+        "y": 306
+      },
+      "type": "xod/core/i2c-write"
+    },
+    {
+      "id": "r1-1chZlG",
+      "position": {
+        "x": -34,
+        "y": 204
+      },
+      "type": "xod/bits/dec-to-bcd"
+    },
+    {
+      "id": "r1QyD2WgG",
+      "position": {
+        "x": -136,
+        "y": 306
+      },
+      "type": "xod/core/i2c-write"
+    },
+    {
+      "boundValues": {
+        "__out__": 1
+      },
+      "description": "Day value. Valid range depends on month and can be [1, 28-31].",
+      "id": "r1SQLh-gf",
+      "label": "DAY",
+      "position": {
+        "x": -136,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "boundValues": {
+        "BJvrLOuyz": 100
+      },
+      "id": "r1UrbTzlf",
+      "position": {
+        "x": -340,
+        "y": 102
+      },
+      "type": "xod/core/modulo"
+    },
+    {
+      "description": "Minutes value in range [0, 59]",
+      "id": "r1nQLhbez",
+      "label": "MIN",
+      "position": {
+        "x": 170,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "rJM1Dnbgz",
+      "position": {
+        "x": -238,
+        "y": 306
+      },
+      "type": "xod/core/i2c-write"
+    },
+    {
+      "id": "rJlHkD3Zgf",
+      "position": {
+        "x": 272,
+        "y": 306
+      },
+      "type": "xod/core/i2c-write"
+    },
+    {
+      "id": "rkv1ch-eM",
+      "position": {
+        "x": -238,
+        "y": 204
+      },
+      "type": "xod/bits/dec-to-bcd"
+    }
+  ]
+}


### PR DESCRIPTION
The PR brings support for popular real-time clock ICs: DS1307 and compatible.

To implement register encoding and decoding, low-level bitwise operations were required. So a new `xod/bits` library was implemented.