### PR TITLE
Fix sd-log node: append, not overwrite; noop without a pulse

### DIFF
--- a/workspace/__lib__/xod/common-hardware/sd-log/patch.cpp
+++ b/workspace/__lib__/xod/common-hardware/sd-log/patch.cpp
@@ -30,7 +30,7 @@ void evaluate(Context ctx) {
 
     char filename[16] = { 0 };
     dump(getValue<input_FILE>(ctx), filename);
-    File file = SD.open(filename, FILE_WRITE);
+    File file = SD.open(filename, O_WRITE | O_CREAT | O_APPEND);
     if (!file) {
         // Failed to open the file. Maybe, SD card gone,
         // try to reinit next time

--- a/workspace/__lib__/xod/common-hardware/sd-log/patch.cpp
+++ b/workspace/__lib__/xod/common-hardware/sd-log/patch.cpp
@@ -11,6 +11,9 @@ struct State {
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
+    if (!isInputDirty<input_W>(ctx))
+        return;
+
     auto state = getState(ctx);
 
     if (!state->begun) {


### PR DESCRIPTION
That what happens if not tested properly on real tasks.

An attempt to make a simple SD logger exposed two very silly bugs.