### PR TITLE
Deployment panel tweaks

### DIFF
--- a/packages/xod-client-electron/package.json
+++ b/packages/xod-client-electron/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "babel-polyfill": "^6.16.0",
     "classnames": "^2.2.5",
+    "electron-context-menu": "^0.9.1",
     "electron-is-dev": "^0.2.0",
     "electron-log": "^2.2.7",
     "electron-settings": "^3.0.14",

--- a/packages/xod-client-electron/src/app/arduinoActions.js
+++ b/packages/xod-client-electron/src/app/arduinoActions.js
@@ -337,8 +337,11 @@ export const startDebugSessionHandler = (storeFn, onCloseCb) => (event, { port }
   const onClose = () => {
     clearInterval(intervalId);
     onCloseCb(() => {
-      const closeConnectionErr = new Error('Lost connection with the device.');
-      event.sender.send(EVENTS.DEBUG_SESSION, [createErrorMessage(closeConnectionErr)]);
+      const errorMessage = R.compose(
+        R.omit('stack'), // Lost connection is not a big deal, we don't want a stacktrace here
+        createErrorMessage
+      )(new Error(MESSAGES.DEBUG_LOST_CONNECTION));
+      event.sender.send(EVENTS.DEBUG_SESSION, [errorMessage]);
     });
     event.sender.send(EVENTS.STOP_DEBUG_SESSION, createSystemMessage('Debug session stopped'));
   };

--- a/packages/xod-client-electron/src/app/main.js
+++ b/packages/xod-client-electron/src/app/main.js
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, ipcMain, shell } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
+import contextMenu from 'electron-context-menu';
 import * as EVENTS from '../shared/events';
 import {
   listBoardsHandler,
@@ -68,6 +69,8 @@ function createWindow() {
 
   // Open the DevTools.
   // win.webContents.openDevTools();
+
+  contextMenu({ window: win });
 
   const { webContents } = win;
 

--- a/packages/xod-client-electron/src/view/containers/App.jsx
+++ b/packages/xod-client-electron/src/view/containers/App.jsx
@@ -44,24 +44,6 @@ const { app, dialog, Menu } = remoteElectron;
 const DEFAULT_CANVAS_WIDTH = 800;
 const DEFAULT_CANVAS_HEIGHT = 600;
 
-const onContextMenu = (event) => {
-  event.preventDefault();
-  event.stopPropagation();
-
-  const { items } = client.menu;
-  const InputMenu = Menu.buildFromTemplate([
-    items.cut,
-    items.copy,
-    items.paste,
-    items.selectall,
-  ]);
-
-  const node = event.target;
-  const isEditable = (node.nodeName.match(/^(input|textarea)$/i) || node.isContentEditable);
-  const isEnabled = !node.disabled;
-  if (isEditable && isEnabled) { InputMenu.popup(remoteElectron.getCurrentWindow()); }
-};
-
 const defaultState = {
   size: client.getViewableSize(DEFAULT_CANVAS_WIDTH, DEFAULT_CANVAS_HEIGHT),
   workspace: '',
@@ -644,7 +626,7 @@ class App extends client.App {
 
   render() {
     return (
-      <HotKeys keyMap={this.getKeyMap()} id="App" onContextMenu={onContextMenu}>
+      <HotKeys keyMap={this.getKeyMap()} id="App">
         <EventListener
           target={window}
           onResize={this.onResize}

--- a/packages/xod-client/src/core/styles/components/Debugger.scss
+++ b/packages/xod-client/src/core/styles/components/Debugger.scss
@@ -183,6 +183,7 @@
         display: inline-block;
         color: $color-comment-text;
         font-family: $font-family-mono;
+        white-space: pre-wrap;
       }
     }
 

--- a/packages/xod-client/src/core/styles/components/Debugger.scss
+++ b/packages/xod-client/src/core/styles/components/Debugger.scss
@@ -121,6 +121,10 @@
   .log {
     max-height: 196px;
 
+    * {
+      user-select: text;
+    }
+
     &::-webkit-scrollbar {
       width: 6px;
     }
@@ -146,6 +150,7 @@
       font-family: $font-family-mono;
       font-size: $font-size-m;
       word-break: break-all;
+      user-select: text;
 
       &:hover {
         background-color: $sidebar-color-bg-even;
@@ -154,22 +159,21 @@
       & > * {
         margin-right: 2px;
         margin-left: 2px;
+
+        cursor: text;
       }
       & > *:nth(0) {
         margin-left: 0;
       }
       .prefix {
-        opacity: 0.5;
-        cursor: default;
+        color: $chalk-light;
       }
       .timestamp {
         color: $color-datatype-number;
-        cursor: default;
       }
       .nodeId {
         text-decoration: underline;
         color: $color-datatype-boolean;
-        cursor: default;
 
         &:hover {
           text-decoration: none;

--- a/packages/xod-client/src/debugger/messages.js
+++ b/packages/xod-client/src/debugger/messages.js
@@ -1,2 +1,3 @@
 export const TRANSPILING = 'Transpiling...';
 export const SUCCES = 'Done!';
+export const INTRODUCTION = 'Here you will see output from the compiler, uploader, debugger, and other tools.';

--- a/packages/xod-client/src/debugger/reducer.js
+++ b/packages/xod-client/src/debugger/reducer.js
@@ -16,6 +16,8 @@ import {
 import { UPLOAD_STATUS, UPLOAD_MSG_TYPE } from './constants';
 import * as MSG from './messages';
 
+import { createSystemMessage, createFlasherMessage, createErrorMessage } from './utils';
+
 import initialState from './state';
 
 const MAX_LOG_MESSAGES = 1000;
@@ -25,19 +27,6 @@ const MAX_LOG_MESSAGES = 1000;
 // Utils
 //
 // =============================================================================
-
-const createSystemMessage = message => ({
-  type: UPLOAD_MSG_TYPE.SYSTEM,
-  message,
-});
-const createFlasherMessage = message => ({
-  type: UPLOAD_MSG_TYPE.FLASHER,
-  message,
-});
-const createErrorMessage = message => ({
-  type: UPLOAD_MSG_TYPE.ERROR,
-  message,
-});
 
 const overDebugLog = R.over(R.lensProp('log'));
 const overUploadLog = R.over(R.lensProp('uploadLog'));

--- a/packages/xod-client/src/debugger/state.js
+++ b/packages/xod-client/src/debugger/state.js
@@ -1,8 +1,13 @@
+import { createSystemMessage } from './utils';
+import { INTRODUCTION } from './messages';
+
 export default {
   isVisible: false,
   isRunning: false,
   log: [],
-  uploadLog: [],
+  uploadLog: [
+    createSystemMessage(INTRODUCTION),
+  ],
   nodeIdsMap: {},
   watchNodeValues: {},
   uploadProgress: null,

--- a/packages/xod-client/src/debugger/utils.js
+++ b/packages/xod-client/src/debugger/utils.js
@@ -1,0 +1,16 @@
+import { UPLOAD_MSG_TYPE } from './constants';
+
+export const createSystemMessage = message => ({
+  type: UPLOAD_MSG_TYPE.SYSTEM,
+  message,
+});
+
+export const createFlasherMessage = message => ({
+  type: UPLOAD_MSG_TYPE.FLASHER,
+  message,
+});
+
+export const createErrorMessage = message => ({
+  type: UPLOAD_MSG_TYPE.ERROR,
+  message,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3800,6 +3800,13 @@ electron-chromedriver@~1.7.1:
     electron-download "^4.1.0"
     extract-zip "^1.6.5"
 
+electron-context-menu@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/electron-context-menu/-/electron-context-menu-0.9.1.tgz#ed4df20c080491c3c996abfcb363159946a38058"
+  dependencies:
+    electron-dl "^1.2.0"
+    electron-is-dev "^0.1.1"
+
 electron-devtools-installer@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.1.tgz#0beb73ccbf65cbc4d09e706cebda638f839b8c55"
@@ -3808,6 +3815,14 @@ electron-devtools-installer@^2.2.1:
     cross-unzip "0.0.2"
     rimraf "^2.5.2"
     semver "^5.3.0"
+
+electron-dl@^1.2.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/electron-dl/-/electron-dl-1.10.0.tgz#f94416064056fc6f2a86ae498614c93526890af9"
+  dependencies:
+    ext-name "^5.0.0"
+    pupa "^1.0.0"
+    unused-filename "^1.0.0"
 
 electron-download-tf@4.3.4:
   version "4.3.4"
@@ -3850,6 +3865,10 @@ electron-download@^4.1.0:
     rc "^1.1.2"
     semver "^5.3.0"
     sumchecker "^2.0.1"
+
+electron-is-dev@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-0.1.2.tgz#8a1043e32b3a1da1c3f553dce28ce764246167e3"
 
 electron-is-dev@^0.2.0:
   version "0.2.0"
@@ -4450,6 +4469,19 @@ express@^4.16.2:
     type-is "~1.6.15"
     utils-merge "1.0.1"
     vary "~1.1.2"
+
+ext-list@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/ext-list/-/ext-list-2.2.2.tgz#0b98e64ed82f5acf0f2931babf69212ef52ddd37"
+  dependencies:
+    mime-db "^1.28.0"
+
+ext-name@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ext-name/-/ext-name-5.0.0.tgz#70781981d183ee15d13993c8822045c506c8f0a6"
+  dependencies:
+    ext-list "^2.0.0"
+    sort-keys-length "^1.0.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -7008,6 +7040,10 @@ miller-rabin@^4.0.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
+mime-db@^1.28.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.32.0.tgz#485b3848b01a3cda5f968b4882c0771e58e09414"
+
 mime-types@^2.0.8, mime-types@^2.1.11, mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17, mime-types@~2.1.7:
   version "2.1.17"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
@@ -7168,6 +7204,10 @@ mocha@^3.3.0, mocha@^3.4.2:
 modelo@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/modelo/-/modelo-4.2.0.tgz#3b4b420023a66ca7e32bdba16e710937e14d1b0b"
+
+modify-filename@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/modify-filename/-/modify-filename-1.1.0.tgz#9a2dec83806fbb2d975f22beec859ca26b393aa1"
 
 modify-values@^1.0.0:
   version "1.0.0"
@@ -8473,6 +8513,10 @@ punycode@1.3.2:
 punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+pupa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pupa/-/pupa-1.0.0.tgz#9a9568a5af7e657b8462a6e9d5328743560ceff6"
 
 puppeteer@^1.0.0-rc:
   version "1.0.0-rc"
@@ -9882,6 +9926,12 @@ sockjs@0.3.18:
     faye-websocket "^0.10.0"
     uuid "^2.0.2"
 
+sort-keys-length@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sort-keys-length/-/sort-keys-length-1.0.1.tgz#9cb6f4f4e9e48155a6aa0671edd336ff1479a188"
+  dependencies:
+    sort-keys "^1.0.0"
+
 sort-keys@^1.0.0, sort-keys@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
@@ -10880,6 +10930,13 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+unused-filename@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unused-filename/-/unused-filename-1.0.0.tgz#d340880f71ae2115ebaa1325bef05cc6684469c6"
+  dependencies:
+    modify-filename "^1.1.0"
+    path-exists "^3.0.0"
 
 unzip-response@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
This PR contains several small tweaks related to Deployment panel:
- [x] a help message that displays in an empty Deployment panel (Closes #1010)
- [x] user can select/copy log text (Closes #1001)
- [x] when debug session stops because of connection loss, no stacktrace is shown (Closes #1014)
- [x] whitespace in log messages is preserved (Closes #1008)