### PR TITLE
Fix copy text from Quick Help

### DIFF
--- a/packages/xod-client/src/core/styles/components/HelpPanel.scss
+++ b/packages/xod-client/src/core/styles/components/HelpPanel.scss
@@ -5,10 +5,8 @@
 
   &-content {
     padding: 6px;
-    & * {
-      user-select: text;
-      cursor: text;
-    }
+    * { user-select: text; }
+    span { cursor: text; }
   }
 
   .no-selection {

--- a/packages/xod-client/src/core/styles/components/Helpbox.scss
+++ b/packages/xod-client/src/core/styles/components/Helpbox.scss
@@ -37,6 +37,9 @@
     .PatchDocs {
       padding: 12px;
     }
+
+    * { user-select: text; }
+    span { cursor: text; }
   }
 
   .pointer {

--- a/packages/xod-client/src/editor/actions.js
+++ b/packages/xod-client/src/editor/actions.js
@@ -312,16 +312,19 @@ const getClipboardEntities = (state) => {
 };
 
 export const copyEntities = event => (dispatch, getState) => {
-  if (isInput(document.activeElement)) return;
+  // If user clicked somewhere on Patch (select Node or something else
+  // except editing comment node) activeElement will be <div />
+  // with className `PatchWrapper`.
+  if (document.activeElement.className === 'PatchWrapper') {
+    const state = getState();
 
-  const state = getState();
-
-  // linter confuses array and a Maybe
-  // eslint-disable-next-line array-callback-return
-  getClipboardEntities(state).map((entities) => {
-    event.clipboardData.setData(getClipboardDataType(), JSON.stringify(entities, null, 2));
-    event.preventDefault();
-  });
+    // linter confuses array and a Maybe
+    // eslint-disable-next-line array-callback-return
+    getClipboardEntities(state).map((entities) => {
+      event.clipboardData.setData(getClipboardDataType(), JSON.stringify(entities, null, 2));
+      event.preventDefault();
+    });
+  }
 };
 
 export const pasteEntities = event => (dispatch, getState) => {

--- a/packages/xod-client/src/editor/components/PatchDocs.jsx
+++ b/packages/xod-client/src/editor/components/PatchDocs.jsx
@@ -23,7 +23,9 @@ const PinInfo = ({ type, label, description }) => (
       <span className="label">{label}</span>
       <span className={cn('type', type)}>{type}</span>
     </div>
-    <div className="description">{description}</div>
+    <div className="description">
+      <span>{description}</span>
+    </div>
   </div>
 );
 
@@ -141,9 +143,15 @@ const PatchDocs = ({ patch, minimal }) => {
 
   return (
     <div className={cls}>
-      <div className="baseName">{baseName}</div>
-      <div className="nodeType">{nodeType}</div>
-      <div className="description">{description}</div>
+      <div className="baseName">
+        <span>{baseName}</span>
+      </div>
+      <div className="nodeType">
+        <span>{nodeType}</span>
+      </div>
+      <div className="description">
+        <span>{description}</span>
+      </div>
       <div className={containerCls} style={{ paddingLeft: distanceToFirstPin }}>
         {inputPins.length > 0 && [
           minimal && (


### PR DESCRIPTION
It closes #1000.
Also, I tweak styles of cursors inside QuickHelp and Helpbox to change it more accurately to `text` (not everywhere, only on text),