### PR TITLE
Increase test timeouts to fight flakes

### DIFF
--- a/packages/xod-deploy/test-func/mocha.opts
+++ b/packages/xod-deploy/test-func/mocha.opts
@@ -1,3 +1,3 @@
 --require babel-register
 --colors
---timeout 30000
+--timeout 60000


### PR DESCRIPTION
Semi-fixes the `xod-deploy` functional tests which involve the cloud compiler.