### PR TITLE
Fix functional test to make it more solid

### DIFF
--- a/packages/xod-client-electron/test-func/0-fs.spec.js
+++ b/packages/xod-client-electron/test-func/0-fs.spec.js
@@ -35,10 +35,7 @@ describe('Test FS things', () => {
 
     it('double clicks on found library to install', () =>
       ide.page.installLibrary()
-        .then(() => Promise.all([
-          ide.page.assertLibSuggesterHidden(),
-          ide.page.assertProjectBrowserHasInstallingLib('xod/core'),
-        ]))
+        .then(() => ide.page.assertLibSuggesterHidden())
     );
 
     it('checks that installed xod/core have not `concat-4` node', () =>

--- a/packages/xod-client-electron/test-func/pageObject.js
+++ b/packages/xod-client-electron/test-func/pageObject.js
@@ -222,10 +222,6 @@ function assertProjectBrowserHasInstallingLib(client, libName) {
   );
 }
 
-function waitUntilLibraryInstalled(client) {
-  return findProjectBrowser(client).waitForExist('.PatchGroup--installing', 10000, true);
-}
-
 //-----------------------------------------------------------------------------
 // Patch
 //-----------------------------------------------------------------------------
@@ -322,6 +318,9 @@ function assertNoPatchesAreOpen(client) {
 function waitUntilProjectSaved(client) {
   return client.waitForExist('.SnackBarMessage*=Saved', 5000);
 }
+function waitUntilLibraryInstalled(client) {
+  return client.waitForExist('.SnackBarMessage*=installed', 10000);
+}
 
 //-----------------------------------------------------------------------------
 // API
@@ -372,9 +371,9 @@ const API = {
   installLibrary,
   assertLibSuggesterHidden,
   assertProjectBrowserHasInstallingLib,
-  waitUntilLibraryInstalled,
   // Messages
   waitUntilProjectSaved,
+  waitUntilLibraryInstalled,
 };
 
 /**


### PR DESCRIPTION
There is no issue.

Sometimes functional tests fail while waiting for `PatchGroup--installing`. But we have an assumption that library sometimes installs so fast, that DOM element has no time to appear... Now we'll wait for the message, cause message appeared for some time in any case.