### PR TITLE
Fix open of xodball breaks library patches

### DIFF
--- a/packages/xod-pm/test-func/mocha.opts
+++ b/packages/xod-pm/test-func/mocha.opts
@@ -1,3 +1,3 @@
 --require babel-register
 --colors
---timeout 10000
+--timeout 30000


### PR DESCRIPTION
There is no issue.
Bug appeared somewhere in PR #1050 or later in one of the fixes 😬 

What was wrong: after loading project from xodball and merging it with library nodes, it doesn't resolve node types inside library patches.

Now it fixed and it will not break library patches after opening a xodball anymore.