### PR TITLE
Fix code generation when native patches implemented locally

### DIFF
--- a/packages/xod-arduino/src/transpiler.js
+++ b/packages/xod-arduino/src/transpiler.js
@@ -38,17 +38,23 @@ const kebabToSnake = R.replace(/-/g, '_');
 
 const createPatchNames = def(
   'createPatchNames :: PatchPath -> { owner :: String, libName :: String, patchName :: String }',
-  (path) => {
-    // TODO: this handles @/local-patches incorrectly
-    const [owner, libName, ...patchNameParts] = R.split('/', path);
-    const patchName = patchNameParts.join('/');
-
-    return R.map(kebabToSnake, {
-      owner,
-      libName,
-      patchName,
-    });
-  }
+  R.compose(
+    R.map(kebabToSnake),
+    R.ifElse(
+      R.startsWith(['@']),
+      parts => ({
+        owner: '',
+        libName: '',
+        patchName: parts.slice(1).join('/'),
+      }),
+      parts => ({
+        owner: parts[0],
+        libName: parts[1],
+        patchName: parts.slice(2).join('/'),
+      })
+    ),
+    R.split('/')
+  )
 );
 
 const findPatchByPath = def(
@@ -401,3 +407,7 @@ export const transformProjectWithDebug = def(
 );
 
 export const transpile = renderProject;
+
+export const forUnitTests = {
+  createPatchNames,
+};

--- a/packages/xod-arduino/test/transpiler.spec.js
+++ b/packages/xod-arduino/test/transpiler.spec.js
@@ -7,7 +7,9 @@ import { explode, foldEither, explodeEither } from 'xod-func-tools';
 import { loadProject } from 'xod-fs';
 import { PIN_TYPE } from 'xod-project';
 import { defaultizePin } from 'xod-project/test/helpers';
-import { transpile, getInitialDirtyFlags, transformProject, getNodeIdsMap } from '../src/transpiler';
+import { transpile, getInitialDirtyFlags, transformProject, getNodeIdsMap, forUnitTests } from '../src/transpiler';
+
+const { createPatchNames } = forUnitTests;
 
 // Returns patch relative to repo’s `workspace` subdir
 const wsPath = (...subpath) => path.resolve(__dirname, '../../../workspace', ...subpath);
@@ -50,7 +52,7 @@ describe('xod-arduino transpiler', () => {
         .then(R.map(transpile))
         .then(foldEither(
           (err) => {
-            assert.include(err.message, '@/too_many_outputs');
+            assert.include(err.message, 'too_many_outputs');
             assert.include(err.message, 'has more than 7 outputs');
           },
           () => assert(false, 'expecting Either.Left')
@@ -163,5 +165,23 @@ describe('getInitialDirtyFlags', () => {
       ]),
       0b11111101
     );
+  });
+});
+
+describe('createPatchNames()', () => {
+  it('correctly splits library patch paths', () => {
+    assert.deepEqual(createPatchNames('bob-alice/bar-baz/qux-digun'), {
+      owner: 'bob_alice',
+      libName: 'bar_baz',
+      patchName: 'qux_digun',
+    });
+  });
+
+  it('correctly splits local patch paths', () => {
+    assert.deepEqual(createPatchNames('@/qux-bar'), {
+      owner: '',
+      libName: '',
+      patchName: 'qux_bar',
+    });
   });
 });


### PR DESCRIPTION
Local patches used to get C++ namespace names containing `@` symbol which is illegal
in C++ identifiers.

It made impossible to have a native patch in the project being transpiled.