### PR TITLE
Don’t truncate log lines

### DIFF
--- a/packages/xod-client/src/core/styles/components/Debugger.scss
+++ b/packages/xod-client/src/core/styles/components/Debugger.scss
@@ -140,13 +140,12 @@
 
     .line {
       display: block;
-      height: 15px;
       margin: 0;
       padding: 2px;
-      overflow: hidden;
 
       font-family: $font-family-mono;
       font-size: $font-size-m;
+      word-break: break-all;
 
       &:hover {
         background-color: $sidebar-color-bg-even;

--- a/packages/xod-client/src/debugger/reducer.js
+++ b/packages/xod-client/src/debugger/reducer.js
@@ -84,6 +84,11 @@ const updateWatchNodeValues = R.curry(
 
 const showDebuggerPane = R.assoc('isVisible', true);
 
+const splitMessage = R.compose(
+  R.reject(R.isEmpty),
+  R.split('\n')
+);
+
 // =============================================================================
 //
 // Reducer
@@ -119,8 +124,7 @@ export default (state = initialState, action) => {
         const messages = R.compose(
           R.append(createSystemMessage(MSG.SUCCES)),
           R.map(createFlasherMessage),
-          R.reject(R.isEmpty),
-          R.split('\n')
+          splitMessage,
         )(payload.message);
 
         return R.compose(
@@ -131,8 +135,7 @@ export default (state = initialState, action) => {
       if (status === UPLOAD_STATUS.FAILED) {
         const messages = R.compose(
           R.map(createErrorMessage),
-          R.reject(R.isEmpty),
-          R.split('\n')
+          splitMessage
         )(payload.message);
 
         return R.compose(

--- a/packages/xod-client/stories/Debugger.jsx
+++ b/packages/xod-client/stories/Debugger.jsx
@@ -222,6 +222,52 @@ const running = () => {
     ));
 };
 
+const longMessages = () => {
+  const store = createStore();
+
+  const errorMessage = [
+    'Error occured during uploading:',
+    'Here goes some stacktrace with very long lines\n',
+    'command /Users/user/xod/very-long-path/verylongpath/very-long-path/verylongpath/verylongpath/verylongpath/verylongpath/verylongpath/gcc',
+    'can\'t find file /Users/user/xod/verylongpath/verylongpath/verylongpath/verylongpath/verylongpath/verylongpath/verylongpath/verylongpath/file.cpp',
+  ].join('\n')
+
+  store.dispatch({
+    type: 'UPLOAD',
+    payload: {
+      message: errorMessage,
+      percentage: 30,
+      id: 1,
+    },
+    meta: {
+      status: 'failed',
+    },
+  });
+  for (let i = 0; i < 300; i++) {
+    addMessages(store);
+
+    if (i % 10 === 0) {
+      store.dispatch(addMessagesToDebuggerLog([{
+        type: 'error',
+        message: errorMessage,
+        stack: 'And it could have a stack trace...',
+      }]));
+    }
+  }
+
+  storiesOf('Debugger', module)
+    .addDecorator(story => <Provider store={store}>{story()}</Provider>)
+    .add('long messages', () => (
+      <div>
+        <LogLength />
+        <Debugger
+          onUploadClick={action('onUploadClick')}
+          onUploadAndDebugClick={action('onUploadAndDebugClick')}
+        />
+      </div>
+    ));
+};
+
 // =============================================================================
 //
 // Run stories
@@ -233,3 +279,4 @@ uploading();
 uploadingSuccess();
 uploadingFail();
 running();
+longMessages();


### PR DESCRIPTION
Closes #988

Works okay as a quick fix(in very rare cases there might be a slight jitter when scrolling), but in the future we should find another solution, because `react-infinite` assumes that all elements in the list have equal height.

