### PR TITLE
Show variadic pin dots on hover

### DIFF
--- a/packages/xod-client/src/core/styles/components/Node.scss
+++ b/packages/xod-client/src/core/styles/components/Node.scss
@@ -72,7 +72,7 @@
     user-select: none;
   }
 
-  &:hover {
+  &.is-hovered {
     .outline {
       stroke: $color-highlight;
     }

--- a/packages/xod-client/src/core/styles/components/Node.scss
+++ b/packages/xod-client/src/core/styles/components/Node.scss
@@ -143,7 +143,7 @@
   }
   &--grip {
     pointer-events: none;
-    stroke-width: 6px;
+    stroke-width: 5px;
     stroke-linecap: round;
     stroke: $color-node-outline;
   }

--- a/packages/xod-client/src/core/styles/components/Pin.scss
+++ b/packages/xod-client/src/core/styles/components/Pin.scss
@@ -106,6 +106,7 @@
 .Node.is-selected + .pins .PinDots,
 .Node.is-hovered + .pins .PinDots,
 .Node.is-changing-arity + .pins .PinDots,
+.PinWidget .PinDots,
 .PatchDocs .PinDots {
   visibility: visible;
 }

--- a/packages/xod-client/src/core/styles/components/Pin.scss
+++ b/packages/xod-client/src/core/styles/components/Pin.scss
@@ -96,8 +96,16 @@
 }
 
 .PinDots {
+  visibility: hidden;
   fill: $chalk;
   font-family: $font-family-normal;
   font-size: 14px;
   font-weight: 500;
+}
+
+.Node.is-selected + .pins .PinDots,
+.Node.is-hovered + .pins .PinDots,
+.Node.is-changing-arity + .pins .PinDots,
+.PatchDocs .PinDots {
+  visibility: visible;
 }

--- a/packages/xod-client/src/editor/components/NodeInspector.jsx
+++ b/packages/xod-client/src/editor/components/NodeInspector.jsx
@@ -39,6 +39,7 @@ const getPinWidgetProps = R.applySpec({
   direction: XP.getPinDirection,
   isConnected: R.prop('isConnected'),
   isBindable: XP.isPinBindable,
+  isLastVariadicGroup: R.prop('isLastVariadicGroup'),
 });
 
 // :: RenderableNode -> { components: {...}, props: {...} }

--- a/packages/xod-client/src/editor/components/inspectorWidgets/Widget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/Widget.jsx
@@ -100,6 +100,7 @@ export default function composeWidget(Component, widgetProps) {
             title={this.props.title}
             normalizedLabel={this.props.normalizedLabel}
             isConnected={this.props.isConnected}
+            isLastVariadicGroup={this.props.isLastVariadicGroup}
             isBindable={this.props.isBindable}
             direction={this.props.direction}
             dataType={this.type}
@@ -131,6 +132,7 @@ export default function composeWidget(Component, widgetProps) {
       PropTypes.array,
     ]),
     isConnected: PropTypes.bool,
+    isLastVariadicGroup: PropTypes.bool,
     isBindable: PropTypes.bool,
     focused: PropTypes.bool,
     // dispatchers
@@ -146,6 +148,7 @@ export default function composeWidget(Component, widgetProps) {
     title: '',
     focused: false,
     isConnected: false,
+    isLastVariadicGroup: false,
     isBindable: true,
     direction: '',
     onPropUpdate: noop,

--- a/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/BoolPinWidget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/BoolPinWidget.jsx
@@ -16,6 +16,7 @@ function BoolWidget(props) {
       normalizedLabel={props.normalizedLabel}
       dataType={props.dataType}
       isConnected={props.isConnected}
+      isLastVariadicGroup={props.isLastVariadicGroup}
       isBindable={props.isBindable}
       direction={props.direction}
     >
@@ -40,6 +41,7 @@ BoolWidget.propTypes = {
   normalizedLabel: PropTypes.string.isRequired,
   dataType: PropTypes.string,
   isConnected: PropTypes.bool,
+  isLastVariadicGroup: PropTypes.bool,
   isBindable: PropTypes.bool,
   direction: PropTypes.string,
 

--- a/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/DeadPinWidget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/DeadPinWidget.jsx
@@ -10,6 +10,7 @@ const DeadWidget = props => (
     normalizedLabel={props.normalizedLabel}
     dataType={props.dataType}
     isConnected={props.isConnected}
+    isLastVariadicGroup={props.isLastVariadicGroup}
     isBindable={props.isBindable}
     direction={props.direction}
   />
@@ -21,6 +22,7 @@ DeadWidget.propTypes = {
   label: PropTypes.string,
   dataType: PropTypes.string,
   isConnected: PropTypes.bool,
+  isLastVariadicGroup: PropTypes.bool,
   isBindable: PropTypes.bool,
   direction: PropTypes.string,
 };

--- a/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/NumberPinWidget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/NumberPinWidget.jsx
@@ -17,6 +17,7 @@ const NumberWidget = (props) => {
       normalizedLabel={props.normalizedLabel}
       dataType={props.dataType}
       isConnected={props.isConnected}
+      isLastVariadicGroup={props.isLastVariadicGroup}
       isBindable={props.isBindable}
       direction={props.direction}
     >
@@ -40,6 +41,7 @@ NumberWidget.propTypes = {
   label: PropTypes.string,
   dataType: PropTypes.string,
   isConnected: PropTypes.bool,
+  isLastVariadicGroup: PropTypes.bool,
   isBindable: PropTypes.bool,
   direction: PropTypes.string,
 

--- a/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/PinIcon.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/PinIcon.jsx
@@ -7,7 +7,7 @@ import { PIN_RADIUS_WITH_SHADOW } from '../../../../project/nodeLayout';
 
 const pinPos = { x: PIN_RADIUS_WITH_SHADOW, y: PIN_RADIUS_WITH_SHADOW };
 
-const PinIcon = ({ id, type, isConnected }) => (
+const PinIcon = ({ id, type, isConnected, isLastVariadicGroup }) => (
   <svg width={PIN_RADIUS_WITH_SHADOW * 2} height={PIN_RADIUS_WITH_SHADOW * 2} className="PinIcon">
     <Pin
       keyName={`widgetPinIcon_${id}`}
@@ -17,6 +17,7 @@ const PinIcon = ({ id, type, isConnected }) => (
       onMouseDown={noop}
       isSelected={false}
       isConnected={isConnected}
+      isLastVariadicGroup={isLastVariadicGroup}
       isAcceptingLinks={false}
     />
   </svg>
@@ -28,6 +29,7 @@ PinIcon.propTypes = {
   id: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   isConnected: PropTypes.bool.isRequired,
+  isLastVariadicGroup: PropTypes.bool.isRequired,
 };
 
 export default PinIcon;

--- a/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/PinWidget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/PinWidget.jsx
@@ -52,6 +52,7 @@ function PinWidget(props) {
         id={props.elementId}
         type={props.dataType}
         isConnected={props.isConnected}
+        isLastVariadicGroup={props.isLastVariadicGroup}
       />
       <label
         htmlFor={props.elementId}
@@ -68,6 +69,7 @@ PinWidget.propTypes = {
   label: PropTypes.string,
   dataType: PropTypes.string,
   isConnected: PropTypes.bool,
+  isLastVariadicGroup: PropTypes.bool,
   isBindable: PropTypes.bool, // eslint-disable-line react/no-unused-prop-types
   direction: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
   children: PropTypes.element,

--- a/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/PulsePinWidget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/PulsePinWidget.jsx
@@ -17,6 +17,7 @@ const PulseWidget = (props) => {
       normalizedLabel={props.normalizedLabel}
       dataType={props.dataType}
       isConnected={props.isConnected}
+      isLastVariadicGroup={props.isLastVariadicGroup}
       isBindable={props.isBindable}
       direction={props.direction}
     >
@@ -42,6 +43,7 @@ PulseWidget.propTypes = {
   label: PropTypes.string,
   dataType: PropTypes.string,
   isConnected: PropTypes.bool,
+  isLastVariadicGroup: PropTypes.bool,
   isBindable: PropTypes.bool,
   direction: PropTypes.string,
 

--- a/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/StringPinWidget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/StringPinWidget.jsx
@@ -15,6 +15,7 @@ const StringWidget = (props) => {
       normalizedLabel={props.normalizedLabel}
       dataType={props.dataType}
       isConnected={props.isConnected}
+      isLastVariadicGroup={props.isLastVariadicGroup}
       isBindable={props.isBindable}
       direction={props.direction}
     >
@@ -37,6 +38,7 @@ StringWidget.propTypes = {
   label: PropTypes.string,
   dataType: PropTypes.string,
   isConnected: PropTypes.bool,
+  isLastVariadicGroup: PropTypes.bool,
   isBindable: PropTypes.bool,
   direction: PropTypes.string,
 

--- a/packages/xod-client/src/editor/containers/Patch/index.jsx
+++ b/packages/xod-client/src/editor/containers/Patch/index.jsx
@@ -33,6 +33,8 @@ import debuggingMode from './modes/debugging';
 import marqueeSelectingMode from './modes/marqueeSelecting';
 import changingArityLevelMode from './modes/changingArityLevel';
 
+import nodeHoverContextType from '../../nodeHoverContextType';
+
 const MODE_HANDLERS = {
   [EDITOR_MODE.DEFAULT]: selectingMode,
   [EDITOR_MODE.LINKING]: linkingMode,
@@ -63,6 +65,7 @@ class Patch extends React.Component {
       modeSpecificState: {
         [mode]: MODE_HANDLERS[mode].getInitialState(props),
       },
+      hoveredNodeId: null,
     };
 
     this.goToMode = this.goToMode.bind(this);
@@ -70,6 +73,18 @@ class Patch extends React.Component {
     this.getModeState = this.getModeState.bind(this);
     this.setModeState = this.setModeState.bind(this);
     this.setModeStateThrottled = throttle(100, true, this.setModeState);
+  }
+
+  getChildContext() {
+    // We're creating context here only for handle hovering of the Node.
+    // Don't be tempted to use context for other tasks if you can solve them differently.
+    return {
+      nodeHover: {
+        nodeId: this.state.hoveredNodeId,
+        onMouseOver: nodeId => this.setState({ hoveredNodeId: nodeId }),
+        onMouseLeave: () => this.setState({ hoveredNodeId: null }),
+      },
+    };
   }
 
   componentWillReceiveProps(nextProps) {
@@ -169,6 +184,10 @@ class Patch extends React.Component {
 
 Patch.contextTypes = {
   store: PropTypes.object,
+};
+
+Patch.childContextTypes = {
+  nodeHover: nodeHoverContextType,
 };
 
 Patch.propTypes = {

--- a/packages/xod-client/src/editor/containers/Patch/modes/panning.jsx
+++ b/packages/xod-client/src/editor/containers/Patch/modes/panning.jsx
@@ -121,6 +121,7 @@ const panningMode = {
               nodes={api.props.nodes}
               selection={api.props.selection}
               linkingPin={api.props.linkingPin}
+              noNodeHovering
             />
             <Layers.LinksOverlay
               hidden // to avoid heavy remounting

--- a/packages/xod-client/src/editor/nodeHoverContextType.js
+++ b/packages/xod-client/src/editor/nodeHoverContextType.js
@@ -1,0 +1,7 @@
+import PropTypes from 'prop-types';
+
+export default PropTypes.shape({
+  nodeId: PropTypes.string,
+  onMouseOver: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+});

--- a/packages/xod-client/src/project/components/Node.jsx
+++ b/packages/xod-client/src/project/components/Node.jsx
@@ -15,6 +15,8 @@ import TerminalNodeBody from './nodeParts/TerminalNodeBody';
 
 import TooltipHOC from '../../tooltip/components/TooltipHOC';
 
+import nodeHoverContextType from '../../editor/nodeHoverContextType';
+
 const renderTooltipContent = (nodeType, nodeLabel, errText) => [
   <div key="nodeLabel" className="Tooltip--nodeLabel">{nodeLabel}</div>,
   <div key="nodeType" className="Tooltip--nodeType">{nodeType}</div>,
@@ -53,6 +55,25 @@ class Node extends React.Component {
     this.props.onDoubleClick(this.props.id, this.props.type);
   }
 
+  onMouseOver(...args) {
+    return R.pathOr(noop, ['context', 'nodeHover', 'onMouseOver'], this)(...args);
+  }
+
+  onMouseLeave(...args) {
+    return R.pathOr(noop, ['context', 'nodeHover', 'onMouseLeave'], this)(...args);
+  }
+
+  getHoveredNodeId() {
+    return R.pathOr(null, ['context', 'nodeHover', 'nodeId'], this);
+  }
+
+  isNodeHovered() {
+    return (
+      this.getHoveredNodeId() === this.props.id
+      && !this.props.noNodeHovering
+    );
+  }
+
   renderBody() {
     const { type } = this.props;
 
@@ -84,6 +105,7 @@ class Node extends React.Component {
       'is-variadic': this.props.isVariadic,
       'is-changing-arity': this.props.isChangingArity,
       'is-errored': (this.props.errors.length > 0),
+      'is-hovered': this.isNodeHovered(),
     });
 
     const pinsCls = classNames('pins', {
@@ -117,9 +139,15 @@ class Node extends React.Component {
             {...position}
             {...size}
             viewBox={`0 0 ${size.width} ${size.height}`}
-            onMouseOver={onMouseOver}
+            onMouseOver={(...args) => {
+              onMouseOver(...args);
+              this.onMouseOver(id);
+            }}
             onMouseMove={onMouseMove}
-            onMouseLeave={onMouseLeave}
+            onMouseLeave={(...args) => {
+              onMouseLeave(...args);
+              this.onMouseLeave();
+            }}
           >
             <g
               className={cls}
@@ -158,6 +186,10 @@ class Node extends React.Component {
   }
 }
 
+Node.contextTypes = {
+  nodeHover: nodeHoverContextType,
+};
+
 Node.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
@@ -180,6 +212,7 @@ Node.propTypes = {
   onMouseDown: PropTypes.func,
   onMouseUp: PropTypes.func,
   onDoubleClick: PropTypes.func,
+  noNodeHovering: PropTypes.bool,
 };
 
 Node.defaultProps = {
@@ -194,6 +227,7 @@ Node.defaultProps = {
   onMouseUp: noop,
   onDoubleClick: noop,
   pinLinkabilityValidator: R.F,
+  noNodeHovering: false,
 };
 
 export default Node;

--- a/packages/xod-client/src/project/components/NodePinsOverlay.jsx
+++ b/packages/xod-client/src/project/components/NodePinsOverlay.jsx
@@ -6,6 +6,8 @@ import PinOverlay from './PinOverlay';
 import { noop } from '../../utils/ramda';
 import { isPinSelected } from '../../editor/utils';
 
+import nodeHoverContextType from '../../editor/nodeHoverContextType';
+
 class NodePinsOverlay extends React.Component {
   constructor(props) {
     super(props);
@@ -50,6 +52,8 @@ class NodePinsOverlay extends React.Component {
         {...size}
         className="NodePinsOverlay"
         viewBox={`0 0 ${size.width} ${size.height}`}
+        onMouseOver={() => this.context.nodeHover.onMouseOver(id)}
+        onMouseLeave={() => this.context.nodeHover.onMouseLeave()}
         data-label={nodeLabel} // for func tests
       >
         <g className="pins">
@@ -71,6 +75,11 @@ class NodePinsOverlay extends React.Component {
     );
   }
 }
+
+
+NodePinsOverlay.contextTypes = {
+  nodeHover: nodeHoverContextType,
+};
 
 NodePinsOverlay.propTypes = {
   id: PropTypes.string.isRequired,

--- a/packages/xod-client/src/project/components/layers/NodesLayer.jsx
+++ b/packages/xod-client/src/project/components/layers/NodesLayer.jsx
@@ -20,6 +20,7 @@ const NodesLayer = ({
   isDebugSession,
   nodeValues,
   onVariadicHandleDown,
+  noNodeHovering,
 }) => {
   const pinLinkabilityValidator = getPinLinkabilityValidator(linkingPin, nodes);
 
@@ -52,6 +53,7 @@ const NodesLayer = ({
               isDebugSession={isDebugSession}
               nodeValue={R.prop(node.id, nodeValues)}
               onVariadicHandleDown={onVariadicHandleDown}
+              noNodeHovering={noNodeHovering}
             />
         ),
         R.values
@@ -76,6 +78,7 @@ NodesLayer.propTypes = {
   isDebugSession: PropTypes.bool,
   nodeValues: PropTypes.objectOf(PropTypes.string),
   onVariadicHandleDown: PropTypes.func,
+  noNodeHovering: PropTypes.bool,
 };
 
 export default pureDeepEqual(NodesLayer);

--- a/packages/xod-client/src/project/components/nodeParts/VariadicHandle.jsx
+++ b/packages/xod-client/src/project/components/nodeParts/VariadicHandle.jsx
@@ -18,8 +18,8 @@ const VariadicHandle = props => (
     />
     <line
       className="VariadicHandle--grip"
-      x1={props.size.width - 2}
-      x2={props.size.width - 2}
+      x1={props.size.width - 1.5}
+      x2={props.size.width - 1.5}
       y1={(props.size.height / 2) - 5}
       y2={(props.size.height / 2) + 5}
     />

--- a/packages/xod-client/src/tooltip/components/TooltipHOC.jsx
+++ b/packages/xod-client/src/tooltip/components/TooltipHOC.jsx
@@ -77,7 +77,7 @@ class TooltipHOC extends React.Component {
 }
 
 TooltipHOC.propTypes = {
-  content: PropTypes.node.isRequired,
+  content: PropTypes.node,
   render: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
There is no issue. 😬 

What I've done:
- Show variadic PinDots on hover, on selection or while changing arity level
- Make Node hovering works not by CSS, but by using React context and state. Now Node still rendered as hovered while User moving mouse over Pins
- Show PinDots in Inspector
- Show PinDots in Help box
- Tweak variadic Node grip (6px width -> 5px, added 0.5px to x to avoid smooth edge)
- Fixed React Warning of `TooltipHOC` on dragging Node (introduced in PR #1094 )

You can check out this PR commit by commit.
Please, pay attention to the first commit, cause there is appeared using of React context.