### PR TITLE
Validate variadic markers

### DIFF
--- a/packages/xod-client-browser/test-func/pageObjects/Node.js
+++ b/packages/xod-client-browser/test-func/pageObjects/Node.js
@@ -46,7 +46,7 @@ class Node extends BasePageObject {
   async findPinByName(name) {
     const nodeId = await this.getId();
     // generally we should use only `this.elementHandle.$`, but in this case it's unavoidable
-    const pinElementHandle = await this.page.$(`#nodePinsOverlay_${nodeId} .PinOverlay[title="${name}"]`);
+    const pinElementHandle = await this.page.$(`#nodePinsOverlay_${nodeId} .PinOverlay[data-label="${name}"]`);
 
     if (!pinElementHandle) return null;
 
@@ -55,7 +55,7 @@ class Node extends BasePageObject {
 }
 
 Node.findByName = async (page, nodeName) => {
-  const elementHandle = await page.$(`.Node[title="${nodeName}"]`);
+  const elementHandle = await page.$(`.Node[data-label="${nodeName}"]`);
   if (!elementHandle) return null;
 
   return new Node(page, elementHandle);

--- a/packages/xod-client-electron/test-func/pageObject.js
+++ b/packages/xod-client-electron/test-func/pageObject.js
@@ -231,11 +231,11 @@ function assertProjectBrowserHasInstallingLib(client, libName) {
 // Patch
 //-----------------------------------------------------------------------------
 function findNode(client, nodeType) {
-  return client.element(`.Node[title=${nodeType}]`);
+  return client.element(`.Node[data-label="${nodeType}"]`);
 }
 
 function dragNode(client, nodeType, dx, dy) {
-  return client.moveToObject(`.Node[title=${nodeType}]`)
+  return client.moveToObject(`.Node[data-label="${nodeType}"]`)
     .buttonDown()
     .moveTo(null, dx, dy)
     .buttonUp()
@@ -243,7 +243,7 @@ function dragNode(client, nodeType, dx, dy) {
 }
 
 function findPin(client, nodeType, pinLabel) {
-  return client.element(`.NodePinsOverlay[title=${nodeType}] .PinOverlay[title=${pinLabel}]`);
+  return client.element(`.NodePinsOverlay[data-label="${nodeType}"] .PinOverlay[data-label="${pinLabel}"]`);
 }
 
 function findLink(client, type) {

--- a/packages/xod-client/src/project/components/Node.jsx
+++ b/packages/xod-client/src/project/components/Node.jsx
@@ -86,6 +86,12 @@ class Node extends React.Component {
 
     const isTerminalNode = XP.isTerminalPatchPath(type);
 
+    const errTitle = (this.props.dead && this.props.errors.length > 0)
+      ? R.compose(
+        R.join(';\n'),
+        R.map(R.prop('message'))
+      )(this.props.errors) : null;
+
     return (
       <svg
         key={id}
@@ -101,10 +107,10 @@ class Node extends React.Component {
           onDoubleClick={this.onDoubleClick}
           id={id}
           data-label={nodeLabel} // for func tests
-          title={nodeLabel}
+          title={errTitle || nodeLabel}
         >
           {this.renderBody()}
-          {!this.props.isDragged ? <title>{nodeLabel}</title> : null}
+          {!this.props.isDragged ? <title>{errTitle || nodeLabel}</title> : null}
         </g>
         <g className="pins" id={`nodePins_${id}`}>
           {pinsArr.map(pin =>
@@ -139,6 +145,9 @@ Node.propTypes = {
   size: PropTypes.any.isRequired,
   position: PropTypes.object.isRequired,
   dead: PropTypes.bool,
+  errors: PropTypes.arrayOf(
+    PropTypes.instanceOf(Error)
+  ),
   isSelected: PropTypes.bool,
   isGhost: PropTypes.bool,
   isDragged: PropTypes.bool,
@@ -152,6 +161,7 @@ Node.propTypes = {
 };
 
 Node.defaultProps = {
+  errors: [],
   dead: false,
   isSelected: false,
   isGhost: false,

--- a/packages/xod-client/src/project/components/Node.jsx
+++ b/packages/xod-client/src/project/components/Node.jsx
@@ -100,7 +100,8 @@ class Node extends React.Component {
           onMouseUp={this.onMouseUp}
           onDoubleClick={this.onDoubleClick}
           id={id}
-          title={nodeLabel} // this is for func-tests
+          data-label={nodeLabel} // for func tests
+          title={nodeLabel}
         >
           {this.renderBody()}
           {!this.props.isDragged ? <title>{nodeLabel}</title> : null}

--- a/packages/xod-client/src/project/components/NodePinsOverlay.jsx
+++ b/packages/xod-client/src/project/components/NodePinsOverlay.jsx
@@ -50,7 +50,7 @@ class NodePinsOverlay extends React.Component {
         {...size}
         className="NodePinsOverlay"
         viewBox={`0 0 ${size.width} ${size.height}`}
-        title={nodeLabel}
+        data-label={nodeLabel} // for func tests
       >
         <g className="pins">
           {pinsArr.map(pin =>

--- a/packages/xod-client/src/project/components/PinOverlay.jsx
+++ b/packages/xod-client/src/project/components/PinOverlay.jsx
@@ -36,7 +36,7 @@ export default class PinOverlay extends React.Component {
     return (
       <g
         className={cls}
-        title={this.props.label}
+        data-label={this.props.label} // for func tests
         onMouseUp={this.onMouseUp}
         onMouseDown={this.onMouseDown}
         onMouseOver={this.handleOver}

--- a/packages/xod-client/src/project/components/layers/NodesLayer.jsx
+++ b/packages/xod-client/src/project/components/layers/NodesLayer.jsx
@@ -34,6 +34,7 @@ const NodesLayer = ({
               type={node.type}
               position={node.position}
               dead={node.dead}
+              errors={node.errors}
               hidden={node.hidden}
               size={node.size}
               pins={node.pins}

--- a/packages/xod-client/test/reducers/editor.spec.js
+++ b/packages/xod-client/test/reducers/editor.spec.js
@@ -26,7 +26,7 @@ const testStore = state => createStore(
 describe('Editor reducer', () => {
   describe('selecting entities', () => {
     const mockState = {
-      project: {
+      project: defaultizeProject({
         authors: [
           'Test Person',
         ],
@@ -89,7 +89,7 @@ describe('Editor reducer', () => {
             comments: {},
           },
         },
-      },
+      }),
       editor: {
         currentTabId: '@/1',
         mode: EDITOR_MODE.DEFAULT,

--- a/packages/xod-func-tools/src/monads.js
+++ b/packages/xod-func-tools/src/monads.js
@@ -150,3 +150,27 @@ export const reduceMaybe = def(
   'reduceEither :: (b -> a -> Maybe b) -> b -> [a] -> Maybe b',
   reduceM(Maybe.of)
 );
+
+/**
+ * Returns Either b c.
+ *
+ * Checks passed value for condition and if it passes it
+ * returns Either.Right with the same value, if not — returns
+ * Either.Left with result of calling second function from second
+ * argument passed into `leftIf`.
+ *
+ * E.G.
+ * ```
+ *   const validateMoreThan5 = leftIf(x => x > 5, x => `${x} less than 5`);
+ *   validateMoreThan5(3); // Either.Left '3 less than 5'
+ *   validateMoreThan5(6); // Either.Right 6
+ * ```
+ */
+export const leftIf = def(
+  'leftIf :: (a -> c) -> (a -> b) -> a -> Either b c',
+  (condition, leftFn, val) => (
+    condition(val)
+    ? Either.of(val)
+    : Either.Left(leftFn(val))
+  )
+);

--- a/packages/xod-func-tools/test/monads.spec.js
+++ b/packages/xod-func-tools/test/monads.spec.js
@@ -13,6 +13,7 @@ import {
   maybeToPromise,
   reduceEither,
   reduceMaybe,
+  leftIf,
 } from '../src/monads';
 
 describe('moands', () => {
@@ -199,6 +200,27 @@ describe('moands', () => {
         () => explodeMaybe('err', res),
         Error
       );
+    });
+
+    describe('leftIf()', () => {
+      const validateMoreThan5 = leftIf(x => x > 5, x => `${x} less than 5`);
+
+      it('returns Either.Right 5 for truthy condition', () => {
+        const res = validateMoreThan5(6);
+        assert.equal(res.isRight, true);
+        assert.equal(
+          explodeEither(res),
+          6
+        );
+      });
+      it('returns Either.Left String for falsy condition', () => {
+        const res = validateMoreThan5(3);
+        assert.equal(res.isLeft, true);
+        assert.equal(
+          foldEither(identity, identity, res),
+          '3 less than 5'
+        );
+      });
     });
   });
 });

--- a/packages/xod-project/src/builtInPatches.js
+++ b/packages/xod-project/src/builtInPatches.js
@@ -9,6 +9,7 @@ import {
   TERMINAL_PIN_KEYS,
   NOT_IMPLEMENTED_IN_XOD_PATH,
   DEFAULT_VALUE_OF_TYPE,
+  MAX_ARITY_STEP,
 } from './constants';
 
 import {
@@ -58,7 +59,7 @@ export const PINS_OF_PATCH_NODES = R.compose(
       getVariadicPath(arityStep),
       {},
     ])
-  )([1, 2, 3])),
+  )(R.range(1, MAX_ARITY_STEP + 1))),
   R.ap([ // [[patchBaseName, patchPins]] for each type and direction
     R.juxt([ // TODO: make more DRY or more readable?
       getTerminalPath(DIRECTION.OUTPUT),

--- a/packages/xod-project/src/builtInPatches.js
+++ b/packages/xod-project/src/builtInPatches.js
@@ -14,6 +14,7 @@ import {
 import {
   getTerminalPath,
   getInternalTerminalPath,
+  getVariadicPath,
 } from './patchPathUtils';
 
 /**
@@ -52,6 +53,12 @@ export const PINS_OF_PATCH_NODES = R.compose(
     NOT_IMPLEMENTED_IN_XOD_PATH,
     {},
   ]),
+  R.concat(R.map(
+    arityStep => ([
+      getVariadicPath(arityStep),
+      {},
+    ])
+  )([1, 2, 3])),
   R.ap([ // [[patchBaseName, patchPins]] for each type and direction
     R.juxt([ // TODO: make more DRY or more readable?
       getTerminalPath(DIRECTION.OUTPUT),

--- a/packages/xod-project/src/constants.js
+++ b/packages/xod-project/src/constants.js
@@ -72,6 +72,8 @@ export const DEFAULT_VALUE_OF_TYPE = {
   [PIN_TYPE.DEAD]: 0,
 };
 
+export const MAX_ARITY_STEP = 3;
+
 /**
  * A lookup table that answers the
  * question 'can a type A be cast to type B?'

--- a/packages/xod-project/src/index.js
+++ b/packages/xod-project/src/index.js
@@ -48,6 +48,11 @@ export {
   applyNodeIdMap,
   resolveNodeTypesInPatch,
   listLibraryNamesUsedInPatch,
+  computeVariadicPins,
+  listValueInputPins,
+  listAccInputPins,
+  listSharedInputPins,
+  validateVariadicPatch,
 } from './patch';
 export * from './node';
 export * from './comment';

--- a/packages/xod-project/src/index.js
+++ b/packages/xod-project/src/index.js
@@ -52,7 +52,7 @@ export {
   listValueInputPins,
   listAccInputPins,
   listSharedInputPins,
-  validateVariadicPatch,
+  validatePatchForVariadics,
 } from './patch';
 export * from './node';
 export * from './comment';

--- a/packages/xod-project/src/messages.js
+++ b/packages/xod-project/src/messages.js
@@ -13,4 +13,7 @@ export const patchHasMoreThanOneVariadicMarkers = patchPath => `Patch "${patchPa
 export const variadicHasNotEnoughInputs = (arityStep, outputCount, minInputs) =>
   `A variadic-${arityStep} patch node with ${outputCount} outputs should have at least ${minInputs} inputs`;
 
+export const wrongVariadicPinTypes = (inputPinLabels, outputPinLabels) =>
+  `Types of inputs ${inputPinLabels.join(', ')} should match the types of outputs ${outputPinLabels.join(', ')}`;
+
 export const ERR_VARIADIC_HAS_NO_OUTPUTS = 'A variadic patch should have at least one output';

--- a/packages/xod-project/src/messages.js
+++ b/packages/xod-project/src/messages.js
@@ -4,4 +4,13 @@ export const formatDeadReferencesFound = (patchPath, submessage) => [
   'Fix or delete them to continue.',
 ].join('\n');
 
-export default {};
+// Variadics
+
+export const patchHasNoVariadicMarkers = patchPath => `Patch "${patchPath}" has no variadic markers.`;
+
+export const patchHasMoreThanOneVariadicMarkers = patchPath => `Patch "${patchPath}" has more than one variadic-* marker`;
+
+export const variadicHasNotEnoughInputs = (arityStep, outputCount, minInputs) =>
+  `A variadic-${arityStep} patch node with ${outputCount} outputs should have at least ${minInputs} inputs`;
+
+export const ERR_VARIADIC_HAS_NO_OUTPUTS = 'A variadic patch should have at least one output';

--- a/packages/xod-project/src/node.js
+++ b/packages/xod-project/src/node.js
@@ -50,6 +50,7 @@ export const createNode = def(
     label: '',
     description: '',
     boundValues: {},
+    arityLevel: 1,
   })
 );
 
@@ -158,6 +159,27 @@ export const setNodePosition = def(
 export const getNodePosition = def(
   'getNodePosition :: Node -> Position',
   R.prop('position')
+);
+
+/**
+ * @function setNodeArityLevel
+ * @param {ArityLevel} arityLevel - new arity of the node
+ * @param {Node} node - node to update
+ * @returns {Node} copy of node with new arity level
+ */
+export const setNodeArityLevel = def(
+  'setNodeArityLevel :: ArityLevel -> Node -> Node',
+  R.assoc('arityLevel')
+);
+
+/**
+ * @function getNodeArityLevel
+ * @param {Node} node
+ * @returns {ArityLevel}
+ */
+export const getNodeArityLevel = def(
+  'getNodeArityLevel :: Node -> ArityLevel',
+  R.prop('arityLevel')
 );
 
 /**

--- a/packages/xod-project/src/optionalFieldsUtils.js
+++ b/packages/xod-project/src/optionalFieldsUtils.js
@@ -7,6 +7,7 @@ export const OPTIONAL_NODE_FIELDS = {
   boundValues: {},
   description: '',
   label: '',
+  arityLevel: 1,
 };
 
 export const OPTIONAL_PATCH_FIELDS = {

--- a/packages/xod-project/src/patch.js
+++ b/packages/xod-project/src/patch.js
@@ -21,6 +21,8 @@ import {
   resolvePatchPath,
   isBuiltInLibName,
   isLocalMarker,
+  isVariadicPath,
+  getVariadicPathKind,
 } from './patchPathUtils';
 
 /**
@@ -1021,7 +1023,15 @@ export const upsertDeadPins = def(
   }
 );
 
-
+/**
+ * It takes Patch and replaces all local nodetypes with absolute.
+ * E.G.
+ * Patch "xod/core/concat-4" has few nodes with types "@/concat".
+ * Theirs node types will be replaced with "xod/core/concat".
+ *
+ * This function is used in loading of libraries.
+ */
+// :: Patch -> Patch
 export const resolveNodeTypesInPatch = patch => R.compose(
   R.reduce(R.flip(assocNode), patch),
   R.map(node => R.compose(
@@ -1032,3 +1042,20 @@ export const resolveNodeTypesInPatch = patch => R.compose(
   R.filter(Node.isLocalNode),
   listNodes
 )(patch);
+
+/**
+ * Get variadic kind (1/2/3) from Patch by checking for
+ * existing of variadic node and extract its kind from
+ * NodeType. Cause Patch could not contain any variadic
+ * node it returns value wrapped into Maybe.
+ */
+export const getVardiadicKindFromPatch = def(
+  'getVardiadicKindFromPatch :: Patch -> Maybe VariadicKind',
+  R.compose(
+    R.map(getVariadicPathKind),
+    Maybe,
+    R.find(isVariadicPath),
+    R.map(Node.getNodeType),
+    listNodes
+  )
+);

--- a/packages/xod-project/src/patch.js
+++ b/packages/xod-project/src/patch.js
@@ -1220,13 +1220,19 @@ export const listSharedInputPins = def(
 );
 
 /**
- * It computed a variadic pins and validates Patch.
- * It returns Either Patch or Validation Error.
+ * It checks Patch for existing of variadic marker.
+ * If it has variadic marker — compute and validate variadic Pins,
+ * and then return Either Error Patch.
+ * If not — just return Either.Right Patch.
  */
-export const validateVariadicPatch = def(
-  'validateVariadicPatch :: Patch -> Either Error Patch',
-  patch => R.compose(
-    R.map(R.always(patch)),
-    computeVariadicPins
+export const validatePatchForVariadics = def(
+  'validatePatchForVariadics :: Patch -> Either Error Patch',
+  patch => R.ifElse(
+    isVariadicPatch,
+    R.compose(
+      R.map(R.always(patch)),
+      computeVariadicPins
+    ),
+    Either.of
   )(patch)
 );

--- a/packages/xod-project/src/patchPathUtils.js
+++ b/packages/xod-project/src/patchPathUtils.js
@@ -130,15 +130,14 @@ export const getTerminalPath = R.curry((direction, type) => `${PATCH_NODES_LIB_N
 // utils for variadic marker nodes
 //
 
-const variadicRegExp =
-  new RegExp(`${PATCH_NODES_LIB_NAME}/variadic-([1-3])`);
+const variadicRegExp = new RegExp(`${PATCH_NODES_LIB_NAME}/variadic-([1-3])`);
 
 // :: PatchPath -> Boolean
 export const isVariadicPath = R.test(variadicRegExp);
 
 // TODO: Maybe `Maybe NonZeroNaturalNumber`?
 // :: PatchPath -> NonZeroNaturalNumber
-export const getVariadicPathCount = R.compose(
+export const getVariadicPathKind = R.compose(
   R.nth(1),
   R.match(variadicRegExp)
 );

--- a/packages/xod-project/src/patchPathUtils.js
+++ b/packages/xod-project/src/patchPathUtils.js
@@ -137,7 +137,7 @@ export const isVariadicPath = R.test(variadicRegExp);
 
 // TODO: Maybe `Maybe NonZeroNaturalNumber`?
 // :: PatchPath -> NonZeroNaturalNumber
-export const getVariadicPathKind = R.compose(
+export const getArityStepFromPatchPath = R.compose(
   R.nth(1),
   R.match(variadicRegExp)
 );

--- a/packages/xod-project/src/patchPathUtils.js
+++ b/packages/xod-project/src/patchPathUtils.js
@@ -94,7 +94,7 @@ export const convertToLocalPath = R.compose(
 // Utils for terminal patches
 //
 
-const TERMINALS_LIB_NAME = 'xod/patch-nodes';
+const PATCH_NODES_LIB_NAME = 'xod/patch-nodes';
 const dataTypes = R.values(CONST.PIN_TYPE);
 
 // :: String -> Direction
@@ -124,7 +124,27 @@ export const isOutputTerminalPath = R.compose(
 );
 
 // ::
-export const getTerminalPath = R.curry((direction, type) => `${TERMINALS_LIB_NAME}/${direction}-${type}`);
+export const getTerminalPath = R.curry((direction, type) => `${PATCH_NODES_LIB_NAME}/${direction}-${type}`);
+
+//
+// utils for variadic marker nodes
+//
+
+const variadicRegExp =
+  new RegExp(`${PATCH_NODES_LIB_NAME}/variadic-([1-3])`);
+
+// :: PatchPath -> Boolean
+export const isVariadicPath = R.test(variadicRegExp);
+
+// TODO: Maybe `Maybe NonZeroNaturalNumber`?
+// :: PatchPath -> NonZeroNaturalNumber
+export const getVariadicPathCount = R.compose(
+  R.nth(1),
+  R.match(variadicRegExp)
+);
+
+// :: NonZeroNaturalNumber -> PatchPath
+export const getVariadicPath = n => `${PATCH_NODES_LIB_NAME}/variadic-${n}`;
 
 //
 // utils for cast patches

--- a/packages/xod-project/src/project.js
+++ b/packages/xod-project/src/project.js
@@ -397,7 +397,7 @@ const checkPinKeys = def(
 export const validatePatchContents = def(
   'validatePatchContents :: Patch -> Project -> Either Error Patch',
   (patch, project) => {
-    // :: patch -> Either
+    // :: patch -> Either Error Patch
     const checkNodeTypes = R.compose(
       R.map(R.always(patch)),
       R.sequence(Either.of),
@@ -417,7 +417,7 @@ export const validatePatchContents = def(
       ),
       Patch.listNodes
     );
-    // :: patch -> Either
+    // :: patch -> Either Error Patch
     const checkLinks = R.compose(
       R.ifElse(
         R.compose(
@@ -435,7 +435,9 @@ export const validatePatchContents = def(
       Patch.listLinks
     );
 
-    return checkNodeTypes(patch).chain(checkLinks);
+    return checkNodeTypes(patch)
+      .chain(checkLinks)
+      .chain(Patch.validatePatchForVariadics);
   }
 );
 

--- a/packages/xod-project/src/types.js
+++ b/packages/xod-project/src/types.js
@@ -38,8 +38,8 @@ const NonZeroNaturalNumber = NullaryType(
   'NonZeroNaturalNumber',
   R.both(Number.isInteger, R.gt(R.__, 0))
 );
-const VariadicKind = NullaryType(
-  'VariadicKind',
+const ArityStep = NullaryType(
+  'ArityStep',
   x => x >= 1 && x <= 3
 );
 
@@ -185,7 +185,7 @@ export const env = XF.env.concat([
   LibName,
   ArityLevel,
   NonZeroNaturalNumber,
-  VariadicKind,
+  ArityStep,
 ]);
 
 export const def = HMDef.create({

--- a/packages/xod-project/src/types.js
+++ b/packages/xod-project/src/types.js
@@ -34,12 +34,17 @@ const OneOfType = XF.OneOfType(packageName, docUrl);
 
 const ObjectWithId = NullaryType('ObjectWithId', R.both(XF.notNil, R.has('id')));
 const ObjectWithKey = NullaryType('ObjectWithKey', R.both(XF.notNil, R.has('key')));
+const NonZeroNaturalNumber = NullaryType(
+  'NonZeroNaturalNumber',
+  R.both(Number.isInteger, R.gt(R.__, 0))
+);
 
 export const Label = AliasType('Label', $.String);
 export const Source = AliasType('Source', $.String);
 export const ShortId = AliasType('ShortId', $.String);
 export const LinkId = AliasType('LinkId', ShortId);
 export const NodeId = AliasType('NodeId', ShortId);
+export const ArityLevel = AliasType('ArityLevel', NonZeroNaturalNumber);
 export const CommentId = AliasType('CommentId', ShortId);
 export const PinKey = AliasType('PinKey', NodeId);
 export const PinLabel = AliasType('PinLabel', $.String);
@@ -80,6 +85,7 @@ export const Node = Model('Node', {
   label: $.String,
   description: $.String,
   boundValues: $.StrMap(DataValue),
+  arityLevel: ArityLevel,
 });
 
 export const Link = Model('Link', {
@@ -173,6 +179,8 @@ export const env = XF.env.concat([
   TerminalNode,
   Version,
   LibName,
+  ArityLevel,
+  NonZeroNaturalNumber,
 ]);
 
 export const def = HMDef.create({

--- a/packages/xod-project/src/types.js
+++ b/packages/xod-project/src/types.js
@@ -40,7 +40,7 @@ const NonZeroNaturalNumber = NullaryType(
 );
 const ArityStep = NullaryType(
   'ArityStep',
-  x => x >= 1 && x <= 3
+  x => x >= 1 && x <= C.MAX_ARITY_STEP
 );
 
 export const Label = AliasType('Label', $.String);

--- a/packages/xod-project/src/types.js
+++ b/packages/xod-project/src/types.js
@@ -38,6 +38,10 @@ const NonZeroNaturalNumber = NullaryType(
   'NonZeroNaturalNumber',
   R.both(Number.isInteger, R.gt(R.__, 0))
 );
+const VariadicKind = NullaryType(
+  'VariadicKind',
+  x => x >= 1 && x <= 3
+);
 
 export const Label = AliasType('Label', $.String);
 export const Source = AliasType('Source', $.String);
@@ -181,6 +185,7 @@ export const env = XF.env.concat([
   LibName,
   ArityLevel,
   NonZeroNaturalNumber,
+  VariadicKind,
 ]);
 
 export const def = HMDef.create({

--- a/packages/xod-project/test/fixtures/blinking.flat.json
+++ b/packages/xod-project/test/fixtures/blinking.flat.json
@@ -10,6 +10,7 @@
       "path": "xod/core/digital-output",
       "nodes": {
         "noNativeImpl": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -22,6 +23,7 @@
           "@@type": "xod-project/Node"
         },
         "pin": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -34,6 +36,7 @@
           "@@type": "xod-project/Node"
         },
         "value": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -62,6 +65,7 @@
       "path": "xod/math/multiply",
       "nodes": {
         "noNativeImpl": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -74,6 +78,7 @@
           "@@type": "xod-project/Node"
         },
         "a": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -86,6 +91,7 @@
           "@@type": "xod-project/Node"
         },
         "b": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -98,6 +104,7 @@
           "@@type": "xod-project/Node"
         },
         "out": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -126,6 +133,7 @@
       "path": "xod/core/latch",
       "nodes": {
         "noNativeImpl": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -138,6 +146,7 @@
           "@@type": "xod-project/Node"
         },
         "toggle": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -150,6 +159,7 @@
           "@@type": "xod-project/Node"
         },
         "set": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -162,6 +172,7 @@
           "@@type": "xod-project/Node"
         },
         "reset": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -174,6 +185,7 @@
           "@@type": "xod-project/Node"
         },
         "state": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -202,6 +214,7 @@
       "path": "xod/core/clock",
       "nodes": {
         "noNativeImpl": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -214,6 +227,7 @@
           "@@type": "xod-project/Node"
         },
         "interval": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -226,6 +240,7 @@
           "@@type": "xod-project/Node"
         },
         "tick": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -254,6 +269,7 @@
       "path": "xod/core/cast-boolean-to-number",
       "nodes": {
         "noNativeImpl": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -266,6 +282,7 @@
           "@@type": "xod-project/Node"
         },
         "__in__": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -278,6 +295,7 @@
           "@@type": "xod-project/Node"
         },
         "__out__": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -306,6 +324,7 @@
       "path": "@/main",
       "nodes": {
         "SJ7g05EdFe~rJWgAqVOtx": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -318,6 +337,7 @@
           "@@type": "xod-project/Node"
         },
         "BJ4l0cVdKe~ryFxRcNdKg": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {
@@ -332,6 +352,7 @@
           "@@type": "xod-project/Node"
         },
         "BJ4l0cVdKe~HkSgA94OYx": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -344,6 +365,7 @@
           "@@type": "xod-project/Node"
         },
         "BJ4l0cVdKe~rJUgCqNuKl": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -356,6 +378,7 @@
           "@@type": "xod-project/Node"
         },
         "SJ7g05EdFe~BJGgAcVOtx-to-BJ4l0cVdKe~B1wg0qVOtg-pin-__in__": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {},
@@ -368,6 +391,7 @@
           "@@type": "xod-project/Node"
         },
         "SJ7g05EdFe~rJxgAqV_tl": {
+          "arityLevel": 1,
           "label": "",
           "description": "",
           "boundValues": {

--- a/packages/xod-project/test/fixtures/bound-input-values-propagation.flat.json
+++ b/packages/xod-project/test/fixtures/bound-input-values-propagation.flat.json
@@ -7,6 +7,7 @@
     "xod/core/add": {
       "nodes": {
         "BJnQUR_BwyZ": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "X",
@@ -19,6 +20,7 @@
           "@@type": "xod-project/Node"
         },
         "HkqmLAOrD1W": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "Y",
@@ -31,6 +33,7 @@
           "@@type": "xod-project/Node"
         },
         "SyomIRurDJ-": {
+          "arityLevel": 1,
           "boundValues": {
             "__in__": 0
           },
@@ -45,6 +48,7 @@
           "@@type": "xod-project/Node"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -75,6 +79,7 @@
         "HJbQvOPL-~r1yIU_vU-": {
           "id": "HJbQvOPL-~r1yIU_vU-",
           "type": "xod/core/add",
+          "arityLevel": 1,
           "boundValues": {
             "BJnQUR_BwyZ": 111,
             "HkqmLAOrD1W": 222

--- a/packages/xod-project/test/fixtures/bound-input-values-propagation.json
+++ b/packages/xod-project/test/fixtures/bound-input-values-propagation.json
@@ -18,6 +18,7 @@
           },
           "description": "",
           "label": "",
+          "arityLevel": 1,
           "boundValues": {
             "wrapped-add-in-1": 111,
             "wrapped-add-in-2": 222
@@ -37,6 +38,7 @@
         "wrapped-add-in-1": {
           "id": "wrapped-add-in-1",
           "type": "xod/patch-nodes/input-number",
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "position": {
@@ -49,6 +51,7 @@
         "wrapped-add-in-2": {
           "id": "wrapped-add-in-2",
           "type": "xod/patch-nodes/input-number",
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "position": {
@@ -61,6 +64,7 @@
         "H1jEI_PUW": {
           "id": "H1jEI_PUW",
           "type": "xod/patch-nodes/output-number",
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "position": {
@@ -73,6 +77,7 @@
         "r1yIU_vU-": {
           "id": "r1yIU_vU-",
           "type": "xod/core/add",
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -130,6 +135,7 @@
     "xod/core/add": {
       "nodes": {
         "BJnQUR_BwyZ": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "X",
@@ -142,6 +148,7 @@
           "@@type": "xod-project/Node"
         },
         "HkqmLAOrD1W": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "Y",
@@ -154,6 +161,7 @@
           "@@type": "xod-project/Node"
         },
         "SyomIRurDJ-": {
+          "arityLevel": 1,
           "boundValues": {
             "__in__": 0
           },
@@ -168,6 +176,7 @@
           "@@type": "xod-project/Node"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",

--- a/packages/xod-project/test/fixtures/bound-values-propagation-to-busy-output.flat.json
+++ b/packages/xod-project/test/fixtures/bound-values-propagation-to-busy-output.flat.json
@@ -9,6 +9,7 @@
       "@@type": "xod-project/Patch",
       "nodes": {
         "ByXnYHPyb": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "Duty cycle value in range 0.0 … 1.0",
           "label": "DUTY",
@@ -21,6 +22,7 @@
           "@@type": "xod-project/Node"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -33,6 +35,7 @@
           "@@type": "xod-project/Node"
         },
         "rJsaFSvk-": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "Board PWM port to write to",
           "label": "PORT",
@@ -61,6 +64,7 @@
       "@@type": "xod-project/Patch",
       "nodes": {
         "B1QQ_nhUb": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -73,6 +77,7 @@
           "@@type": "xod-project/Node"
         },
         "BkRma33U-": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -85,6 +90,7 @@
           "@@type": "xod-project/Node"
         },
         "ByZ7_hnUb": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -113,6 +119,7 @@
       "@@type": "xod-project/Patch",
       "nodes": {
         "B1x2RV3eZ": {
+          "arityLevel": 1,
           "boundValues": {
             "__in__": ""
           },
@@ -127,6 +134,7 @@
           "@@type": "xod-project/Node"
         },
         "H1PnRN2lW": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -155,6 +163,7 @@
       "@@type": "xod-project/Patch",
       "nodes": {
         "BkDHHm3JG~S1XVBXhyf~H114eThI-": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -167,6 +176,7 @@
           "@@type": "xod-project/Node"
         },
         "BkDHHm3JG~S1XVBXhyf~SyqVe6hLb": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -179,6 +189,7 @@
           "@@type": "xod-project/Node"
         },
         "H1iBrm2Jf": {
+          "arityLevel": 1,
           "boundValues": {
             "B1x2RV3eZ": 11
           },

--- a/packages/xod-project/test/fixtures/cast-multiple-outputs.flat.json
+++ b/packages/xod-project/test/fixtures/cast-multiple-outputs.flat.json
@@ -17,6 +17,7 @@
       "comments": {},
       "nodes": {
         "Bk_h9jpZW": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "Bk_h9jpZW",
@@ -29,6 +30,7 @@
           "@@type": "xod-project/Node"
         },
         "BkeKcj6ZZ": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "BkeKcj6ZZ",
@@ -41,6 +43,7 @@
           "@@type": "xod-project/Node"
         },
         "Hkqu9oaWb": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "Hkqu9oaWb",
@@ -53,6 +56,7 @@
           "@@type": "xod-project/Node"
         },
         "rksccsp-W": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "rksccsp-W",
@@ -81,6 +85,7 @@
       "comments": {},
       "nodes": {
         "Hk5ccgtI-": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -93,6 +98,7 @@
           "@@type": "xod-project/Node"
         },
         "HkjwYxKUb": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "OUT_A",
@@ -105,6 +111,7 @@
           "@@type": "xod-project/Node"
         },
         "rJqjcxYUZ": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -117,6 +124,7 @@
           "@@type": "xod-project/Node"
         },
         "rkavKlFUb": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "OUT_B",
@@ -145,6 +153,7 @@
       "comments": {},
       "nodes": {
         "HJdO9HwJ-": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "HJdO9HwJ-",
@@ -157,6 +166,7 @@
           "@@type": "xod-project/Node"
         },
         "S1n95SDJb": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "S1n95SDJb",
@@ -169,6 +179,7 @@
           "@@type": "xod-project/Node"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "noNativeImpl",
@@ -197,6 +208,7 @@
       "comments": {},
       "nodes": {
         "__in__": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "__in__",
@@ -209,6 +221,7 @@
           "@@type": "xod-project/Node"
         },
         "__out__": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "__out__",
@@ -221,6 +234,7 @@
           "@@type": "xod-project/Node"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "noNativeImpl",
@@ -240,6 +254,7 @@
       "comments": {},
       "nodes": {
         "B1VMtgtUb": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -252,6 +267,7 @@
           "@@type": "xod-project/Node"
         },
         "HyXhclKUZ": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -264,6 +280,7 @@
           "@@type": "xod-project/Node"
         },
         "rk5MteYLZ": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -284,6 +301,7 @@
           "type": "xod/core/cast-number-to-string",
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         },
@@ -296,6 +314,7 @@
           "type": "xod/core/cast-number-to-string",
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         }

--- a/packages/xod-project/test/fixtures/deep-bound-values-propagation.flat.json
+++ b/packages/xod-project/test/fixtures/deep-bound-values-propagation.flat.json
@@ -16,6 +16,7 @@
       "links": {},
       "nodes": {
         "HkXm80uHPyb": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "A value to store",
           "label": "NEW",
@@ -28,6 +29,7 @@
           "@@type": "xod-project/Node"
         },
         "Hy-QUR_BPkZ": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "Saves `NEW` value in memory",
           "label": "UPD",
@@ -40,6 +42,7 @@
           "@@type": "xod-project/Node"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -52,6 +55,7 @@
           "@@type": "xod-project/Node"
         },
         "r1lQLAOBwJb": {
+          "arityLevel": 1,
           "boundValues": {
             "__in__": 0
           },
@@ -82,6 +86,7 @@
       "links": {},
       "nodes": {
         "BkF78AurDJW": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "X",
@@ -94,6 +99,7 @@
           "@@type": "xod-project/Node"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -106,6 +112,7 @@
           "@@type": "xod-project/Node"
         },
         "rkO7L0uSP1Z": {
+          "arityLevel": 1,
           "boundValues": {
             "__in__": 0
           },
@@ -136,6 +143,7 @@
       "links": {},
       "nodes": {
         "HJdO9HwJ-": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "LINE",
@@ -148,6 +156,7 @@
           "@@type": "xod-project/Node"
         },
         "S1n95SDJb": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "DUMP",
@@ -160,6 +169,7 @@
           "@@type": "xod-project/Node"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -188,6 +198,7 @@
       "links": {},
       "nodes": {
         "__in__": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -200,6 +211,7 @@
           "@@type": "xod-project/Node"
         },
         "__out__": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -212,6 +224,7 @@
           "@@type": "xod-project/Node"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -231,6 +244,7 @@
     "@/main": {
       "nodes": {
         "rJuzwF_IZ~H1vZPFOUW~HkU68Y_IW": {
+          "arityLevel": 1,
           "boundValues": {
             "HkXm80uHPyb": 123,
             "r1lQLAOBwJb": 456
@@ -246,6 +260,7 @@
           "@@type": "xod-project/Node"
         },
         "BJZPPF_Ib": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -258,6 +273,7 @@
           "@@type": "xod-project/Node"
         },
         "ryN_PKd8W": {
+          "arityLevel": 1,
           "boundValues": {
             "S1n95SDJb": "ON_BOOT"
           },
@@ -280,6 +296,7 @@
           "type": "xod/core/cast-number-to-string",
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         }

--- a/packages/xod-project/test/fixtures/deep-bound-values-propagation.xodball.json
+++ b/packages/xod-project/test/fixtures/deep-bound-values-propagation.xodball.json
@@ -14,6 +14,7 @@
             "x": 138,
             "y": 16
           },
+          "arityLevel": 1,
           "boundValues": {
             "rJJbPFO8b": 123,
             "B1FlPYuL-": 456
@@ -42,6 +43,7 @@
             "x": 138,
             "y": 432
           },
+          "arityLevel": 1,
           "boundValues": {
             "S1n95SDJb": "ON_BOOT"
           }
@@ -265,6 +267,7 @@
     "xod/core/round": {
       "nodes": {
         "BkF78AurDJW": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "X",
@@ -276,6 +279,7 @@
           "type": "xod/patch-nodes/input-number"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -287,6 +291,7 @@
           "type": "xod/patch-nodes/not-implemented-in-xod"
         },
         "rkO7L0uSP1Z": {
+          "arityLevel": 1,
           "boundValues": {
             "__in__": 0
           },
@@ -315,6 +320,7 @@
     "xod/core/console-log": {
       "nodes": {
         "HJdO9HwJ-": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "LINE",
@@ -326,6 +332,7 @@
           "type": "xod/patch-nodes/input-string"
         },
         "S1n95SDJb": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "DUMP",
@@ -337,6 +344,7 @@
           "type": "xod/patch-nodes/input-pulse"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -363,6 +371,7 @@
     "xod/core/buffer": {
       "nodes": {
         "HkXm80uHPyb": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "A value to store",
           "label": "NEW",
@@ -374,6 +383,7 @@
           "type": "xod/patch-nodes/input-number"
         },
         "Hy-QUR_BPkZ": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "Saves `NEW` value in memory",
           "label": "UPD",
@@ -385,6 +395,7 @@
           "type": "xod/patch-nodes/input-pulse"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -396,6 +407,7 @@
           "type": "xod/patch-nodes/not-implemented-in-xod"
         },
         "r1lQLAOBwJb": {
+          "arityLevel": 1,
           "boundValues": {
             "__in__": 0
           },
@@ -424,6 +436,7 @@
     "xod/core/cast-number-to-string": {
       "nodes": {
         "__in__": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -435,6 +448,7 @@
           "type": "xod/patch-nodes/input-number"
         },
         "__out__": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",
@@ -446,6 +460,7 @@
           "type": "xod/patch-nodes/output-string"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",

--- a/packages/xod-project/test/fixtures/deeply-nested.flat.json
+++ b/packages/xod-project/test/fixtures/deeply-nested.flat.json
@@ -10,6 +10,7 @@
       "links": {},
       "nodes": {
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "noNativeImpl",
@@ -22,6 +23,7 @@
           "@@type": "xod-project/Node"
         },
         "ryVmUAOrvkb": {
+          "arityLevel": 1,
           "boundValues": {
             "__in__": false
           },
@@ -52,6 +54,7 @@
       "links": {},
       "nodes": {
         "HJdO9HwJ-": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "HJdO9HwJ-",
@@ -64,6 +67,7 @@
           "@@type": "xod-project/Node"
         },
         "S1n95SDJb": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "S1n95SDJb",
@@ -76,6 +80,7 @@
           "@@type": "xod-project/Node"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "noNativeImpl",
@@ -104,6 +109,7 @@
       "links": {},
       "nodes": {
         "ByHmL0uHPk-": {
+          "arityLevel": 1,
           "boundValues": {
             "__in__": false
           },
@@ -118,6 +124,7 @@
           "@@type": "xod-project/Node"
         },
         "ByU7LRuSPkW": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "ByU7LRuSPkW",
@@ -130,6 +137,7 @@
           "@@type": "xod-project/Node"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "noNativeImpl",
@@ -142,6 +150,7 @@
           "@@type": "xod-project/Node"
         },
         "ryv7IRdSP1b": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "ryv7IRdSP1b",
@@ -176,6 +185,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         },
@@ -188,6 +198,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {
             "HJdO9HwJ-": "It works!"
           },
@@ -202,6 +213,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         }

--- a/packages/xod-project/test/fixtures/deeply-nested.json
+++ b/packages/xod-project/test/fixtures/deeply-nested.json
@@ -19,6 +19,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         },
@@ -31,6 +32,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {
             "HJdO9HwJ-": "It works!"
           },
@@ -45,6 +47,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         },
@@ -57,6 +60,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         }
@@ -128,6 +132,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         },
@@ -140,6 +145,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         },
@@ -152,6 +158,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         },
@@ -164,6 +171,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         }
@@ -223,6 +231,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         },
@@ -235,6 +244,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         },
@@ -247,6 +257,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         },
@@ -259,6 +270,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         }
@@ -318,6 +330,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         },
@@ -330,6 +343,7 @@
           },
           "label": "",
           "description": "",
+          "arityLevel": 1,
           "boundValues": {},
           "@@type": "xod-project/Node"
         }
@@ -359,6 +373,7 @@
       "links": {},
       "nodes": {
         "ByHmL0uHPk-": {
+          "arityLevel": 1,
           "boundValues": {
             "__in__": false
           },
@@ -373,6 +388,7 @@
           "@@type": "xod-project/Node"
         },
         "ByU7LRuSPkW": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "ByU7LRuSPkW",
@@ -385,6 +401,7 @@
           "@@type": "xod-project/Node"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "noNativeImpl",
@@ -397,6 +414,7 @@
           "@@type": "xod-project/Node"
         },
         "ryv7IRdSP1b": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "ryv7IRdSP1b",
@@ -425,6 +443,7 @@
       "links": {},
       "nodes": {
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "noNativeImpl",
@@ -437,6 +456,7 @@
           "@@type": "xod-project/Node"
         },
         "ryVmUAOrvkb": {
+          "arityLevel": 1,
           "boundValues": {
             "__in__": false
           },
@@ -467,6 +487,7 @@
       "links": {},
       "nodes": {
         "HJdO9HwJ-": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "HJdO9HwJ-",
@@ -479,6 +500,7 @@
           "@@type": "xod-project/Node"
         },
         "S1n95SDJb": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "S1n95SDJb",
@@ -491,6 +513,7 @@
           "@@type": "xod-project/Node"
         },
         "noNativeImpl": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "id": "noNativeImpl",

--- a/packages/xod-project/test/fixtures/with-empty-optional-fields.json
+++ b/packages/xod-project/test/fixtures/with-empty-optional-fields.json
@@ -7,6 +7,7 @@
       "comments": {},
       "nodes": {
         "a": {
+          "arityLevel": 1,
           "boundValues": {},
           "description": "",
           "label": "",

--- a/packages/xod-project/test/helpers.js
+++ b/packages/xod-project/test/helpers.js
@@ -113,6 +113,7 @@ export const defaultizeNode = R.merge({
   label: '',
   description: '',
   boundValues: {},
+  arityLevel: 1,
 });
 
 export const defaultizePin = R.merge({

--- a/packages/xod-project/test/patch.spec.js
+++ b/packages/xod-project/test/patch.spec.js
@@ -1496,6 +1496,50 @@ describe('Patch', () => {
         assert.equal(res.isLeft, true);
         Helper.expectErrorMessage(expect, res, MSG.variadicHasNotEnoughInputs(2, 1, 3));
       });
+      it('returns Either.Left Error for patch with different types of output pins and accumulator input pins', () => {
+        const patch = Helper.defaultizePatch({
+          nodes: {
+            a: {
+              id: 'a',
+              type: 'xod/patch-nodes/variadic-2',
+            },
+            b: {
+              id: 'b',
+              label: 'X',
+              type: 'xod/patch-nodes/input-number',
+            },
+            c: {
+              id: 'c',
+              label: 'Y',
+              type: 'xod/patch-nodes/input-number',
+            },
+            d: {
+              id: 'd',
+              label: 'ADD',
+              type: 'xod/patch-nodes/input-number',
+            },
+            e: {
+              id: 'e',
+              label: 'ADD2',
+              type: 'xod/patch-nodes/input-number',
+            },
+            f: {
+              id: 'f',
+              label: 'A',
+              type: 'xod/patch-nodes/output-number',
+            },
+            g: {
+              id: 'g',
+              label: 'B',
+              type: 'xod/patch-nodes/output-boolean',
+            },
+          },
+        });
+        const res = Patch.computeVariadicPins(patch);
+
+        assert.equal(res.isLeft, true);
+        Helper.expectErrorMessage(expect, res, MSG.wrongVariadicPinTypes(['Y'], ['B']));
+      });
       it('returns Either.Right VariadicPins for patch with variadic marker and correct amount of pins', () => {
         const patch = Helper.defaultizePatch({
           nodes: {

--- a/packages/xod-project/test/patch.spec.js
+++ b/packages/xod-project/test/patch.spec.js
@@ -1334,5 +1334,50 @@ describe('Patch', () => {
         );
       });
     });
+
+    describe('getVardiadicKindFromPatch', () => {
+      it('returns Nothing for patch without variadic Node', () => {
+        const patch = Helper.defaultizePatch({});
+        assert.equal(
+          Patch.getVardiadicKindFromPatch(patch).isNothing,
+          true
+        );
+      });
+      it('returns Nothing for patch with wrong kind of variadic Node', () => {
+        const patch = Helper.defaultizePatch({
+          nodes: {
+            a: {
+              id: 'a',
+              type: 'xod/patch-nodes/variadic-99',
+            },
+          },
+        });
+        assert.equal(
+          Patch.getVardiadicKindFromPatch(patch).isNothing,
+          true
+        );
+      });
+
+      const createTestForJust = (n) => {
+        it(`returns Maybe ${n} for patch with variadic Node`, () => {
+          const patch = Helper.defaultizePatch({
+            nodes: {
+              a: {
+                id: 'a',
+                type: `xod/patch-nodes/variadic-${n}`,
+              },
+            },
+          });
+          assert.equal(
+            Patch.getVardiadicKindFromPatch(patch).getOrElse(null),
+            n
+          );
+        });
+      };
+
+      createTestForJust(1);
+      createTestForJust(2);
+      createTestForJust(3);
+    });
   });
 });


### PR DESCRIPTION
It closes #1064.

But latest one item from acceptance criteria could not be finished in ideal way, cause we need to do a massive refactoring over "dead reference errors", flatten Patch tree and validate leaves and etc.

Error is appearing, but it looks like:
```
Patch @/01-hello contains dead references:
A variadic patch should have at least one output
Fix or delete them to continue.
````