### PR TITLE
Do not emit extraneous pulse from defer-pulse on boot

### DIFF
--- a/workspace/__lib__/xod/core/defer-pulse/patch.cpp
+++ b/workspace/__lib__/xod/core/defer-pulse/patch.cpp
@@ -6,7 +6,7 @@ struct State {
 void evaluate(Context ctx) {
     if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated
         setTimeout(ctx, 0);
-    } else {
+    } else if (isTimedOut(ctx)) {
         emitValue<output_OUT>(ctx, true);
     }
 }


### PR DESCRIPTION
Fixes the problem [reported on forum](https://forum.xod.io/t/state-machine-initialization-in-xod-0-18-1/499). I introduced the bug in #1020 