### PR TITLE
Tweak Helpbox positioning (right-sided)

### DIFF
--- a/packages/xod-client/src/core/styles/components/Helpbox.scss
+++ b/packages/xod-client/src/core/styles/components/Helpbox.scss
@@ -16,6 +16,15 @@
 
   transition: opacity 0.1s;
 
+  &--rightSided {
+    .pointer {
+      left: auto !important;
+      right: -7px;
+      &:before {
+        transform: rotate(135deg) !important;
+      }
+    }
+  }
   &--hidden {
     opacity: 0;
     pointer-events: none;

--- a/packages/xod-client/src/editor/reducer.js
+++ b/packages/xod-client/src/editor/reducer.js
@@ -13,6 +13,7 @@ import {
   FOCUS_AREAS,
   SELECTION_ENTITY_TYPE,
   TAB_TYPES,
+  PANEL_IDS,
 } from './constants';
 import { createSelectionEntity, getNewSelection, getTabByPatchPath } from './utils';
 import { setCurrentPatchOffset, switchPatchUnsafe } from './actions';
@@ -649,11 +650,19 @@ const editorReducer = (state = {}, action) => {
         state
       );
     case EAT.MOVE_PANEL:
-      return R.assocPath(
-        ['panels', action.payload.panelId, 'sidebar'],
-        action.payload.sidebarId,
-        state
-      );
+      return R.compose(
+        // hide helpbox panel on moving ProjectBrowser
+        // it should be fixed in the future
+        // by saving expanded states of PatchGroups
+        R.when(
+          () => action.payload.panelId === PANEL_IDS.PROJECT_BROWSER,
+          R.over(R.lensProp('isHelpboxVisible'), R.F)
+        ),
+        R.assocPath(
+          ['panels', action.payload.panelId, 'sidebar'],
+          action.payload.sidebarId
+        )
+      )(state);
     case EAT.TOGGLE_PANEL_AUTOHIDE:
       return R.over(
         R.lensPath(['panels', action.payload.panelId, 'autohide']),

--- a/packages/xod-client/src/editor/utils.js
+++ b/packages/xod-client/src/editor/utils.js
@@ -302,6 +302,7 @@ const calculateHelpboxPosition = (container, item) => {
   return {
     isVisible: elVisible,
     top: Math.ceil(elBox.top),
+    left: Math.ceil(elBox.left),
     right: Math.ceil(elBox.right),
   };
 };

--- a/packages/xod-client/src/projectBrowser/containers/ProjectBrowser.jsx
+++ b/packages/xod-client/src/projectBrowser/containers/ProjectBrowser.jsx
@@ -70,7 +70,9 @@ class ProjectBrowser extends React.Component {
     this.renderLocalPatches = this.renderLocalPatches.bind(this);
     this.renderLibraryPatches = this.renderLibraryPatches.bind(this);
   }
-
+  componentDidMount() {
+    triggerUpdateHelpboxPositionViaProjectBrowser();
+  }
   shouldComponentUpdate(nextProps) {
     return !R.eqBy(
       pickPropsForComparsion,


### PR DESCRIPTION
There is no issue.
But now Helpbox will render to the left of a referred element if it could not fit the window width.
E.G. Helpbox renders fine for right-sided ProjectBrowser.

I'm not sure that `rightSided` is a good name for this, maybe it should be `leftSided` or something else. Open to suggestions.