### PR TITLE
Legalize parametric patch names

### DIFF
--- a/packages/xod-client/src/project/actions.js
+++ b/packages/xod-client/src/project/actions.js
@@ -117,7 +117,7 @@ export const redoPatch = patchPath => ({
 });
 
 export const addPatch = baseName => (dispatch, getState) => {
-  if (!XP.isValidIdentifier(baseName)) {
+  if (!XP.isValidPatchBasename(baseName)) {
     return dispatch(addError(PROJECT_BROWSER_ERRORS.INVALID_PATCH_NAME));
   }
 
@@ -140,6 +140,10 @@ export const renamePatch = (oldPatchPath, newBaseName) => (
   dispatch,
   getState
 ) => {
+  if (!XP.isValidPatchBasename(newBaseName)) {
+    return dispatch(addError(PROJECT_BROWSER_ERRORS.INVALID_PATCH_NAME));
+  }
+
   const newPatchPath = XP.getLocalPath(newBaseName);
   const state = getState();
 

--- a/packages/xod-client/src/projectBrowser/components/ProjectBrowserPopups.jsx
+++ b/packages/xod-client/src/projectBrowser/components/ProjectBrowserPopups.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { isValidIdentifier, IDENTIFIER_RULES } from 'xod-project';
+import { isValidPatchBasename, PATCH_BASENAME_RULES } from 'xod-project';
 import { POPUP_ID } from '../../popups/constants';
 import { isPopupVisible } from '../../popups/selectors';
 
 import PopupPrompt from '../../utils/components/PopupPrompt';
 import PopupConfirm from '../../utils/components/PopupConfirm';
-import { lowercaseKebabMask } from '../../utils/inputFormatting';
+import { patchBasenameMask } from '../../utils/inputFormatting';
 
 class ProjectBrowserPopups extends React.PureComponent {
   constructor(props) {
@@ -40,9 +40,9 @@ class ProjectBrowserPopups extends React.PureComponent {
         title="Create new patch"
         onConfirm={this.props.onPatchCreate}
         onClose={this.props.onCloseAllPopups}
-        inputMask={lowercaseKebabMask}
-        inputValidator={isValidIdentifier}
-        helpText={IDENTIFIER_RULES}
+        inputMask={patchBasenameMask}
+        inputValidator={isValidPatchBasename}
+        helpText={PATCH_BASENAME_RULES}
       >
         Type the name for new patch:
       </PopupPrompt>
@@ -58,9 +58,9 @@ class ProjectBrowserPopups extends React.PureComponent {
         title="Rename patch"
         onConfirm={this.onPatchRenameConfirmed}
         onClose={this.props.onCloseAllPopups}
-        inputMask={lowercaseKebabMask}
-        inputValidator={isValidIdentifier}
-        helpText={IDENTIFIER_RULES}
+        inputMask={patchBasenameMask}
+        inputValidator={isValidPatchBasename}
+        helpText={PATCH_BASENAME_RULES}
       >
         Type new name for patch &laquo;{selectedPatchName}&raquo;:
       </PopupPrompt>

--- a/packages/xod-client/src/projectBrowser/components/ProjectBrowserPopups.jsx
+++ b/packages/xod-client/src/projectBrowser/components/ProjectBrowserPopups.jsx
@@ -56,6 +56,7 @@ class ProjectBrowserPopups extends React.PureComponent {
       <PopupPrompt
         key="rename_patch"
         title="Rename patch"
+        value={selectedPatchName}
         onConfirm={this.onPatchRenameConfirmed}
         onClose={this.props.onCloseAllPopups}
         inputMask={patchBasenameMask}

--- a/packages/xod-client/src/utils/components/PopupPrompt.jsx
+++ b/packages/xod-client/src/utils/components/PopupPrompt.jsx
@@ -9,12 +9,14 @@ import { noop } from '../../utils/ramda';
 import { KEYCODE } from '../../utils/constants';
 import deepSCU from '../deepSCU';
 
+const selectOnFocus = event => event.target.select();
+
 class PopupPrompt extends React.Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      inputValue: '',
+      inputValue: props.value,
     };
 
     this.onCloseClicked = this.onCloseClicked.bind(this);
@@ -107,6 +109,7 @@ class PopupPrompt extends React.Component {
                   type={inputType}
                   value={this.state.inputValue}
                   onChange={this.onInputChange}
+                  onFocus={selectOnFocus}
                   autoFocus
                 />
                 <p className="helpText">{helpText}</p>
@@ -133,6 +136,7 @@ class PopupPrompt extends React.Component {
 
 PopupPrompt.propTypes = {
   title: PropTypes.string,
+  value: PropTypes.string,
   helpText: PropTypes.string,
   children: PropTypes.any,
   confirmText: PropTypes.string,
@@ -149,6 +153,7 @@ PopupPrompt.propTypes = {
 
 PopupPrompt.defaultProps = {
   title: 'We have a question...',
+  value: '',
   helpText: '',
   confirmText: 'Confirm',
   cancelText: 'Cancel',

--- a/packages/xod-client/src/utils/inputFormatting.js
+++ b/packages/xod-client/src/utils/inputFormatting.js
@@ -3,6 +3,7 @@ import * as R from 'ramda';
 import { PIN_TYPE } from 'xod-project';
 
 export const lowercaseKebabMask = R.replace(/[^a-z0-9-]/g, '');
+export const patchBasenameMask = R.replace(/[^a-z0-9-,()]/g, '');
 
 export const PROPERTY_TYPE_PARSE = {
   [PIN_TYPE.BOOLEAN]: v => !!v,

--- a/packages/xod-project/src/constants.js
+++ b/packages/xod-project/src/constants.js
@@ -63,6 +63,8 @@ export const IDENTIFIER_RULES = `Only a-z, 0-9 and - are allowed.
   Name must not begin or end with a hypen,
   or contain more than one hypen in a row`;
 
+export const PATCH_BASENAME_RULES = IDENTIFIER_RULES;
+
 /**
  * Enumeration of possible pin types
  *

--- a/packages/xod-project/src/patchPathUtils.js
+++ b/packages/xod-project/src/patchPathUtils.js
@@ -13,6 +13,7 @@ import {
 export {
   isLocalMarker,
   isValidIdentifier,
+  isValidPatchBasename,
   isPathLocal,
   isPathLibrary,
   isLibName,

--- a/packages/xod-project/test/fixtures/blinking.xodball
+++ b/packages/xod-project/test/fixtures/blinking.xodball
@@ -2535,10 +2535,10 @@
         }
       ]
     },
-    "xod/core/analog_output": {
+    "xod/core/analog-output": {
       "comments": {},
       "description": "",
-      "path": "xod/core/analog_output",
+      "path": "xod/core/analog-output",
       "nodes": {
         "noNativeImpl": {
           "label": "",
@@ -2642,10 +2642,10 @@
         }
       ]
     },
-    "xod/core/analog_input": {
+    "xod/core/analog-input": {
       "comments": {},
       "description": "",
-      "path": "xod/core/analog_input",
+      "path": "xod/core/analog-input",
       "nodes": {
         "noNativeImpl": {
           "label": "",

--- a/packages/xod-project/test/project.spec.js
+++ b/packages/xod-project/test/project.spec.js
@@ -296,7 +296,7 @@ describe('Project', () => {
     it('should return Either.Right with Project', () => {
       const patch = {};
       const oldPath = '@/test';
-      const newPath = '@/anotherPath';
+      const newPath = '@/another-path';
       const project = Helper.defaultizeProject({
         patches: { [oldPath]: patch },
       });
@@ -511,7 +511,7 @@ describe('Project', () => {
     });
     it('should return Either.Right for correct values', () => {
       const oldPath = '@/test';
-      const newPath = '@/anotherPath';
+      const newPath = '@/another-path';
       const project = Helper.defaultizeProject({ patches: { [oldPath]: {} } });
 
       const newProject = Project.rebasePatch(newPath, oldPath, project);
@@ -525,7 +525,7 @@ describe('Project', () => {
     });
     it('should update path property of a moved patch', () => {
       const oldPath = '@/test';
-      const newPath = '@/anotherPath';
+      const newPath = '@/another-path';
       const project = Helper.defaultizeProject({
         patches: {
           [oldPath]: { path: oldPath },
@@ -544,7 +544,7 @@ describe('Project', () => {
     });
     it('should update all reference on changed path', () => {
       const oldPath = '@/test';
-      const newPath = '@/anotherPath';
+      const newPath = '@/another-path';
       const withNodesPath = '@/withNodes';
       const project = Helper.defaultizeProject({
         patches: {


### PR DESCRIPTION
It closes #1114.

Also tweaked rename popup. Now input already contains current patch name and autoselected.