### PR TITLE
Fix focusing artifacts

### DIFF
--- a/packages/xod-client/src/core/styles/base/base.scss
+++ b/packages/xod-client/src/core/styles/base/base.scss
@@ -9,3 +9,7 @@ body, html {
   width: 100%;
   height: 100%;
 }
+
+*:focus {
+  outline: none;
+}

--- a/packages/xod-client/src/core/styles/components/Comment.scss
+++ b/packages/xod-client/src/core/styles/components/Comment.scss
@@ -48,6 +48,15 @@
 
     a {
       color: $color-canvas-selected;
+
+      &:focus {
+        outline: 0;
+        box-shadow: 0 0 5px 1px $color-canvas-selected;
+        border: 2px solid transparent;
+        border-top: 0;
+        margin-left: -2px;
+        border-radius: 4px;
+      }
     }
   }
 


### PR DESCRIPTION
It fixed #941.
I disabled "outline" styles for all focused elements. It means that there is no "default" focusing style for elements. If we need some — implement it.
Most of the elements already have styles for focus state.
In this PR I just added one for the element, that I found without custom focus — links inside Comments.