### PR TITLE
Add code highlighting in Cpp Editor

### DIFF
--- a/packages/xod-arduino/src/getTokens.js
+++ b/packages/xod-arduino/src/getTokens.js
@@ -1,0 +1,26 @@
+/* eslint-disable max-len */
+
+const getTokens = () => [
+  {
+    regex: /\b((?:input|output)_[A-Z0-9-_]+)\b/gm,
+    token: 'tag',
+  },
+  {
+    regex: /\b(Number|NodeId|Context|DirtyFlags|TimeMs|u?int\d{1,2}_t|size_t|XString|State|List|Iterator)\b/gm,
+    token: 'type',
+  },
+  {
+    regex: /\b(getValue|emitValue|isInputDirty|transactionTime|setTimeout|clearTimeout|isTimedOut|evaluate|getState)\b/gm,
+    token: 'builtin',
+  },
+  {
+    regex: /\b((digital|analog)(Read|Write)|pinMode|analogReference)\b/gm,
+    token: 'builtin',
+  },
+  {
+    regex: /\bGENERATED_CODE\b/gm,
+    token: 'tag',
+  },
+];
+
+export default getTokens;

--- a/packages/xod-arduino/src/index.js
+++ b/packages/xod-arduino/src/index.js
@@ -4,3 +4,5 @@ export {
   transformProjectWithDebug,
   getNodeIdsMap,
 } from './transpiler';
+
+export { default as getTokens } from './getTokens';

--- a/packages/xod-client/src/core/styles/abstracts/colors.scss
+++ b/packages/xod-client/src/core/styles/abstracts/colors.scss
@@ -49,6 +49,8 @@ $blackberry: #4a4a57;
 $blackberry-light: #616077;
 $blackberry-shadow: #3a3a40;
 
+$blueberry: #77a0ff;
+
 $olive: #827a22;
 $olive-light: #988f34;
 $olive-shadow: #726b1e;

--- a/packages/xod-client/src/core/styles/components/CodeMirror.scss
+++ b/packages/xod-client/src/core/styles/components/CodeMirror.scss
@@ -433,21 +433,20 @@ span.CodeMirror-selectedtext { background: none; }
 .cm-s-xod .cm-operator { color: $chalk-bright; }
 .cm-s-xod .cm-variable-2 { color: $apricot-light; }
 .cm-s-xod .cm-variable-3, .cm-s-xod .cm-type { color: $apricot-light; }
-.cm-s-xod .cm-builtin { color: $apricot-light; }
+.cm-s-xod .cm-builtin { color: $blueberry; }
 .cm-s-xod .cm-atom { color: $red-bright; }
 .cm-s-xod .cm-number { color: $red-bright; }
-.cm-s-xod .cm-def { color: #77A0FF; }
+.cm-s-xod .cm-def { color: $blueberry; }
 .cm-s-xod .cm-string { color: $apricot-light; }
 .cm-s-xod .cm-string-2 { color: $apricot-light; }
 .cm-s-xod .cm-comment { color: $light-grey-bright; }
 .cm-s-xod .cm-variable { color: $chalk; }
-.cm-s-xod .cm-tag { color: $emerald; }
+.cm-s-xod .cm-tag { color: $emerald-light; }
 .cm-s-xod .cm-meta { color: $emerald; }
-.cm-s-xod .cm-attribute { color: #77A0FF; }
-.cm-s-xod .cm-property { color: #77A0FF; }
+.cm-s-xod .cm-attribute { color: $blueberry; }
+.cm-s-xod .cm-property { color: $blueberry; }
 .cm-s-xod .cm-qualifier { color: $apricot-light; }
 .cm-s-xod .cm-variable-3, .cm-s-xod .cm-type { color: $apricot-light; }
-.cm-s-xod .cm-tag { color: $emerald; }
 .cm-s-xod .cm-error {
   color: $white;
   background-color: $red;

--- a/packages/xod-client/src/editor/codemirrorXodMode.js
+++ b/packages/xod-client/src/editor/codemirrorXodMode.js
@@ -1,0 +1,21 @@
+import CodeMirror from 'codemirror';
+import 'codemirror/addon/mode/simple';
+import 'codemirror/addon/mode/overlay';
+import 'codemirror/mode/clike/clike';
+
+import { getTokens } from 'xod-arduino';
+
+(() => {
+  let xodOverlay;
+  CodeMirror.defineMode('xodCpp', (config, parserConfig) => {
+    xodOverlay = CodeMirror.simpleMode(config, {
+      mode: { spec: CodeMirror.modes.clike },
+      start: getTokens(),
+    });
+    return CodeMirror.overlayMode(
+      CodeMirror.getMode(config, parserConfig.backdrop || 'text/x-c++src'),
+      xodOverlay
+    );
+  });
+  CodeMirror.defineMIME('text/x-c++xod', 'xodCpp');
+})();


### PR DESCRIPTION
There is no issue.

It will highlights:
* Types from XOD (`Number`, `State`, `XString` and etc),
* Built-in functions (`getValue`, `setTimeout` and etc),
* Special keywords (`GENERATED_CODE`, `input_$$$` and etc)
* Some built-in functions from Arduino (`digitalRead`, `pinMode` and etc), that are approved by XOD Team (for example, synchronous functions which will lead to a holdup of running transactions, like `delay()`, is not included)