### PR TITLE
Don’t show tooltip for dragged node

### DIFF
--- a/packages/xod-client/src/project/components/Node.jsx
+++ b/packages/xod-client/src/project/components/Node.jsx
@@ -72,17 +72,17 @@ class Node extends React.Component {
       position,
       size,
       type,
+      isDragged,
     } = this.props;
 
     const pinsArr = R.values(pins);
 
     const cls = classNames('Node', {
       'is-selected': this.props.isSelected,
-      'is-dragged': this.props.isDragged,
+      'is-dragged': isDragged,
       'is-ghost': this.props.isGhost,
       'is-errored': (this.props.errors.length > 0),
     });
-
 
     const svgStyle = {
       overflow: 'visible',
@@ -102,7 +102,7 @@ class Node extends React.Component {
 
     return (
       <TooltipHOC
-        content={renderTooltipContent(type, nodeLabel, errMessage)}
+        content={isDragged ? null : renderTooltipContent(type, nodeLabel, errMessage)}
         render={(onMouseOver, onMouseMove, onMouseLeave) => (
           <svg
             key={id}

--- a/packages/xod-client/src/tooltip/components/Tooltip.jsx
+++ b/packages/xod-client/src/tooltip/components/Tooltip.jsx
@@ -46,6 +46,8 @@ class Tooltip extends React.Component {
   }
 
   render() {
+    if (!this.state.content) return null;
+
     const cls = cn('Tooltip', {
       'is-visible': this.state.shown,
     });


### PR DESCRIPTION
It was like this before custom tooltips:
https://github.com/xodio/xod/blob/22819700d2a82fbb3c28b08682ac1a8d2ef0ca23/packages/xod-client/src/project/components/Node.jsx#L106