### PR TITLE
Fix disparity between `not-implemented-in-xod` node and attached implementation

### DIFF
--- a/packages/xod-client/src/editor/actions.js
+++ b/packages/xod-client/src/editor/actions.js
@@ -394,7 +394,7 @@ export const pasteEntities = event => (dispatch, getState) => {
       R.eqBy(
         R.compose( // check if selection is structurally the same as copied entities
           R.map(R.map(R.omit('id'))),
-          R.dissoc('links'),
+          R.omit(['links', 'impl']),
           resetClipboardEntitiesPosition
         ),
         copiedEntities

--- a/packages/xod-client/src/project/reducer.js
+++ b/packages/xod-client/src/project/reducer.js
@@ -14,6 +14,7 @@ import {
   snapNodePositionToSlots,
 } from './nodeLayout';
 import { NODE_PROPERTY_KIND, NODE_PROPERTY_KEY } from './constants';
+import { isNotImplementedInXodNode } from './utils';
 
 // TODO: rewrite this?
 const selectNodePropertyUpdater = ({ kind, key, value }) => {
@@ -261,6 +262,22 @@ export default (state = {}, action) => {
           XP.upsertLinks(entities.links),
           XP.upsertComments(entities.comments),
           XP.upsertNodes(entities.nodes),
+          R.unless(
+            () => R.isNil(entities.impl),
+            R.compose(
+              (patch) => {
+                const existingNiixNode = R.compose(
+                  R.find(isNotImplementedInXodNode),
+                  XP.listNodes
+                )(patch);
+
+                return existingNiixNode
+                  ? XP.dissocNode(existingNiixNode, patch)
+                  : patch;
+              },
+              XP.setImpl(entities.impl)
+            )
+          )
         ),
         state
       );

--- a/packages/xod-client/src/project/reducer.js
+++ b/packages/xod-client/src/project/reducer.js
@@ -5,6 +5,7 @@ import { getLibName } from 'xod-pm';
 
 import * as AT from './actionTypes';
 import { PASTE_ENTITIES, INSTALL_LIBRARIES_COMPLETE } from '../editor/actionTypes';
+import { IMPL_TEMPLATE } from '../editor/constants';
 
 import {
   addPoints,
@@ -278,7 +279,16 @@ export default (state = {}, action) => {
 
       return R.over(
         XP.lensPatch(patchPath), // TODO: can we have a situation where patch does not exist?
-        XP.assocNode(newNode),
+        R.compose(
+          XP.assocNode(newNode),
+          R.when(
+            R.both(
+              () => typeId === XP.NOT_IMPLEMENTED_IN_XOD_PATH,
+              R.complement(XP.hasImpl)
+            ),
+            XP.setImpl(IMPL_TEMPLATE)
+          )
+        ),
         state
       );
     }

--- a/packages/xod-client/src/project/utils.js
+++ b/packages/xod-client/src/project/utils.js
@@ -139,3 +139,8 @@ export const isPatchDeadTerminal = R.compose(
   ),
   XP.getPatchPath,
 );
+
+export const isNotImplementedInXodNode = R.compose(
+  R.equals(XP.NOT_IMPLEMENTED_IN_XOD_PATH),
+  XP.getNodeType,
+);

--- a/packages/xod-project/src/constants.js
+++ b/packages/xod-project/src/constants.js
@@ -38,6 +38,7 @@ export const ERROR = {
   LOOPS_DETECTED: 'The program has a cycle path. Use xod/core/defer-* nodes to break the cycle',
   DATATYPE_INVALID: 'Invalid data type',
   IMPLEMENTATION_NOT_FOUND: 'No implementation for {patchPath} found.',
+  CPP_AS_ENTRY_POINT: 'Can’t use patch not implemented in XOD as entry point',
   CAST_PATCH_NOT_FOUND: 'Casting patch "{patchPath}" is not found in the project',
   // .xodball format
   NOT_A_JSON: 'File that you try to load is not in a JSON format',


### PR DESCRIPTION
Closes #969
Closes #998

Ideally, `not-implemented-in-xod` node and implementation attachment should be a single entity, but for now measures taken in this PR should be enough.
