### PR TITLE
Update forks

### DIFF
--- a/packages/xod-client-browser/package.json
+++ b/packages/xod-client-browser/package.json
@@ -18,7 +18,7 @@
     "react-fa": "^5.0.0",
     "react-hotkeys": "^0.10.0",
     "react-redux": "^4.4.5",
-    "react-skylight": "git+https://github.com/xodio/react-skylight.git",
+    "react-skylight": "git+https://github.com/xodio/react-skylight.git#6dc266edc5198d0d1a6feb57f329826e782ec967",
     "redux": "^3.0.5",
     "redux-thunk": "^2.1.0",
     "xod-arduino": "^0.17.0",

--- a/packages/xod-client-electron/package.json
+++ b/packages/xod-client-electron/package.json
@@ -33,7 +33,7 @@
     "react-fa": "^5.0.0",
     "react-hotkeys": "^0.10.0",
     "react-redux": "^4.4.5",
-    "react-skylight": "git+https://github.com/xodio/react-skylight.git",
+    "react-skylight": "git+https://github.com/xodio/react-skylight.git#6dc266edc5198d0d1a6feb57f329826e782ec967",
     "redux": "^3.0.5",
     "redux-thunk": "^2.1.0",
     "serialport": "^4.0.7",

--- a/packages/xod-client/package.json
+++ b/packages/xod-client/package.json
@@ -29,7 +29,7 @@
     "rc-menu": "git+https://github.com/xodio/menu.git#npm",
     "rc-progress": "^2.1.2",
     "react": "^16.2",
-    "react-autolink-text2": "git+https://github.com/xodio/react-autolink-text.git#npm",
+    "react-autolink-text2": "^3.2.0",
     "react-autosuggest": "git+https://github.com/xodio/react-autosuggest.git#bc6ab71a2ec47ad5fbce5d13ff6a572942ea765e",
     "react-codemirror": "^1.0.0",
     "react-collapsible": "^2.0.3",

--- a/packages/xod-client/package.json
+++ b/packages/xod-client/package.json
@@ -45,7 +45,7 @@
     "react-infinite": "^0.12.1",
     "react-redux": "^4.0.6",
     "react-reflex": "^2.0.11",
-    "react-skylight": "git+https://github.com/xodio/react-skylight.git",
+    "react-skylight": "git+https://github.com/xodio/react-skylight.git#6dc266edc5198d0d1a6feb57f329826e782ec967",
     "react-sortable-hoc": "0.6.7",
     "recompose": "^0.25.0",
     "redux": "^3.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8539,7 +8539,7 @@ promise@^7.0.1, promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@15.x, "prop-types@^0.14.9 || ^15.3.0", prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0:
+prop-types@15.x, "prop-types@^0.14.9 || ^15.3.0 || ^16.0.0", prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -8815,11 +8815,11 @@ rc@^1.1.2, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-"react-autolink-text2@git+https://github.com/xodio/react-autolink-text.git#npm":
-  version "3.0.0"
-  resolved "git+https://github.com/xodio/react-autolink-text.git#33add8d3e13d88561c8be57efcce83555a48e509"
+react-autolink-text2@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-autolink-text2/-/react-autolink-text2-3.2.0.tgz#f0df734d0463fde0b8505a66c581bd16eb129cd8"
   dependencies:
-    prop-types "^0.14.9 || ^15.3.0"
+    prop-types "^0.14.9 || ^15.3.0 || ^16.0.0"
 
 "react-autosuggest@git+https://github.com/xodio/react-autosuggest.git#bc6ab71a2ec47ad5fbce5d13ff6a572942ea765e":
   version "9.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9000,9 +9000,9 @@ react-reflex@^2.0.11:
     prop-types "^15.5.8"
     react-measure "^2.0.2"
 
-"react-skylight@git+https://github.com/xodio/react-skylight.git":
+"react-skylight@git+https://github.com/xodio/react-skylight.git#6dc266edc5198d0d1a6feb57f329826e782ec967":
   version "0.4.2"
-  resolved "git+https://github.com/xodio/react-skylight.git#b5579d39572d57259721c0af290fd3286dde451c"
+  resolved "git+https://github.com/xodio/react-skylight.git#6dc266edc5198d0d1a6feb57f329826e782ec967"
   dependencies:
     prop-types "^15.5.10"
 


### PR DESCRIPTION
forks that are not used anymore:
- https://github.com/xodio/react-autolink-text
- https://github.com/xodio/react-collapsible
- https://github.com/xodio/react-hotkeys
- https://github.com/xodio/react-fa

"active" forks:
- https://github.com/xodio/menu (see [this PR](https://github.com/react-component/menu/pull/112))
- https://github.com/xodio/electron-builder, because it's still not fully compatible with our monorepo setup
- https://github.com/xodio/react-autosuggest — we're maintaining a version tailored for our needs, no PR to original repo
- https://github.com/xodio/react-skylight — same as `react-autosuggest`
