### PR TITLE
Mark links between incompatible types

### DIFF
--- a/packages/xod-arduino/src/transpiler.js
+++ b/packages/xod-arduino/src/transpiler.js
@@ -326,7 +326,6 @@ const transformProjectWithImpls = def(
   'transformProjectWithImpls :: Project -> PatchPath -> TranspilationOptions -> Either Error TProject',
   (project, path, opts) =>
     R.compose(
-      Project.wrapDeadRefErrorMessage(path),
       R.chain(tProject => {
         const nodeWithTooManyOutputs = R.find(
           R.pipe(R.prop('outputs'), R.length, R.lt(7)),

--- a/packages/xod-client/src/core/containers/App.jsx
+++ b/packages/xod-client/src/core/containers/App.jsx
@@ -43,7 +43,11 @@ export default class App extends React.Component {
       foldEither(
         R.compose(
           this.props.actions.addError,
-          R.when(R.is(Error), err => composeMessage(err.message))
+          R.when(R.is(Error), err => {
+            const title = err.title || err.message;
+            const message = err.title ? err.message : null;
+            return composeMessage(title, message);
+          })
         ),
         this.props.actions.showCode
       ),

--- a/packages/xod-client/src/project/components/Link.jsx
+++ b/packages/xod-client/src/project/components/Link.jsx
@@ -2,9 +2,19 @@ import * as R from 'ramda';
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { mapIndexed } from 'xod-func-tools';
 
 import { noop } from '../../utils/ramda';
 import { PIN_RADIUS, LINK_HOTSPOT_SIZE } from '../nodeLayout';
+
+import TooltipHOC from '../../tooltip/components/TooltipHOC';
+
+// :: [Error] -> [ReactNode]
+const renderTooltipContent = mapIndexed((err, idx) => (
+  <div key={idx} className="Tooltip--error">
+    {err.message}
+  </div>
+));
 
 class Link extends React.Component {
   constructor(props) {
@@ -61,33 +71,45 @@ class Link extends React.Component {
     const linkEndRadius = PIN_RADIUS - 3;
 
     return (
-      <g
-        className={cls}
-        id={this.elementId}
-        onClick={this.onClick}
-        style={{ pointerEvents }}
-      >
-        <line
-          stroke="transparent"
-          strokeWidth={LINK_HOTSPOT_SIZE.WIDTH}
-          {...coords}
-        />
-        <line className="line" {...coords} />
-        <circle
-          className="end"
-          cx={coords.x1}
-          cy={coords.y1}
-          r={linkEndRadius}
-          fill="black"
-        />
-        <circle
-          className="end"
-          cx={coords.x2}
-          cy={coords.y2}
-          r={linkEndRadius}
-          fill="black"
-        />
-      </g>
+      <TooltipHOC
+        content={
+          R.isEmpty(this.props.errors)
+            ? null
+            : renderTooltipContent(this.props.errors)
+        }
+        render={(onMouseOver, onMouseMove, onMouseLeave) => (
+          <g
+            className={cls}
+            id={this.elementId}
+            onClick={this.onClick}
+            onMouseOver={onMouseOver}
+            onMouseMove={onMouseMove}
+            onMouseLeave={onMouseLeave}
+            style={{ pointerEvents }}
+          >
+            <line
+              stroke="transparent"
+              strokeWidth={LINK_HOTSPOT_SIZE.WIDTH}
+              {...coords}
+            />
+            <line className="line" {...coords} />
+            <circle
+              className="end"
+              cx={coords.x1}
+              cy={coords.y1}
+              r={linkEndRadius}
+              fill="black"
+            />
+            <circle
+              className="end"
+              cx={coords.x2}
+              cy={coords.y2}
+              r={linkEndRadius}
+              fill="black"
+            />
+          </g>
+        )}
+      />
     );
   }
 }
@@ -98,6 +120,7 @@ Link.propTypes = {
   to: PropTypes.object.isRequired,
   type: PropTypes.string.isRequired,
   dead: PropTypes.bool,
+  errors: PropTypes.arrayOf(PropTypes.instanceOf(Error)),
   isSelected: PropTypes.bool,
   isGhost: PropTypes.bool,
   isOverlay: PropTypes.bool,
@@ -107,6 +130,7 @@ Link.propTypes = {
 
 Link.defaultProps = {
   dead: false,
+  errors: [],
   isSelected: false,
   isGhost: false,
   isOverlay: false,

--- a/packages/xod-client/src/project/components/layers/LinksOverlayLayer.jsx
+++ b/packages/xod-client/src/project/components/layers/LinksOverlayLayer.jsx
@@ -20,6 +20,8 @@ const LinksOverlayLayer = ({ links, selection, hidden, onClick }) => (
           from={link.from}
           to={link.to}
           type={link.type}
+          dead={link.dead}
+          errors={link.errors}
           onClick={onClick}
           isSelected={isLinkSelected(selection, link.id)}
         />

--- a/packages/xod-project/src/constants.js
+++ b/packages/xod-project/src/constants.js
@@ -7,7 +7,7 @@
 // TODO: Messages that are templates (contains variables)
 //       should be moved into messages.js as separate variables.
 export const ERROR = {
-  // project
+  // dead ref errors:
   TYPE_NOT_FOUND: 'Patch with type "{type}" is not found in the project',
   PINS_NOT_FOUND:
     "Specified node types haven't required pins for creating links",
@@ -56,10 +56,17 @@ export const ERROR = {
   ALL_TYPES_MUST_BE_RESOLVED: 'All generic types must be resolved', // TODO: phrasing!
   CAST_PATCH_NOT_FOUND:
     'Casting patch "{patchPath}" is not found in the project',
+  CANT_CAST_TYPES_DIRECTLY:
+    '{patchPath}: type {fromType} can’t cast to {toType} directly.',
   // .xodball format
   NOT_A_JSON: 'File that you try to load is not in a JSON format',
   INVALID_XODBALL_FORMAT:
     'File that you try to load is corrupted and has a wrong structure',
+};
+
+export const ERROR_TITLES = {
+  DEAD_REFERENCE: 'Dead reference error',
+  BAD_LINKS: 'Program contains bad links',
 };
 
 export const IDENTIFIER_RULES = `Only a-z, 0-9 and - are allowed.

--- a/packages/xod-project/src/flatten.js
+++ b/packages/xod-project/src/flatten.js
@@ -15,7 +15,7 @@ import * as Pin from './pin';
 import * as Node from './node';
 import * as Link from './link';
 import { def } from './types';
-import { formatString, wrapDeadRefErrorMessage } from './utils';
+import { formatString } from './utils';
 import { err, errOnNothing } from './func-tools';
 import * as PatchPathUtils from './patchPathUtils';
 import { getPinKeyForTerminalDirection } from './builtInPatches';
@@ -1033,7 +1033,6 @@ export default def(
         )(project)
       ),
       R.map(expandVariadicNodes(path)),
-      wrapDeadRefErrorMessage(path),
       Project.validateProject
     )(inputProject)
 );

--- a/packages/xod-project/src/func-tools.js
+++ b/packages/xod-project/src/func-tools.js
@@ -38,10 +38,18 @@ export const find = R.curry(R.compose(Maybe, R.find));
  * Returns an Error object wrapped into Either.Left
  * @private
  * @function err
- * @param {string} errorMessage
+ * @param {string|object} errorMessage
  * @returns {Either.Left<Error>}
  */
-export const err = R.compose(R.always, Either.Left, R.construct(Error));
+export const err = R.compose(
+  R.always,
+  Either.Left,
+  R.ifElse(R.is(String), R.construct(Error), ({ title, message }) => {
+    const e = new Error(message);
+    e.title = title;
+    return e;
+  })
+);
 
 /**
  * Returns function that checks condition and returns Either
@@ -49,7 +57,7 @@ export const err = R.compose(R.always, Either.Left, R.construct(Error));
  * Right with passed content for true
  * @private
  * @function errOnFalse
- * @param {string} errorMessage
+ * @param {string|object} errorMessage
  * @param {function} condition
  * @returns {function}
  */
@@ -61,7 +69,7 @@ export const errOnFalse = R.curry((errorMessage, condition) =>
  * Return Either.Right for Maybe.Just and Either.Left for Maybe.Nothing
  * @private
  * @function errOnNothing
- * @param {string} errorMessage Error message for Maybe.Nothing
+ * @param {string|object} errorMessage Error message for Maybe.Nothing
  * @param {*|Maybe<*>} data Data or Maybe monad
  * @returns {Either<Error|*>}
  */

--- a/packages/xod-project/src/messages.js
+++ b/packages/xod-project/src/messages.js
@@ -1,10 +1,3 @@
-export const formatDeadReferencesFound = (patchPath, submessage) =>
-  [
-    `Patch ${patchPath} contains dead references:`,
-    submessage,
-    'Fix or delete them to continue.',
-  ].join('\n');
-
 // Variadics
 
 export const noVariadicMarkers = patchPath =>

--- a/packages/xod-project/src/project.js
+++ b/packages/xod-project/src/project.js
@@ -475,15 +475,14 @@ const checkLinkPin = def(
 /**
  * Checks project for existence of patches and pins that used in link.
  *
- * @private
- * @function checkPinKeys
+ * @function validateLinkPins
  * @param {Link} link
  * @param {Patch} patch
  * @param {Project} project
  * @returns {Either<Error|Patch>}
  */
-const checkPinKeys = def(
-  'checkPinKeys :: Link -> Patch -> Project -> Either Error Patch',
+export const validateLinkPins = def(
+  'validateLinkPins :: Link -> Patch -> Project -> Either Error Patch',
   (link, patch, project) => {
     const checkInputPin = checkLinkPin(
       Link.getLinkInputNodeId,
@@ -548,7 +547,7 @@ export const validatePatchContents = def(
         R.compose(
           R.map(R.always(patch)),
           R.sequence(Either.of),
-          R.map(checkPinKeys(R.__, patch, project))
+          R.map(validateLinkPins(R.__, patch, project))
         )
       ),
       Patch.listLinks

--- a/packages/xod-project/src/project.js
+++ b/packages/xod-project/src/project.js
@@ -352,6 +352,127 @@ export const getPinsForNode = def(
 );
 
 /**
+ * Returns `Maybe Patch`, that is defined as a type of the Node.
+ * If specified Project contains specified Node it will return
+ * `Just Patch` guaranteed. Otherwise it could be `Nothing`.
+ */
+export const getPatchByNode = def(
+  'getPatchByNode :: Node -> Project -> Maybe Patch',
+  (node, project) =>
+    R.compose(getPatchByPath(R.__, project), Node.getNodeType)(node)
+);
+/**
+ * Returns Maybe list of Pins, computed from the Patch,
+ * that is defined as a type of the specified Node.
+ */
+export const getNodePins = def(
+  'getNodePins :: Node -> Project -> Maybe [Pin]',
+  (node, project) =>
+    R.compose(R.map(Patch.listPins), getPatchByNode(R.__, project))(node)
+);
+
+const checkPinsCompatibility = def(
+  'checkPinsCompatibility :: [Pin] -> Patch -> Either Error Patch',
+  ([inputPin, outputPin], patch) => {
+    const patchPath = Patch.getPatchPath(patch);
+    const inputPinType = Pin.getPinType(inputPin);
+    const outputPinType = Pin.getPinType(outputPin);
+
+    return R.compose(
+      R.map(R.always(patch)),
+      Tools.errOnFalse(
+        {
+          title: CONST.ERROR_TITLES.BAD_LINKS,
+          message: Utils.formatString(CONST.ERROR.CANT_CAST_TYPES_DIRECTLY, {
+            fromType: outputPinType,
+            toType: inputPinType,
+            patchPath,
+          }),
+        },
+        Utils.canCastTypes
+      )
+    )(outputPinType, inputPinType);
+  }
+);
+
+/**
+ * Checks one of the link ends (defined by getters).
+ */
+const checkLinkPin = def(
+  'checkLinkPin :: (Link -> NodeId) -> (Link -> PinKey) -> Link -> Patch -> Project -> Either Error Pin',
+  (nodeIdGetter, pinKeyGetter, link, patch, project) => {
+    const nodeId = nodeIdGetter(link);
+    const pinKey = pinKeyGetter(link);
+    const patchPath = Patch.getPatchPath(patch);
+
+    // :: Maybe Node
+    const maybeNode = Patch.getNodeById(nodeId, patch);
+    // :: Maybe NodeType
+    const maybeNodeType = R.map(Node.getNodeType, maybeNode);
+    // :: Maybe Patch
+    const maybePatch = R.chain(getPatchByPath(R.__, project), maybeNodeType);
+
+    // :: Maybe Patch -> Maybe Node -> Either Error (Map NodeId Pin)
+    const checkPinExists = R.curry((mPatch, mNode) =>
+      R.compose(
+        Tools.errOnNothing({
+          title: CONST.ERROR_TITLES.DEAD_REFERENCE,
+          message: CONST.ERROR.PINS_NOT_FOUND,
+        }),
+        R.chain(([justPatch, justNode]) =>
+          R.ifElse(
+            Patch.isVariadicPatch,
+            R.compose(
+              Maybe,
+              R.prop(pinKey),
+              R.reject(Pin.isDeadPin),
+              getPinsForNode(justNode, R.__, project)
+            ),
+            Patch.getPinByKey(pinKey)
+          )(justPatch)
+        ),
+        R.unapply(R.sequence(Maybe.of))
+      )(mPatch, mNode)
+    );
+
+    // :: Maybe Patch -> PatchPath -> Either Error Patch
+    const checkPatchExists = (mPatch, nodeType) =>
+      Tools.errOnNothing(
+        {
+          title: CONST.ERROR_TITLES.DEAD_REFERENCE,
+          message: Utils.formatString(CONST.ERROR.TYPE_NOT_FOUND, {
+            type: nodeType,
+          }),
+        },
+        maybePatch
+      );
+    // :: Maybe Node -> Either Error Node
+    const checkNodeExists = mNode =>
+      Tools.errOnNothing(
+        {
+          title: CONST.ERROR_TITLES.DEAD_REFERENCE,
+          message: Utils.formatString(CONST.ERROR.NODE_NOT_FOUND, {
+            nodeId,
+            patchPath,
+          }),
+        },
+        mNode
+      );
+
+    return R.compose(
+      R.chain(() => checkPinExists(maybePatch, maybeNode)),
+      R.chain(
+        R.compose(
+          nodeType => checkPatchExists(maybePatch, nodeType),
+          Node.getNodeType
+        )
+      ),
+      checkNodeExists
+    )(maybeNode);
+  }
+);
+
+/**
  * Checks project for existence of patches and pins that used in link.
  *
  * @private
@@ -364,63 +485,23 @@ export const getPinsForNode = def(
 const checkPinKeys = def(
   'checkPinKeys :: Link -> Patch -> Project -> Either Error Patch',
   (link, patch, project) => {
-    // TODO: Move check function and child functions on the top-level
-    // :: (Link -> NodeId) -> (Link -> PinKey) -> Either Error Link
-    const check = (nodeIdGetter, pinKeyGetter) => {
-      const nodeId = nodeIdGetter(link);
-      const pinKey = pinKeyGetter(link);
-      const patchPath = Patch.getPatchPath(patch);
+    const checkInputPin = checkLinkPin(
+      Link.getLinkInputNodeId,
+      Link.getLinkInputPinKey
+    );
+    const checkOutputPin = checkLinkPin(
+      Link.getLinkOutputNodeId,
+      Link.getLinkOutputPinKey
+    );
 
-      // :: Maybe Node
-      const node = Patch.getNodeById(nodeId, patch);
-      // :: Maybe NodeType
-      const nodeType = R.map(Node.getNodeType, node);
-      // :: Maybe Patch
-      const nodePatch = R.chain(getPatchByPath(R.__, project), nodeType);
-
-      // :: Maybe Patch -> Maybe Node -> Either Error Pin
-      const checkPinExists = R.curry((maybePatch, maybeNode) =>
-        R.compose(
-          Tools.errOnNothing(CONST.ERROR.PINS_NOT_FOUND),
-          R.chain(([justPatch, justNode]) =>
-            R.ifElse(
-              Patch.isVariadicPatch,
-              R.compose(
-                Maybe,
-                R.prop(pinKey),
-                R.reject(Pin.isDeadPin),
-                getPinsForNode(justNode, R.__, project)
-              ),
-              Patch.getPinByKey(pinKey)
-            )(justPatch)
-          ),
-          R.unapply(R.sequence(Maybe.of))
-        )(maybePatch, maybeNode)
-      );
-
-      // :: Maybe Patch -> Either Error Patch
-      const checkNodePatchExists = maybePatch =>
-        Tools.errOnNothing(
-          Utils.formatString(CONST.ERROR.TYPE_NOT_FOUND, { type: nodeType }),
-          maybePatch
-        );
-      // :: Maybe Node -> Either Error Node
-      const checkNodeExists = maybeNode =>
-        Tools.errOnNothing(
-          Utils.formatString(CONST.ERROR.NODE_NOT_FOUND, { nodeId, patchPath }),
-          maybeNode
-        );
-
-      return R.compose(
-        R.chain(() => checkPinExists(nodePatch, node)),
-        R.chain(() => checkNodePatchExists(nodePatch)),
-        () => checkNodeExists(node)
-      )();
-    };
-
-    return check(Link.getLinkInputNodeId, Link.getLinkInputPinKey)
-      .chain(() => check(Link.getLinkOutputNodeId, Link.getLinkOutputPinKey))
-      .map(R.always(patch));
+    return R.compose(
+      R.map(R.always(patch)),
+      R.chain(checkPinsCompatibility(R.__, patch)),
+      R.sequence(Either.of)
+    )([
+      checkInputPin(link, patch, project),
+      checkOutputPin(link, patch, project),
+    ]);
   }
 );
 
@@ -446,9 +527,12 @@ export const validatePatchContents = def(
         R.compose(
           type =>
             R.compose(
-              Tools.errOnNothing(
-                Utils.formatString(CONST.ERROR.TYPE_NOT_FOUND, { type })
-              ),
+              Tools.errOnNothing({
+                title: CONST.ERROR_TITLES.DEAD_REFERENCE,
+                message: Utils.formatString(CONST.ERROR.TYPE_NOT_FOUND, {
+                  type,
+                }),
+              }),
               getPatchByPath(R.__, project)
             )(type),
           Node.getNodeType
@@ -704,25 +788,6 @@ export const updatePatch = def(
 // Getters with traversing through project
 //
 // =============================================================================
-/**
- * Returns `Maybe Patch`, that is defined as a type of the Node.
- * If specified Project contains specified Node it will return
- * `Just Patch` guaranteed. Otherwise it could be `Nothing`.
- */
-export const getPatchByNode = def(
-  'getPatchByNode :: Node -> Project -> Maybe Patch',
-  (node, project) =>
-    R.compose(getPatchByPath(R.__, project), Node.getNodeType)(node)
-);
-/**
- * Returns Maybe list of Pins, computed from the Patch,
- * that is defined as a type of the specified Node.
- */
-export const getNodePins = def(
-  'getNodePins :: Node -> Project -> Maybe [Pin]',
-  (node, project) =>
-    R.compose(R.map(Patch.listPins), getPatchByNode(R.__, project))(node)
-);
 /**
  * Returns Maybe Pin, extracted from the Patch,
  * that is defined as a type of the Node.

--- a/packages/xod-project/src/utils.js
+++ b/packages/xod-project/src/utils.js
@@ -3,7 +3,6 @@ import shortid from 'shortid';
 
 import * as Node from './node';
 import * as CONST from './constants';
-import { formatDeadReferencesFound } from './messages';
 import { def } from './types';
 
 /**
@@ -26,23 +25,6 @@ export const formatString = R.curry((template, replacements) =>
       R.replace(new RegExp(`\\{${key}\\}`, 'gi'), replacement)
     )
   )(replacements)
-);
-
-/**
- * Updates Error message of Left value by wrapping it with
- * dead reference error message. Right value will be passed unchanged.
- *
- * @param {PatchPath} patchPath
- * @param {Either} either Either Error a
- * @returns {Either} Either Error a
- */
-export const wrapDeadRefErrorMessage = R.curry((patchPath, either) =>
-  either.bimap(error => {
-    // Error message updated by mutation to prevent creating new stack trace.
-    // eslint-disable-next-line no-param-reassign
-    error.message = formatDeadReferencesFound(patchPath, error.message);
-    return error;
-  }, R.identity)
 );
 
 /**

--- a/packages/xod-project/test/flatten.spec.js
+++ b/packages/xod-project/test/flatten.spec.js
@@ -819,17 +819,11 @@ describe('Flatten', () => {
       // number to *
       fn(CONST.PIN_TYPE.NUMBER, CONST.PIN_TYPE.BOOLEAN);
       fn(CONST.PIN_TYPE.NUMBER, CONST.PIN_TYPE.STRING);
-      fn(CONST.PIN_TYPE.NUMBER, CONST.PIN_TYPE.PULSE);
       // boolean to *
       fn(CONST.PIN_TYPE.BOOLEAN, CONST.PIN_TYPE.NUMBER);
       fn(CONST.PIN_TYPE.BOOLEAN, CONST.PIN_TYPE.STRING);
       fn(CONST.PIN_TYPE.BOOLEAN, CONST.PIN_TYPE.PULSE);
-      // string to *
-      fn(CONST.PIN_TYPE.STRING, CONST.PIN_TYPE.BOOLEAN);
-      fn(CONST.PIN_TYPE.STRING, CONST.PIN_TYPE.PULSE);
-      // pulse to *
-      fn(CONST.PIN_TYPE.PULSE, CONST.PIN_TYPE.NUMBER);
-      fn(CONST.PIN_TYPE.PULSE, CONST.PIN_TYPE.BOOLEAN);
+      // string and pulse types does not casts to anything
     };
 
     describe('no links to terminal', () => {

--- a/packages/xod-project/test/project.spec.js
+++ b/packages/xod-project/test/project.spec.js
@@ -391,6 +391,339 @@ describe('Project', () => {
       );
     });
   });
+  describe('validateLinkPins', () => {
+    const testPatches = {
+      numbers: Helper.defaultizePatch({
+        path: 'test/nodes/numbers',
+        nodes: {
+          in: {
+            type: 'xod/patch-nodes/input-number',
+          },
+          out: {
+            type: 'xod/patch-nodes/output-number',
+          },
+        },
+      }),
+      pulses: Helper.defaultizePatch({
+        path: 'test/nodes/pulses',
+        nodes: {
+          in: {
+            type: 'xod/patch-nodes/input-pulse',
+          },
+          out: {
+            type: 'xod/patch-nodes/output-pulse',
+          },
+        },
+      }),
+      variadic: Helper.defaultizePatch({
+        path: 'test/nodes/variadic',
+        nodes: {
+          in: {
+            type: 'xod/patch-nodes/input-number',
+          },
+          in2: {
+            type: 'xod/patch-nodes/input-number',
+          },
+          out: {
+            type: 'xod/patch-nodes/output-number',
+          },
+          v: {
+            type: 'xod/patch-nodes/variadic-1',
+          },
+        },
+      }),
+    };
+
+    it('invalid link if input Node does not exists', () => {
+      const link = Helper.defaultizeLink({
+        id: 'l',
+        input: { nodeId: 'a', pinKey: 'out' },
+        output: { nodeId: 'b', pinKey: 'in' },
+      });
+      const patch = Helper.defaultizePatch({
+        path: '@/test',
+        nodes: {
+          b: {
+            type: 'test/nodes/numbers',
+          },
+        },
+        links: {
+          l: link,
+        },
+      });
+      const project = Helper.defaultizeProject({
+        patches: {
+          '@/test': patch,
+          'test/nodes/numbers': testPatches.numbers,
+        },
+      });
+
+      const result = Project.validateLinkPins(link, patch, project);
+      Helper.expectEitherError(
+        `Can't find the Node "a" in the patch with path "@/test"`,
+        result
+      );
+    });
+    it('invalid link if output Node does not exists', () => {
+      const link = Helper.defaultizeLink({
+        id: 'l',
+        input: { nodeId: 'a', pinKey: 'out' },
+        output: { nodeId: 'b', pinKey: 'in' },
+      });
+      const patch = Helper.defaultizePatch({
+        path: '@/test',
+        nodes: {
+          a: {
+            type: 'test/nodes/numbers',
+          },
+        },
+        links: {
+          l: link,
+        },
+      });
+      const project = Helper.defaultizeProject({
+        patches: {
+          '@/test': patch,
+          'test/nodes/numbers': testPatches.numbers,
+        },
+      });
+
+      const result = Project.validateLinkPins(link, patch, project);
+      Helper.expectEitherError(
+        `Can't find the Node "b" in the patch with path "@/test"`,
+        result
+      );
+    });
+    it('invalid link if input Pin does not exists', () => {
+      const link = Helper.defaultizeLink({
+        id: 'l',
+        input: { nodeId: 'a', pinKey: 'out2' },
+        output: { nodeId: 'b', pinKey: 'in' },
+      });
+      const patch = Helper.defaultizePatch({
+        path: '@/test',
+        nodes: {
+          a: {
+            type: 'test/nodes/numbers',
+          },
+          b: {
+            type: 'test/nodes/numbers',
+          },
+        },
+        links: {
+          l: link,
+        },
+      });
+      const project = Helper.defaultizeProject({
+        patches: {
+          '@/test': patch,
+          'test/nodes/numbers': testPatches.numbers,
+        },
+      });
+
+      const result = Project.validateLinkPins(link, patch, project);
+      Helper.expectEitherError(
+        "Specified node types haven't required pins for creating links",
+        result
+      );
+    });
+    it('invalid link if output Pin does not exists', () => {
+      const link = Helper.defaultizeLink({
+        id: 'l',
+        input: { nodeId: 'a', pinKey: 'out' },
+        output: { nodeId: 'b', pinKey: 'in2' },
+      });
+      const patch = Helper.defaultizePatch({
+        path: '@/test',
+        nodes: {
+          a: {
+            type: 'test/nodes/numbers',
+          },
+          b: {
+            type: 'test/nodes/numbers',
+          },
+        },
+        links: {
+          l: link,
+        },
+      });
+      const project = Helper.defaultizeProject({
+        patches: {
+          '@/test': patch,
+          'test/nodes/numbers': testPatches.numbers,
+        },
+      });
+
+      const result = Project.validateLinkPins(link, patch, project);
+      Helper.expectEitherError(
+        "Specified node types haven't required pins for creating links",
+        result
+      );
+    });
+    it('invalid link if Patch for input Node does not exists', () => {
+      const link = Helper.defaultizeLink({
+        id: 'l',
+        input: { nodeId: 'a', pinKey: 'out' },
+        output: { nodeId: 'b', pinKey: 'in' },
+      });
+      const patch = Helper.defaultizePatch({
+        path: '@/test',
+        nodes: {
+          a: {
+            type: 'test/nodes/not-exists',
+          },
+          b: {
+            type: 'test/nodes/numbers',
+          },
+        },
+        links: {
+          l: link,
+        },
+      });
+      const project = Helper.defaultizeProject({
+        patches: {
+          '@/test': patch,
+          'test/nodes/numbers': testPatches.numbers,
+        },
+      });
+
+      const result = Project.validateLinkPins(link, patch, project);
+      Helper.expectEitherError(
+        'Patch with type "test/nodes/not-exists" is not found in the project',
+        result
+      );
+    });
+    it('invalid link if Patch for output Node does not exists', () => {
+      const link = Helper.defaultizeLink({
+        id: 'l',
+        input: { nodeId: 'a', pinKey: 'out' },
+        output: { nodeId: 'b', pinKey: 'in' },
+      });
+      const patch = Helper.defaultizePatch({
+        path: '@/test',
+        nodes: {
+          a: {
+            type: 'test/nodes/numbers',
+          },
+          b: {
+            type: 'test/nodes/not-exists',
+          },
+        },
+        links: {
+          l: link,
+        },
+      });
+      const project = Helper.defaultizeProject({
+        patches: {
+          '@/test': patch,
+          'test/nodes/numbers': testPatches.numbers,
+        },
+      });
+
+      const result = Project.validateLinkPins(link, patch, project);
+      Helper.expectEitherError(
+        'Patch with type "test/nodes/not-exists" is not found in the project',
+        result
+      );
+    });
+    it('invalid link between incompatible pins', () => {
+      const link = Helper.defaultizeLink({
+        id: 'l',
+        input: { nodeId: 'a', pinKey: 'out' },
+        output: { nodeId: 'b', pinKey: 'in' },
+      });
+      const patch = Helper.defaultizePatch({
+        path: '@/test',
+        nodes: {
+          a: {
+            type: 'test/nodes/numbers',
+          },
+          b: {
+            type: 'test/nodes/pulses',
+          },
+        },
+        links: {
+          l: link,
+        },
+      });
+      const project = Helper.defaultizeProject({
+        patches: {
+          '@/test': patch,
+          'test/nodes/numbers': testPatches.numbers,
+          'test/nodes/pulses': testPatches.pulses,
+        },
+      });
+
+      const result = Project.validateLinkPins(link, patch, project);
+      Helper.expectEitherError(
+        '@/test: type pulse can’t cast to number directly.',
+        result
+      );
+    });
+
+    it('valid link between compatible pins', () => {
+      const link = Helper.defaultizeLink({
+        id: 'l',
+        input: { nodeId: 'a', pinKey: 'out' },
+        output: { nodeId: 'b', pinKey: 'in' },
+      });
+      const patch = Helper.defaultizePatch({
+        path: '@/test',
+        nodes: {
+          a: {
+            type: 'test/nodes/numbers',
+          },
+          b: {
+            type: 'test/nodes/numbers',
+          },
+        },
+        links: {
+          l: link,
+        },
+      });
+      const project = Helper.defaultizeProject({
+        patches: {
+          '@/test': patch,
+          'test/nodes/numbers': testPatches.numbers,
+        },
+      });
+
+      const result = Project.validateLinkPins(link, patch, project);
+      assert.equal(Either.isRight(result), true);
+    });
+    it('valid link connected to variadic input', () => {
+      const link = Helper.defaultizeLink({
+        id: 'l',
+        input: { nodeId: 'a', pinKey: 'out' },
+        output: { nodeId: 'b', pinKey: 'in2-$1' },
+      });
+      const patch = Helper.defaultizePatch({
+        path: '@/test',
+        nodes: {
+          a: {
+            type: 'test/nodes/numbers',
+          },
+          b: {
+            type: 'test/nodes/variadic',
+            arityLevel: 2,
+          },
+        },
+        links: {
+          l: link,
+        },
+      });
+      const project = Helper.defaultizeProject({
+        patches: {
+          '@/test': patch,
+          'test/nodes/numbers': testPatches.numbers,
+          'test/nodes/variadic': testPatches.variadic,
+        },
+      });
+
+      const result = Project.validateLinkPins(link, patch, project);
+      assert.equal(Either.isRight(result), true);
+    });
+  });
 
   // entity setters
   describe('assocPatch', () => {


### PR DESCRIPTION
It closes #1118.
And fixes #999.

Xodball for testing: [broken-link.xodball.zip](https://github.com/xodio/xod/files/1811826/broken-link.xodball.zip)

Also, in this PR appeared:
- tooltips for "dead reference" links. Check it out: [deadref.xodball.zip](https://github.com/xodio/xod/files/1816376/deadref.xodball.zip)
- errors with titles from `xod-project` (try to "show code" in both xodballs)