### PR TITLE
Bump electron version

### DIFF
--- a/packages/xod-client-electron/package.json
+++ b/packages/xod-client-electron/package.json
@@ -55,7 +55,7 @@
     "cpx": "^1.5.0",
     "devtron": "^1.3.0",
     "electron": "1.6.16",
-    "electron-builder": "git+https://github.com/xodio/electron-builder#81bb2e786be4659d85e32b995de83bdb98bea128",
+    "electron-builder": "git+https://github.com/xodio/electron-builder#390724e57468c57424287d47f4b932f959f9c75d",
     "electron-devtools-installer": "^2.2.1",
     "electron-mocha": "^3.4.0",
     "fsp": "^0.1.2"

--- a/packages/xod-client-electron/package.json
+++ b/packages/xod-client-electron/package.json
@@ -54,7 +54,7 @@
     "chai-as-promised": "^6.0.0",
     "cpx": "^1.5.0",
     "devtron": "^1.3.0",
-    "electron": "1.6.11",
+    "electron": "1.6.16",
     "electron-builder": "git+https://github.com/xodio/electron-builder#81bb2e786be4659d85e32b995de83bdb98bea128",
     "electron-devtools-installer": "^2.2.1",
     "electron-mocha": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3823,9 +3823,9 @@ ejs@^2.5.7, ejs@~2.5.6:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
 
-"electron-builder@git+https://github.com/xodio/electron-builder#81bb2e786be4659d85e32b995de83bdb98bea128":
-  version "19.34.2"
-  resolved "git+https://github.com/xodio/electron-builder#81bb2e786be4659d85e32b995de83bdb98bea128"
+"electron-builder@git+https://github.com/xodio/electron-builder#390724e57468c57424287d47f4b932f959f9c75d":
+  version "19.55.3"
+  resolved "git+https://github.com/xodio/electron-builder#390724e57468c57424287d47f4b932f959f9c75d"
   dependencies:
     "7zip-bin" "^2.2.4"
     app-package-builder "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4017,9 +4017,9 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@1.6.11:
-  version "1.6.11"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.6.11.tgz#be79c0ebdcefedb5bf28117409800fa53baceffa"
+electron@1.6.16:
+  version "1.6.16"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.6.16.tgz#f37a8f49cc2625059c99eb266dee4dffe0917b63"
   dependencies:
     "@types/node" "^7.0.18"
     electron-download "^3.0.1"


### PR DESCRIPTION
Electron has a known critical severity security vulnerability in version range >= 1.6.0,< 1.6.16 and should be updated.