### PR TITLE
Use parametric patch names for cast and defer nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "doc:fz": "cd docs && make",
     "flow": "flow check",
     "lerna": "lerna",
-    "lint": "eslint packages/*/src packages/*/test packages/*/test-func --ext js,jsx --max-warnings 0",
+    "lint": "eslint packages/*/src packages/*/test packages/*/test-func tools packages/*/tools packages/*/benchmark --ext js,jsx --max-warnings 0",
     "start:electron": "lerna run start --scope xod-client-electron --stream",
     "start:spectron-repl": "./tools/spectron-repl",
     "storybook": "lerna run storybook --stream --scope xod-client",

--- a/packages/xod-client-browser/benchmark/getDurations.js
+++ b/packages/xod-client-browser/benchmark/getDurations.js
@@ -3,8 +3,7 @@
  * @see https://groups.google.com/forum/#!topic/google-chrome-developer-tools/J0pQuKeeqfw
  */
 
-
-const getDuration = (pathToJson) => {
+const getDuration = pathToJson => {
   /* eslint-disable import/no-dynamic-require */
   /* eslint-disable global-require */
   const { traceEvents } = require(pathToJson);
@@ -21,6 +20,15 @@ const getDuration = (pathToJson) => {
 };
 
 /* eslint-disable no-console */
-console.log('first column of nodes:', getDuration('./tracing-results/adding_first_nodes.json'));
-console.log('last column of nodes:', getDuration('./tracing-results/adding_last_nodes.json'));
-console.log('linking last nodes:', getDuration('./tracing-results/linking_last_nodes.json'));
+console.log(
+  'first column of nodes:',
+  getDuration('./tracing-results/adding_first_nodes.json')
+);
+console.log(
+  'last column of nodes:',
+  getDuration('./tracing-results/adding_last_nodes.json')
+);
+console.log(
+  'linking last nodes:',
+  getDuration('./tracing-results/linking_last_nodes.json')
+);

--- a/packages/xod-client-browser/benchmark/index.js
+++ b/packages/xod-client-browser/benchmark/index.js
@@ -10,10 +10,13 @@ import PromptPopup from '../test-func/pageObjects/PromptPopup';
 import PatchGroupItemContextMenu from '../test-func/pageObjects/PatchGroupItemContextMenu';
 import { getSelectedNodes } from '../test-func/pageObjects/Node';
 
-const getTracingResultsPath = name => path.resolve(__dirname, `./tracing-results/${name}.json`);
+const getTracingResultsPath = name =>
+  path.resolve(__dirname, `./tracing-results/${name}.json`);
 
-const waitForSelectingMode = page => page.waitFor('.PatchWrapper-container.selecting');
-const pinSelector = (nodeId, pinName) => `#nodePinsOverlay_${nodeId} .PinOverlay[title=${pinName}]`;
+const waitForSelectingMode = page =>
+  page.waitFor('.PatchWrapper-container.selecting');
+const pinSelector = (nodeId, pinName) =>
+  `#nodePinsOverlay_${nodeId} .PinOverlay[title=${pinName}]`;
 
 const width = 1300;
 const height = 850;
@@ -57,10 +60,14 @@ const height = 850;
   // TODO: User Timing API to marks placed here like this:
   //    await page.evaluate(() => { window.performance.mark('added_node'); });
   // show up in JSON, but are not visible when viewing profile in Chrome
-  await page.tracing.start({ path: getTracingResultsPath('adding_first_nodes') });
+  await page.tracing.start({
+    path: getTracingResultsPath('adding_first_nodes'),
+  });
   for (let col = COLS; col >= 0; col -= 1) {
     if (col === 0) {
-      await page.tracing.start({ path: getTracingResultsPath('adding_last_nodes') });
+      await page.tracing.start({
+        path: getTracingResultsPath('adding_last_nodes'),
+      });
     }
 
     for (let row = ROWS; row >= 0; row -= 1) {
@@ -69,7 +76,9 @@ const height = 850;
       await contextMenu.clickPlace();
 
       const [placedNode] = await getSelectedNodes(page);
-      const { width: placedNodeWidth } = await placedNode.getBoundingClientRect();
+      const {
+        width: placedNodeWidth,
+      } = await placedNode.getBoundingClientRect();
       const placedNodeId = await placedNode.getId();
       nodeIds.push(placedNodeId);
 
@@ -88,7 +97,9 @@ const height = 850;
   // linking placed nodes
   for (let idx = nodeIds.length - 1; idx > 0; idx -= 1) {
     if (idx === ROWS) {
-      await page.tracing.start({ path: getTracingResultsPath('linking_last_nodes') });
+      await page.tracing.start({
+        path: getTracingResultsPath('linking_last_nodes'),
+      });
     }
 
     const currentId = nodeIds[idx];
@@ -97,8 +108,12 @@ const height = 850;
     const yPinElementHandle = await page.$(pinSelector(currentId, 'Y'));
     const sumPinElementHandle = await page.$(pinSelector(prevId, 'SUM'));
 
-    const yPinPosition = getCenterPositon(await getBoundingClientRect(page, yPinElementHandle));
-    const sumPinPosition = getCenterPositon(await getBoundingClientRect(page, sumPinElementHandle));
+    const yPinPosition = getCenterPositon(
+      await getBoundingClientRect(page, yPinElementHandle)
+    );
+    const sumPinPosition = getCenterPositon(
+      await getBoundingClientRect(page, sumPinElementHandle)
+    );
 
     await page.mouse.move(yPinPosition.x, yPinPosition.y);
     await page.mouse.down();

--- a/packages/xod-client-browser/tools/loadTutorialProject.js
+++ b/packages/xod-client-browser/tools/loadTutorialProject.js
@@ -2,15 +2,16 @@ const fs = require('fs');
 const path = require('path');
 const { loadProject } = require('xod-fs');
 
-const projectDir = process.env.XOD_BROWSER_INITIAL_PROJECT_DIR
-  || path.resolve(__dirname, '../../../workspace/welcome-to-xod');
-const workspaceDir = process.env.XOD_BROWSER_INITIAL_WORKSPACE_DIR
-  || path.resolve(projectDir, '..');
+const projectDir =
+  process.env.XOD_BROWSER_INITIAL_PROJECT_DIR ||
+  path.resolve(__dirname, '../../../workspace/welcome-to-xod');
+const workspaceDir =
+  process.env.XOD_BROWSER_INITIAL_WORKSPACE_DIR ||
+  path.resolve(projectDir, '..');
 const targetPath = path.resolve(__dirname, '../tutorialProject.json');
 
-loadProject([workspaceDir], projectDir)
-  .then((project) => {
-    const json = JSON.stringify(project, null, 2);
-    fs.writeFileSync(targetPath, json);
-    process.exit(0);
-  });
+loadProject([workspaceDir], projectDir).then(project => {
+  const json = JSON.stringify(project, null, 2);
+  fs.writeFileSync(targetPath, json);
+  process.exit(0);
+});

--- a/packages/xod-client-browser/tools/staticServer.js
+++ b/packages/xod-client-browser/tools/staticServer.js
@@ -8,9 +8,11 @@ const pathToDist = path.resolve(__dirname, '../dist');
 
 const file = new nodeStatic.Server(pathToDist);
 const server = http.createServer((request, response) => {
-  request.addListener('end', () => {
-    file.serve(request, response);
-  }).resume();
+  request
+    .addListener('end', () => {
+      file.serve(request, response);
+    })
+    .resume();
 });
 
 const startServer = util.promisify(server.listen.bind(server, PORT));

--- a/packages/xod-fs/src/utils.js
+++ b/packages/xod-fs/src/utils.js
@@ -99,7 +99,7 @@ export const doesFileExist = def(
 );
 
 export const getPatchName = def(
-  'getPatchName :: Path -> Identifier',
+  'getPatchName :: Path -> PatchBaseName',
   patchPath => {
     const parts = patchPath.split(path.sep);
     return parts[parts.length - 2];

--- a/packages/xod-project/src/constants.js
+++ b/packages/xod-project/src/constants.js
@@ -48,7 +48,7 @@ export const ERROR = {
   PIN_KEY_INVALID: 'Pin key should be generated with shortid',
   // other
   LOOPS_DETECTED:
-    'The program has a cycle path. Use xod/core/defer-* nodes to break the cycle',
+    'The program has a cycle path. Use xod/core/defer node to break the cycle',
   DATATYPE_INVALID: 'Invalid data type',
   IMPLEMENTATION_NOT_FOUND: 'No implementation for {patchPath} found.',
   CPP_AS_ENTRY_POINT: 'Can’t use patch not implemented in XOD as entry point',

--- a/packages/xod-project/src/patchPathUtils.js
+++ b/packages/xod-project/src/patchPathUtils.js
@@ -158,10 +158,19 @@ export const getCastPatchPath = (typeIn, typeOut) =>
 // defer-* nodes
 //
 
-const deferNodeRegExp = new RegExp(`xod/core/defer-(${dataTypes.join('|')})$`);
+const legacyDeferNodeRegExp = new RegExp(
+  `^xod/core/defer-(${dataTypes.join('|')})$`
+);
+// TODO: when custom types will be added this should be generalized
+const deferNodeRegExp = new RegExp(
+  `^xod/core/defer\\((${dataTypes.join('|')})\\)$`
+);
 
 // :: PatchPath -> Boolean
-export const isDeferNodeType = R.test(deferNodeRegExp);
+export const isDeferNodeType = R.either(
+  R.test(legacyDeferNodeRegExp),
+  R.test(deferNodeRegExp)
+);
 
 //
 // constant-* nodes

--- a/packages/xod-project/src/patchPathUtils.js
+++ b/packages/xod-project/src/patchPathUtils.js
@@ -118,7 +118,7 @@ export const getTerminalPath = R.curry(
 // utils for variadic marker nodes
 //
 
-const variadicRegExp = new RegExp(`${PATCH_NODES_LIB_NAME}/variadic-([1-3])`);
+const variadicRegExp = new RegExp(`^${PATCH_NODES_LIB_NAME}/variadic-([1-3])`);
 
 // :: PatchPath -> Boolean
 export const isVariadicPath = R.test(variadicRegExp);
@@ -186,7 +186,7 @@ export const isDeferNodeType = R.either(
 
 // TODO: this gives a false positive for `xod/core/constant-pulse`
 const constantNodeRegExp = new RegExp(
-  `xod/core/constant-(${dataTypes.join('|')})$`
+  `^xod/core/constant-(${dataTypes.join('|')})$`
 );
 
 // :: PatchPath -> Boolean
@@ -208,7 +208,7 @@ export const convertToInternalTerminalPath = R.compose(
 );
 
 const internalTerminalRegExp = new RegExp(
-  `xod/internal/terminal-(${dataTypes.join('|')})$`
+  `^xod/internal/terminal-(${dataTypes.join('|')})$`
 );
 
 // :: PatchPath -> Boolean

--- a/packages/xod-project/src/patchPathUtils.js
+++ b/packages/xod-project/src/patchPathUtils.js
@@ -137,12 +137,20 @@ export const getVariadicPath = n => `${PATCH_NODES_LIB_NAME}/variadic-${n}`;
 // utils for cast patches
 //
 
+const legacyCastTypeRegExp = new RegExp(
+  `^xod/core/cast-(${dataTypes.join('|')})-to-(${dataTypes.join('|')})$`
+);
+// TODO: When custom types will be added this should be generalized.
+//       Also, casting from/to generic types should be forbidden.
 const castTypeRegExp = new RegExp(
-  `xod/core/cast-(${dataTypes.join('|')})-to-(${dataTypes.join('|')})$`
+  `^xod/core/cast\\((${dataTypes.join('|')}),(${dataTypes.join('|')})\\)$`
 );
 
 // :: String -> Boolean
-export const isCastPatchPath = R.test(castTypeRegExp);
+export const isCastPatchPath = R.either(
+  R.test(legacyCastTypeRegExp),
+  R.test(castTypeRegExp)
+);
 
 /**
  * Returns path for casting patch
@@ -152,7 +160,7 @@ export const isCastPatchPath = R.test(castTypeRegExp);
  * @returns {String}
  */
 export const getCastPatchPath = (typeIn, typeOut) =>
-  `xod/core/cast-${typeIn}-to-${typeOut}`;
+  `xod/core/cast(${typeIn},${typeOut})`;
 
 //
 // defer-* nodes
@@ -176,6 +184,7 @@ export const isDeferNodeType = R.either(
 // constant-* nodes
 //
 
+// TODO: this gives a false positive for `xod/core/constant-pulse`
 const constantNodeRegExp = new RegExp(
   `xod/core/constant-(${dataTypes.join('|')})$`
 );

--- a/packages/xod-project/src/types.js
+++ b/packages/xod-project/src/types.js
@@ -9,6 +9,7 @@ import {
   isTerminalPatchPath,
   isProjectNameValid,
   isValidIdentifier,
+  isValidPatchBasename,
   isValidPatchPath,
   isLibName,
 } from './internal/patchPathUtils';
@@ -66,6 +67,7 @@ export const PinKey = AliasType('PinKey', NodeId);
 export const PinLabel = AliasType('PinLabel', $.String);
 export const Identifier = NullaryType('Identifier', isValidIdentifier);
 export const ProjectName = NullaryType('ProjectName', isProjectNameValid);
+export const PatchBaseName = NullaryType('PatchBaseName', isValidPatchBasename);
 export const PatchPath = NullaryType('PatchPath', isValidPatchPath);
 export const LibName = NullaryType('LibName', isLibName);
 export const PinDirection = EnumType('PinDirection', R.values(C.PIN_DIRECTION));
@@ -177,6 +179,7 @@ export const env = XF.env.concat([
   NodeId,
   NodeOrId,
   Patch,
+  PatchBaseName,
   PatchPath,
   Pin,
   PinDirection,

--- a/packages/xod-project/src/utils.js
+++ b/packages/xod-project/src/utils.js
@@ -100,7 +100,7 @@ export const defaultValueOfType = def(
 
 export const canCastTypes = def(
   'canCastTypes :: DataType -> DataType -> Boolean',
-  (from, to) => CONST.TYPES_COMPATIBILITY[from][to]
+  (from, to) => R.pathOr(false, [from, to], CONST.TYPES_COMPATIBILITY)
 );
 
 // =============================================================================

--- a/packages/xod-project/test/fixtures/blinking.flat.xodball
+++ b/packages/xod-project/test/fixtures/blinking.flat.xodball
@@ -249,9 +249,9 @@
       ],
       "@@type": "xod-project/Patch"
     },
-    "xod/core/cast-boolean-to-number": {
+    "xod/core/cast(boolean,number)": {
       "comments": {},
-      "path": "xod/core/cast-boolean-to-number",
+      "path": "xod/core/cast(boolean,number)",
       "nodes": {
         "noNativeImpl": {
           "label": "",
@@ -364,7 +364,7 @@
             "x": 0,
             "y": 0
           },
-          "type": "xod/core/cast-boolean-to-number",
+          "type": "xod/core/cast(boolean,number)",
           "@@type": "xod-project/Node"
         },
         "SJ7g05EdFe~rJxgAqV_tl": {

--- a/packages/xod-project/test/fixtures/blinking.xodball
+++ b/packages/xod-project/test/fixtures/blinking.xodball
@@ -1921,10 +1921,10 @@
         }
       ]
     },
-    "xod/core/cast-string-to-pulse": {
+    "xod/core/cast(string,pulse)": {
       "comments": {},
       "description": "",
-      "path": "xod/core/cast-string-to-pulse",
+      "path": "xod/core/cast(string,pulse)",
       "nodes": {
         "noNativeImpl": {
           "label": "",
@@ -1969,10 +1969,10 @@
         }
       ]
     },
-    "xod/core/cast-string-to-boolean": {
+    "xod/core/cast(string,boolean)": {
       "comments": {},
       "description": "",
-      "path": "xod/core/cast-string-to-boolean",
+      "path": "xod/core/cast(string,boolean)",
       "nodes": {
         "noNativeImpl": {
           "label": "",
@@ -2017,10 +2017,10 @@
         }
       ]
     },
-    "xod/core/cast-number-to-pulse": {
+    "xod/core/cast(number,pulse)": {
       "comments": {},
       "description": "",
-      "path": "xod/core/cast-number-to-pulse",
+      "path": "xod/core/cast(number,pulse)",
       "nodes": {
         "noNativeImpl": {
           "label": "",
@@ -2065,10 +2065,10 @@
         }
       ]
     },
-    "xod/core/cast-number-to-string": {
+    "xod/core/cast(number,string)": {
       "comments": {},
       "description": "",
-      "path": "xod/core/cast-number-to-string",
+      "path": "xod/core/cast(number,string)",
       "nodes": {
         "noNativeImpl": {
           "label": "",
@@ -2113,10 +2113,10 @@
         }
       ]
     },
-    "xod/core/cast-pulse-to-number": {
+    "xod/core/cast(pulse,number)": {
       "comments": {},
       "description": "",
-      "path": "xod/core/cast-pulse-to-number",
+      "path": "xod/core/cast(pulse,number)",
       "nodes": {
         "noNativeImpl": {
           "label": "",
@@ -2161,10 +2161,10 @@
         }
       ]
     },
-    "xod/core/cast-pulse-to-boolean": {
+    "xod/core/cast(pulse,boolean)": {
       "comments": {},
       "description": "",
-      "path": "xod/core/cast-pulse-to-boolean",
+      "path": "xod/core/cast(pulse,boolean)",
       "nodes": {
         "noNativeImpl": {
           "label": "",
@@ -2209,10 +2209,10 @@
         }
       ]
     },
-    "xod/core/cast-number-to-boolean": {
+    "xod/core/cast(number,boolean)": {
       "comments": {},
       "description": "",
-      "path": "xod/core/cast-number-to-boolean",
+      "path": "xod/core/cast(number,boolean)",
       "nodes": {
         "noNativeImpl": {
           "label": "",
@@ -2257,10 +2257,10 @@
         }
       ]
     },
-    "xod/core/cast-boolean-to-string": {
+    "xod/core/cast(boolean,string)": {
       "comments": {},
       "description": "",
-      "path": "xod/core/cast-boolean-to-string",
+      "path": "xod/core/cast(boolean,string)",
       "nodes": {
         "noNativeImpl": {
           "label": "",
@@ -2305,10 +2305,10 @@
         }
       ]
     },
-    "xod/core/cast-boolean-to-number": {
+    "xod/core/cast(boolean,number)": {
       "comments": {},
       "description": "",
-      "path": "xod/core/cast-boolean-to-number",
+      "path": "xod/core/cast(boolean,number)",
       "nodes": {
         "noNativeImpl": {
           "label": "",
@@ -2390,10 +2390,10 @@
         }
       ]
     },
-    "xod/core/cast-boolean-to-pulse": {
+    "xod/core/cast(boolean,pulse)": {
       "comments": {},
       "description": "",
-      "path": "xod/core/cast-boolean-to-pulse",
+      "path": "xod/core/cast(boolean,pulse)",
       "nodes": {
         "noNativeImpl": {
           "label": "",

--- a/packages/xod-project/test/fixtures/cast-multiple-outputs.flat.xodball
+++ b/packages/xod-project/test/fixtures/cast-multiple-outputs.flat.xodball
@@ -184,7 +184,7 @@
       "path": "xod/core/console-log",
       "@@type": "xod-project/Patch"
     },
-    "xod/core/cast-number-to-string": {
+    "xod/core/cast(number,string)": {
       "attachments": [
         {
           "content": "struct State {\n};\n\n{{ GENERATED_CODE }}\n\nvoid evaluate(Context ctx) {\n    char str[16];\n    auto num = getValue<input_IN>(ctx);\n    dtostrf(num, 0, 2, str);\n    auto xstr = ::xod::List<char>::fromPlainArray(str, strlen(str));\n    emitValue<output_OUT>(ctx, xstr);\n}\n",
@@ -233,7 +233,7 @@
           "@@type": "xod-project/Node"
         }
       },
-      "path": "xod/core/cast-number-to-string",
+      "path": "xod/core/cast(number,string)",
       "@@type": "xod-project/Patch"
     },
     "@/main": {
@@ -281,7 +281,7 @@
             "x": 0,
             "y": 0
           },
-          "type": "xod/core/cast-number-to-string",
+          "type": "xod/core/cast(number,string)",
           "label": "",
           "description": "",
           "boundValues": {},
@@ -293,7 +293,7 @@
             "x": 0,
             "y": 0
           },
-          "type": "xod/core/cast-number-to-string",
+          "type": "xod/core/cast(number,string)",
           "label": "",
           "description": "",
           "boundValues": {},

--- a/packages/xod-project/test/fixtures/cast-multiple-outputs.xodball
+++ b/packages/xod-project/test/fixtures/cast-multiple-outputs.xodball
@@ -216,7 +216,7 @@
       },
       "path": "@/two-nums-output"
     },
-    "xod/core/cast-number-to-string": {
+    "xod/core/cast(number,string)": {
       "nodes": {
         "__in__": {
           "boundValues": {},
@@ -253,7 +253,7 @@
         }
       },
       "links": {},
-      "path": "xod/core/cast-number-to-string",
+      "path": "xod/core/cast(number,string)",
       "description": "Transforms a number to string with two digits after dot",
       "attachments": [
         {

--- a/packages/xod-project/test/fixtures/deep-bound-values-propagation.flat.xodball
+++ b/packages/xod-project/test/fixtures/deep-bound-values-propagation.flat.xodball
@@ -176,7 +176,7 @@
       "path": "xod/core/console-log",
       "@@type": "xod-project/Patch"
     },
-    "xod/core/cast-number-to-string": {
+    "xod/core/cast(number,string)": {
       "attachments": [
         {
           "filename": "patch.cpp",
@@ -225,7 +225,7 @@
         }
       },
       "comments": {},
-      "path": "xod/core/cast-number-to-string",
+      "path": "xod/core/cast(number,string)",
       "@@type": "xod-project/Patch"
     },
     "@/main": {
@@ -277,7 +277,7 @@
             "x": 0,
             "y": 0
           },
-          "type": "xod/core/cast-number-to-string",
+          "type": "xod/core/cast(number,string)",
           "label": "",
           "description": "",
           "boundValues": {},

--- a/packages/xod-project/test/fixtures/deep-bound-values-propagation.xodball
+++ b/packages/xod-project/test/fixtures/deep-bound-values-propagation.xodball
@@ -421,7 +421,7 @@
         }
       ]
     },
-    "xod/core/cast-number-to-string": {
+    "xod/core/cast(number,string)": {
       "nodes": {
         "__in__": {
           "boundValues": {},
@@ -459,7 +459,7 @@
       },
       "links": {},
       "comments": {},
-      "path": "xod/core/cast-number-to-string",
+      "path": "xod/core/cast(number,string)",
       "description": "Transforms a number to string with two digits after dot",
       "attachments": [
         {

--- a/packages/xod-project/test/flatten.spec.js
+++ b/packages/xod-project/test/flatten.spec.js
@@ -858,7 +858,7 @@ describe('Flatten', () => {
             links: {},
             attachments: [Attachment.createImplAttachment('// ok')],
           },
-          'xod/core/cast-boolean-to-number': {
+          'xod/core/cast(boolean,number)': {
             nodes: {
               __in__: {
                 id: '__in__',
@@ -995,7 +995,7 @@ describe('Flatten', () => {
                 links: {},
                 attachments: [Attachment.createImplAttachment('// ok')],
               },
-              [`xod/core/cast-${typeIn}-to-${typeOut}`]: {
+              [`xod/core/cast(${typeIn},${typeOut})`]: {
                 nodes: {
                   __in__: {
                     id: '__in__',
@@ -1040,7 +1040,7 @@ describe('Flatten', () => {
           }
 
           const flatProject = flatten(project, '@/main');
-          const expectedPath = `xod/core/cast-${typeIn}-to-${typeOut}`; // getCastPatchPath(typeIn, typeOut);
+          const expectedPath = `xod/core/cast(${typeIn},${typeOut})`; // getCastPatchPath(typeIn, typeOut);
           const expectedPaths =
             typeIn === typeOut
               ? [`xod/core/${typeIn}`, expectedPath, '@/main']
@@ -1152,7 +1152,7 @@ describe('Flatten', () => {
                 links: {},
                 attachments: [Attachment.createImplAttachment('// ok')],
               },
-              [`xod/core/cast-${typeIn}-to-${typeOut}`]: {
+              [`xod/core/cast(${typeIn},${typeOut})`]: {
                 nodes: {
                   __in__: {
                     id: '__in__',
@@ -1196,7 +1196,7 @@ describe('Flatten', () => {
           }
 
           const flatProject = flatten(project, '@/main');
-          const expectedPath = `xod/core/cast-${typeIn}-to-${typeOut}`; // getCastPatchPath(typeIn, typeOut);
+          const expectedPath = `xod/core/cast(${typeIn},${typeOut})`; // getCastPatchPath(typeIn, typeOut);
           const expectedPaths =
             typeIn === typeOut
               ? [`xod/core/${typeIn}`, expectedPath, '@/main']
@@ -1415,7 +1415,7 @@ describe('Flatten', () => {
 
         Helper.expectEitherError(
           formatString(CONST.ERROR.CAST_PATCH_NOT_FOUND, {
-            patchPath: 'xod/core/cast-boolean-to-number',
+            patchPath: 'xod/core/cast(boolean,number)',
           }),
           flatProject
         );
@@ -1670,7 +1670,7 @@ describe('Flatten', () => {
             links: {},
             attachments: [Attachment.createImplAttachment('// ok')],
           },
-          'xod/core/cast-boolean-to-number': {
+          'xod/core/cast(boolean,number)': {
             nodes: {
               __in__: {
                 id: '__in__',
@@ -1691,7 +1691,7 @@ describe('Flatten', () => {
             links: {},
             attachments: [Attachment.createImplAttachment('// ok')],
           },
-          'xod/core/cast-number-to-boolean': {
+          'xod/core/cast(number,boolean)': {
             nodes: {
               __in__: {
                 id: '__in__',

--- a/packages/xod-project/test/patchPathUtils.spec.js
+++ b/packages/xod-project/test/patchPathUtils.spec.js
@@ -298,4 +298,71 @@ describe('PatchPathUtils', () => {
       );
     });
   });
+
+  describe('Cast patch utils', () => {
+    describe('isCastPatchPath', () => {
+      it('should recognise legacy cast paths', () => {
+        assert.isTrue(
+          PatchPathUtils.isCastPatchPath('xod/core/cast-boolean-to-number')
+        );
+        assert.isTrue(
+          PatchPathUtils.isCastPatchPath('xod/core/cast-boolean-to-pulse')
+        );
+        assert.isTrue(
+          PatchPathUtils.isCastPatchPath('xod/core/cast-boolean-to-string')
+        );
+        assert.isTrue(
+          PatchPathUtils.isCastPatchPath('xod/core/cast-number-to-boolean')
+        );
+        assert.isTrue(
+          PatchPathUtils.isCastPatchPath('xod/core/cast-number-to-string')
+        );
+      });
+      it('should recognise new cast paths', () => {
+        assert.isTrue(
+          PatchPathUtils.isCastPatchPath('xod/core/cast(boolean,number)')
+        );
+        assert.isTrue(
+          PatchPathUtils.isCastPatchPath('xod/core/cast(boolean,pulse)')
+        );
+        assert.isTrue(
+          PatchPathUtils.isCastPatchPath('xod/core/cast(boolean,string)')
+        );
+        assert.isTrue(
+          PatchPathUtils.isCastPatchPath('xod/core/cast(number,boolean)')
+        );
+        assert.isTrue(
+          PatchPathUtils.isCastPatchPath('xod/core/cast(number,string)')
+        );
+      });
+    });
+    describe('getCastPatchPath', () => {
+      it('should return patch paths that are recognised as cast paths', () => {
+        assert.isTrue(
+          PatchPathUtils.isCastPatchPath(
+            PatchPathUtils.getCastPatchPath(
+              CONST.PIN_TYPE.BOOLEAN,
+              CONST.PIN_TYPE.NUMBER
+            )
+          )
+        );
+        assert.isTrue(
+          PatchPathUtils.isCastPatchPath(
+            PatchPathUtils.getCastPatchPath(
+              CONST.PIN_TYPE.BOOLEAN,
+              CONST.PIN_TYPE.STRING
+            )
+          )
+        );
+        assert.isTrue(
+          PatchPathUtils.isCastPatchPath(
+            PatchPathUtils.getCastPatchPath(
+              CONST.PIN_TYPE.NUMBER,
+              CONST.PIN_TYPE.BOOLEAN
+            )
+          )
+        );
+      });
+    });
+  });
 });

--- a/tools/electron-upload.js
+++ b/tools/electron-upload.js
@@ -13,7 +13,8 @@ const file = resolve(options['--file']);
 const tag = options['--tag'];
 const basename = path.basename(file);
 
-storage({ keyFilename }).bucket('releases.xod.io')
+storage({ keyFilename })
+  .bucket('releases.xod.io')
   .upload(file, {
     destination: `${tag}/${basename}`,
     metadata: {
@@ -21,8 +22,8 @@ storage({ keyFilename }).bucket('releases.xod.io')
     },
     public: true,
   })
-  .catch((error) => {
-// eslint-disable-next-line no-console
+  .catch(error => {
+    // eslint-disable-next-line no-console
     console.error(error);
     process.exit(1);
   });

--- a/tools/extract-release-notes.js
+++ b/tools/extract-release-notes.js
@@ -27,18 +27,25 @@ const releases = new Transform(function* f1(line) {
 });
 
 process.stdin
-  .pipe(new Transform(function* f2(stdin) {
-    for (const line of stdin.toString().trim().split(/$/m)) {
-      yield line;
-    }
-  }))
+  .pipe(
+    new Transform(function* f2(stdin) {
+      for (const line of stdin
+        .toString()
+        .trim()
+        .split(/$/m)) {
+        yield line;
+      }
+    })
+  )
   .on('finish', () => {
     releases.write('<a name="TERMINAL"></a>');
   })
   .pipe(releases)
-  .pipe(new Transform(function* f3(release) {
-    if (release.tag === process.argv[2]) {
-      yield `${release.content.trim()}\n`;
-    }
-  }))
+  .pipe(
+    new Transform(function* f3(release) {
+      if (release.tag === process.argv[2]) {
+        yield `${release.content.trim()}\n`;
+      }
+    })
+  )
   .pipe(process.stdout);

--- a/workspace/__lib__/xod/core/cast(boolean,number)/patch.cpp
+++ b/workspace/__lib__/xod/core/cast(boolean,number)/patch.cpp
@@ -1,0 +1,11 @@
+
+#pragma XOD dirtieness disable
+
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    emitValue<output_OUT>(ctx, getValue<input_IN>(ctx) ? 1.0 : 0.0);
+}

--- a/workspace/__lib__/xod/core/cast(boolean,number)/patch.xodp
+++ b/workspace/__lib__/xod/core/cast(boolean,number)/patch.xodp
@@ -1,0 +1,29 @@
+{
+  "description": "Transforms true value to 1.0 and false to 0.0",
+  "nodes": [
+    {
+      "id": "__in__",
+      "position": {
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-boolean"
+    },
+    {
+      "id": "__out__",
+      "position": {
+        "x": 0,
+        "y": 300
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "noNativeImpl",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/core/cast(boolean,pulse)/patch.cpp
+++ b/workspace/__lib__/xod/core/cast(boolean,pulse)/patch.cpp
@@ -1,0 +1,15 @@
+struct State {
+  bool state = false;
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    State* state = getState(ctx);
+    auto newValue = getValue<input_IN>(ctx);
+
+    if (newValue == true && state->state == false)
+        emitValue<output_OUT>(ctx, 1);
+
+    state->state = newValue;
+}

--- a/workspace/__lib__/xod/core/cast(boolean,pulse)/patch.xodp
+++ b/workspace/__lib__/xod/core/cast(boolean,pulse)/patch.xodp
@@ -1,0 +1,29 @@
+{
+  "description": "Emits a pulse on a rising edge, i.e. when false changes to true",
+  "nodes": [
+    {
+      "id": "__in__",
+      "position": {
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-boolean"
+    },
+    {
+      "id": "__out__",
+      "position": {
+        "x": 0,
+        "y": 300
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "id": "noNativeImpl",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/core/cast(boolean,string)/patch.cpp
+++ b/workspace/__lib__/xod/core/cast(boolean,string)/patch.cpp
@@ -1,0 +1,15 @@
+
+#pragma XOD dirtieness disable
+
+struct State {
+    CStringView view;
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    auto state = getState(ctx);
+    auto x = getValue<input_IN>(ctx);
+    state->view = CStringView(x ? "true" : "false");
+    emitValue<output_OUT>(ctx, XString(&state->view));
+}

--- a/workspace/__lib__/xod/core/cast(boolean,string)/patch.xodp
+++ b/workspace/__lib__/xod/core/cast(boolean,string)/patch.xodp
@@ -1,0 +1,29 @@
+{
+  "description": "Transforms boolean false to string “false” and true to “true”",
+  "nodes": [
+    {
+      "id": "__in__",
+      "position": {
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-boolean"
+    },
+    {
+      "id": "__out__",
+      "position": {
+        "x": 0,
+        "y": 300
+      },
+      "type": "xod/patch-nodes/output-string"
+    },
+    {
+      "id": "noNativeImpl",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/core/cast(number,boolean)/patch.cpp
+++ b/workspace/__lib__/xod/core/cast(number,boolean)/patch.cpp
@@ -1,0 +1,11 @@
+
+#pragma XOD dirtieness disable
+
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    emitValue<output_OUT>(ctx, getValue<input_IN>(ctx) != 0.0);
+}

--- a/workspace/__lib__/xod/core/cast(number,boolean)/patch.xodp
+++ b/workspace/__lib__/xod/core/cast(number,boolean)/patch.xodp
@@ -1,0 +1,29 @@
+{
+  "description": "Transforms 0.0 to false and any other value to true",
+  "nodes": [
+    {
+      "id": "__in__",
+      "position": {
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "__out__",
+      "position": {
+        "x": 0,
+        "y": 300
+      },
+      "type": "xod/patch-nodes/output-boolean"
+    },
+    {
+      "id": "noNativeImpl",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/core/cast(number,string)/patch.cpp
+++ b/workspace/__lib__/xod/core/cast(number,string)/patch.cpp
@@ -1,0 +1,17 @@
+
+#pragma XOD dirtieness disable
+
+struct State {
+    char str[16];
+    CStringView view;
+    State() : view(str) { }
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    auto state = getState(ctx);
+    auto num = getValue<input_IN>(ctx);
+    dtostrf(num, 0, 2, state->str);
+    emitValue<output_OUT>(ctx, XString(&state->view));
+}

--- a/workspace/__lib__/xod/core/cast(number,string)/patch.xodp
+++ b/workspace/__lib__/xod/core/cast(number,string)/patch.xodp
@@ -1,0 +1,29 @@
+{
+  "description": "Transforms a number to string with two digits after dot",
+  "nodes": [
+    {
+      "id": "__in__",
+      "position": {
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "__out__",
+      "position": {
+        "x": 0,
+        "y": 300
+      },
+      "type": "xod/patch-nodes/output-string"
+    },
+    {
+      "id": "noNativeImpl",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/core/defer(boolean)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(boolean)/patch.cpp
@@ -1,0 +1,17 @@
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated
+        setTimeout(ctx, 0);
+        // This will not have any immediate effect, because
+        // deferred nodes are at the very bottom of sorted graph.
+        // We do this to just save the value for reemission
+        // on deferred-only evaluation.
+        emitValue<output_OUT>(ctx, getValue<input_IN>(ctx));
+    } else { // deferred-only evaluation pass
+        emitValue<output_OUT>(ctx, getValue<output_OUT>(ctx));
+    }
+}

--- a/workspace/__lib__/xod/core/defer(boolean)/patch.xodp
+++ b/workspace/__lib__/xod/core/defer(boolean)/patch.xodp
@@ -1,0 +1,29 @@
+{
+  "description": "Allows to create feedback loops. Repeats a change of the input on the output right after the current transaction will complete.",
+  "nodes": [
+    {
+      "id": "BJI7P8t9Z",
+      "position": {
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-boolean"
+    },
+    {
+      "id": "HJhXDIY9-",
+      "position": {
+        "x": 0,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-boolean"
+    },
+    {
+      "id": "rkFQwUYc-",
+      "position": {
+        "x": 0,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/core/defer(number)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(number)/patch.cpp
@@ -1,0 +1,17 @@
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated
+        setTimeout(ctx, 0);
+        // This will not have any immediate effect, because
+        // deferred nodes are at the very bottom of sorted graph.
+        // We do this to just save the value for reemission
+        // on deferred-only evaluation.
+        emitValue<output_OUT>(ctx, getValue<input_IN>(ctx));
+    } else { // deferred-only evaluation pass
+        emitValue<output_OUT>(ctx, getValue<output_OUT>(ctx));
+    }
+}

--- a/workspace/__lib__/xod/core/defer(number)/patch.xodp
+++ b/workspace/__lib__/xod/core/defer(number)/patch.xodp
@@ -1,0 +1,29 @@
+{
+  "description": "Allows to create feedback loops. Repeats a change of the input on the output right after the current transaction will complete.",
+  "nodes": [
+    {
+      "id": "B15NPUY9W",
+      "position": {
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "Hk2NPLFcZ",
+      "position": {
+        "x": 0,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "id": "HyZHD8tcW",
+      "position": {
+        "x": 0,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-number"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/core/defer(pulse)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(pulse)/patch.cpp
@@ -1,0 +1,12 @@
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated
+        setTimeout(ctx, 0);
+    } else if (isTimedOut(ctx)) {
+        emitValue<output_OUT>(ctx, true);
+    }
+}

--- a/workspace/__lib__/xod/core/defer(pulse)/patch.xodp
+++ b/workspace/__lib__/xod/core/defer(pulse)/patch.xodp
@@ -1,0 +1,29 @@
+{
+  "description": "Allows to create feedback loops. Repeats a change of the input on the output right after the current transaction will complete.",
+  "nodes": [
+    {
+      "id": "Hk-UvIK9b",
+      "position": {
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "id": "S1K8wUY9b",
+      "position": {
+        "x": 0,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "id": "r1IIwLKcb",
+      "position": {
+        "x": 0,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/core/defer(string)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(string)/patch.cpp
@@ -1,0 +1,17 @@
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated
+        setTimeout(ctx, 0);
+        // This will not have any immediate effect, because
+        // deferred nodes are at the very bottom of sorted graph.
+        // We do this to just save the value for reemission
+        // on deferred-only evaluation.
+        emitValue<output_OUT>(ctx, getValue<input_IN>(ctx));
+    } else { // deferred-only evaluation pass
+        emitValue<output_OUT>(ctx, getValue<output_OUT>(ctx));
+    }
+}

--- a/workspace/__lib__/xod/core/defer(string)/patch.xodp
+++ b/workspace/__lib__/xod/core/defer(string)/patch.xodp
@@ -1,0 +1,29 @@
+{
+  "description": "Allows to create feedback loops. Repeats a change of the input on the output right after the current transaction will complete.",
+  "nodes": [
+    {
+      "id": "B11dDLY9W",
+      "position": {
+        "x": 0,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-string"
+    },
+    {
+      "id": "H15wwUtcZ",
+      "position": {
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-string"
+    },
+    {
+      "id": "S1nDPLY9-",
+      "position": {
+        "x": 0,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/core/defer/patch.xodp
+++ b/workspace/__lib__/xod/core/defer/patch.xodp
@@ -1,0 +1,29 @@
+{
+  "description": "Allows to create feedback loops. Repeats a change of the input on the output right after the current transaction will complete.",
+  "nodes": [
+    {
+      "id": "BJI7P8t9Z",
+      "position": {
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-t1"
+    },
+    {
+      "id": "HJhXDIY9-",
+      "position": {
+        "x": 0,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-t1"
+    },
+    {
+      "id": "rkFQwUYc-",
+      "position": {
+        "x": 0,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/abstract"
+    }
+  ]
+}

--- a/workspace/count-with-feedback-loops/__fixtures__/arduino.cpp
+++ b/workspace/count-with-feedback-loops/__fixtures__/arduino.cpp
@@ -1219,9 +1219,9 @@ void evaluate(Context ctx) {
 } // namespace xod__core__greater
 
 //-----------------------------------------------------------------------------
-// xod/core/cast_boolean_to_pulse implementation
+// xod/core/cast__boolean__pulse implementation
 //-----------------------------------------------------------------------------
-namespace xod__core__cast_boolean_to_pulse {
+namespace xod__core__cast__boolean__pulse {
 
 struct State {
   bool state = false;
@@ -1303,12 +1303,12 @@ void evaluate(Context ctx) {
     state->state = newValue;
 }
 
-} // namespace xod__core__cast_boolean_to_pulse
+} // namespace xod__core__cast__boolean__pulse
 
 //-----------------------------------------------------------------------------
-// xod/core/cast_number_to_string implementation
+// xod/core/cast__number__string implementation
 //-----------------------------------------------------------------------------
-namespace xod__core__cast_number_to_string {
+namespace xod__core__cast__number__string {
 
 #pragma XOD dirtieness disable
 
@@ -1389,7 +1389,7 @@ void evaluate(Context ctx) {
     emitValue<output_OUT>(ctx, XString(&state->view));
 }
 
-} // namespace xod__core__cast_number_to_string
+} // namespace xod__core__cast__number__string
 
 } // namespace xod
 
@@ -1407,8 +1407,8 @@ namespace xod {
 // Define/allocate persistent storages (state, timeout, output data) for all nodes
 
 constexpr Logic node_0_output_OUT = false;
-xod__core__cast_boolean_to_pulse::Node node_0 = {
-    xod__core__cast_boolean_to_pulse::State(), // state default
+xod__core__cast__boolean__pulse::Node node_0 = {
+    xod__core__cast__boolean__pulse::State(), // state default
     node_0_output_OUT, // output OUT default
     false, // OUT dirty
     true // node itself dirty
@@ -1461,8 +1461,8 @@ xod__core__greater::Node node_14 = {
 };
 
 constexpr XString node_15_output_OUT = XString();
-xod__core__cast_number_to_string::Node node_15 = {
-    xod__core__cast_number_to_string::State(), // state default
+xod__core__cast__number__string::Node node_15 = {
+    xod__core__cast__number__string::State(), // state default
     node_15_output_OUT, // output OUT default
     true // node itself dirty
 };
@@ -1517,18 +1517,18 @@ void runTransaction(bool firstRun) {
     }
 
     // Evaluate all dirty nodes
-    { // xod__core__cast_boolean_to_pulse #0
+    { // xod__core__cast__boolean__pulse #0
         if (node_0.isNodeDirty) {
             XOD_TRACE_F("Eval node #");
             XOD_TRACE_LN(0);
 
-            xod__core__cast_boolean_to_pulse::ContextObject ctxObj;
+            xod__core__cast__boolean__pulse::ContextObject ctxObj;
             ctxObj._node = &node_0;
 
             // copy data from upstream nodes into context
             ctxObj._input_IN = node_17.output_OUT;
 
-            xod__core__cast_boolean_to_pulse::evaluate(&ctxObj);
+            xod__core__cast__boolean__pulse::evaluate(&ctxObj);
 
             // mark downstream nodes dirty
             node_13.isNodeDirty |= node_0.isOutputDirty_OUT;
@@ -1596,18 +1596,18 @@ void runTransaction(bool firstRun) {
             node_17.isNodeDirty = true;
         }
     }
-    { // xod__core__cast_number_to_string #15
+    { // xod__core__cast__number__string #15
         if (node_15.isNodeDirty) {
             XOD_TRACE_F("Eval node #");
             XOD_TRACE_LN(15);
 
-            xod__core__cast_number_to_string::ContextObject ctxObj;
+            xod__core__cast__number__string::ContextObject ctxObj;
             ctxObj._node = &node_15;
 
             // copy data from upstream nodes into context
             ctxObj._input_IN = node_13.output_OUT;
 
-            xod__core__cast_number_to_string::evaluate(&ctxObj);
+            xod__core__cast__number__string::evaluate(&ctxObj);
 
             // mark downstream nodes dirty
             node_16.isNodeDirty = true;

--- a/workspace/count-with-feedback-loops/__fixtures__/arduino.cpp
+++ b/workspace/count-with-feedback-loops/__fixtures__/arduino.cpp
@@ -803,101 +803,6 @@ void evaluate(Context ctx) {
 } // namespace xod__common_hardware__text_lcd_16x2
 
 //-----------------------------------------------------------------------------
-// xod/core/defer_boolean implementation
-//-----------------------------------------------------------------------------
-namespace xod__core__defer_boolean {
-
-struct State {
-};
-
-struct Node {
-    State state;
-    TimeMs timeoutAt;
-    Logic output_OUT;
-
-    union {
-        struct {
-            bool isOutputDirty_OUT : 1;
-            bool isNodeDirty : 1;
-        };
-
-        DirtyFlags dirtyFlags;
-    };
-};
-
-struct input_IN { };
-struct output_OUT { };
-
-template<typename PinT> struct ValueType { using T = void; };
-template<> struct ValueType<input_IN> { using T = Logic; };
-template<> struct ValueType<output_OUT> { using T = Logic; };
-
-struct ContextObject {
-    Node* _node;
-
-    Logic _input_IN;
-
-    bool _isInputDirty_IN;
-};
-
-using Context = ContextObject*;
-
-template<typename PinT> typename ValueType<PinT>::T getValue(Context ctx) {
-    static_assert(always_false<PinT>::value,
-            "Invalid pin descriptor. Expected one of:" \
-            " input_IN" \
-            " output_OUT");
-}
-
-template<> Logic getValue<input_IN>(Context ctx) {
-    return ctx->_input_IN;
-}
-template<> Logic getValue<output_OUT>(Context ctx) {
-    return ctx->_node->output_OUT;
-}
-
-template<typename InputT> bool isInputDirty(Context ctx) {
-    static_assert(always_false<InputT>::value,
-            "Invalid input descriptor. Expected one of:" \
-            " input_IN");
-    return false;
-}
-
-template<> bool isInputDirty<input_IN>(Context ctx) {
-    return ctx->_isInputDirty_IN;
-}
-
-template<typename OutputT> void emitValue(Context ctx, typename ValueType<OutputT>::T val) {
-    static_assert(always_false<OutputT>::value,
-            "Invalid output descriptor. Expected one of:" \
-            " output_OUT");
-}
-
-template<> void emitValue<output_OUT>(Context ctx, Logic val) {
-    ctx->_node->output_OUT = val;
-    ctx->_node->isOutputDirty_OUT = true;
-}
-
-State* getState(Context ctx) {
-    return &ctx->_node->state;
-}
-
-void evaluate(Context ctx) {
-    if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated
-        setTimeout(ctx, 0);
-        // This will not have any immediate effect, because
-        // deferred nodes are at the very bottom of sorted graph.
-        // We do this to just save the value for reemission
-        // on deferred-only evaluation.
-        emitValue<output_OUT>(ctx, getValue<input_IN>(ctx));
-    } else { // deferred-only evaluation pass
-        emitValue<output_OUT>(ctx, getValue<output_OUT>(ctx));
-    }
-}
-
-} // namespace xod__core__defer_boolean
-
-//-----------------------------------------------------------------------------
 // xod/core/clock implementation
 //-----------------------------------------------------------------------------
 namespace xod__core__clock {
@@ -1131,6 +1036,101 @@ void evaluate(Context ctx) {
 } // namespace xod__core__count
 
 //-----------------------------------------------------------------------------
+// xod/core/defer__boolean implementation
+//-----------------------------------------------------------------------------
+namespace xod__core__defer__boolean {
+
+struct State {
+};
+
+struct Node {
+    State state;
+    TimeMs timeoutAt;
+    Logic output_OUT;
+
+    union {
+        struct {
+            bool isOutputDirty_OUT : 1;
+            bool isNodeDirty : 1;
+        };
+
+        DirtyFlags dirtyFlags;
+    };
+};
+
+struct input_IN { };
+struct output_OUT { };
+
+template<typename PinT> struct ValueType { using T = void; };
+template<> struct ValueType<input_IN> { using T = Logic; };
+template<> struct ValueType<output_OUT> { using T = Logic; };
+
+struct ContextObject {
+    Node* _node;
+
+    Logic _input_IN;
+
+    bool _isInputDirty_IN;
+};
+
+using Context = ContextObject*;
+
+template<typename PinT> typename ValueType<PinT>::T getValue(Context ctx) {
+    static_assert(always_false<PinT>::value,
+            "Invalid pin descriptor. Expected one of:" \
+            " input_IN" \
+            " output_OUT");
+}
+
+template<> Logic getValue<input_IN>(Context ctx) {
+    return ctx->_input_IN;
+}
+template<> Logic getValue<output_OUT>(Context ctx) {
+    return ctx->_node->output_OUT;
+}
+
+template<typename InputT> bool isInputDirty(Context ctx) {
+    static_assert(always_false<InputT>::value,
+            "Invalid input descriptor. Expected one of:" \
+            " input_IN");
+    return false;
+}
+
+template<> bool isInputDirty<input_IN>(Context ctx) {
+    return ctx->_isInputDirty_IN;
+}
+
+template<typename OutputT> void emitValue(Context ctx, typename ValueType<OutputT>::T val) {
+    static_assert(always_false<OutputT>::value,
+            "Invalid output descriptor. Expected one of:" \
+            " output_OUT");
+}
+
+template<> void emitValue<output_OUT>(Context ctx, Logic val) {
+    ctx->_node->output_OUT = val;
+    ctx->_node->isOutputDirty_OUT = true;
+}
+
+State* getState(Context ctx) {
+    return &ctx->_node->state;
+}
+
+void evaluate(Context ctx) {
+    if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated
+        setTimeout(ctx, 0);
+        // This will not have any immediate effect, because
+        // deferred nodes are at the very bottom of sorted graph.
+        // We do this to just save the value for reemission
+        // on deferred-only evaluation.
+        emitValue<output_OUT>(ctx, getValue<input_IN>(ctx));
+    } else { // deferred-only evaluation pass
+        emitValue<output_OUT>(ctx, getValue<output_OUT>(ctx));
+    }
+}
+
+} // namespace xod__core__defer__boolean
+
+//-----------------------------------------------------------------------------
 // xod/core/greater implementation
 //-----------------------------------------------------------------------------
 namespace xod__core__greater {
@@ -1219,92 +1219,6 @@ void evaluate(Context ctx) {
 } // namespace xod__core__greater
 
 //-----------------------------------------------------------------------------
-// xod/core/cast_number_to_string implementation
-//-----------------------------------------------------------------------------
-namespace xod__core__cast_number_to_string {
-
-#pragma XOD dirtieness disable
-
-struct State {
-    char str[16];
-    CStringView view;
-    State() : view(str) { }
-};
-
-struct Node {
-    State state;
-    XString output_OUT;
-
-    union {
-        struct {
-            bool isNodeDirty : 1;
-        };
-
-        DirtyFlags dirtyFlags;
-    };
-};
-
-struct input_IN { };
-struct output_OUT { };
-
-template<typename PinT> struct ValueType { using T = void; };
-template<> struct ValueType<input_IN> { using T = Number; };
-template<> struct ValueType<output_OUT> { using T = XString; };
-
-struct ContextObject {
-    Node* _node;
-
-    Number _input_IN;
-
-};
-
-using Context = ContextObject*;
-
-template<typename PinT> typename ValueType<PinT>::T getValue(Context ctx) {
-    static_assert(always_false<PinT>::value,
-            "Invalid pin descriptor. Expected one of:" \
-            " input_IN" \
-            " output_OUT");
-}
-
-template<> Number getValue<input_IN>(Context ctx) {
-    return ctx->_input_IN;
-}
-template<> XString getValue<output_OUT>(Context ctx) {
-    return ctx->_node->output_OUT;
-}
-
-template<typename InputT> bool isInputDirty(Context ctx) {
-    static_assert(always_false<InputT>::value,
-            "Invalid input descriptor. Expected one of:" \
-            "");
-    return false;
-}
-
-template<typename OutputT> void emitValue(Context ctx, typename ValueType<OutputT>::T val) {
-    static_assert(always_false<OutputT>::value,
-            "Invalid output descriptor. Expected one of:" \
-            " output_OUT");
-}
-
-template<> void emitValue<output_OUT>(Context ctx, XString val) {
-    ctx->_node->output_OUT = val;
-}
-
-State* getState(Context ctx) {
-    return &ctx->_node->state;
-}
-
-void evaluate(Context ctx) {
-    auto state = getState(ctx);
-    auto num = getValue<input_IN>(ctx);
-    dtostrf(num, 0, 2, state->str);
-    emitValue<output_OUT>(ctx, XString(&state->view));
-}
-
-} // namespace xod__core__cast_number_to_string
-
-//-----------------------------------------------------------------------------
 // xod/core/cast_boolean_to_pulse implementation
 //-----------------------------------------------------------------------------
 namespace xod__core__cast_boolean_to_pulse {
@@ -1391,6 +1305,92 @@ void evaluate(Context ctx) {
 
 } // namespace xod__core__cast_boolean_to_pulse
 
+//-----------------------------------------------------------------------------
+// xod/core/cast_number_to_string implementation
+//-----------------------------------------------------------------------------
+namespace xod__core__cast_number_to_string {
+
+#pragma XOD dirtieness disable
+
+struct State {
+    char str[16];
+    CStringView view;
+    State() : view(str) { }
+};
+
+struct Node {
+    State state;
+    XString output_OUT;
+
+    union {
+        struct {
+            bool isNodeDirty : 1;
+        };
+
+        DirtyFlags dirtyFlags;
+    };
+};
+
+struct input_IN { };
+struct output_OUT { };
+
+template<typename PinT> struct ValueType { using T = void; };
+template<> struct ValueType<input_IN> { using T = Number; };
+template<> struct ValueType<output_OUT> { using T = XString; };
+
+struct ContextObject {
+    Node* _node;
+
+    Number _input_IN;
+
+};
+
+using Context = ContextObject*;
+
+template<typename PinT> typename ValueType<PinT>::T getValue(Context ctx) {
+    static_assert(always_false<PinT>::value,
+            "Invalid pin descriptor. Expected one of:" \
+            " input_IN" \
+            " output_OUT");
+}
+
+template<> Number getValue<input_IN>(Context ctx) {
+    return ctx->_input_IN;
+}
+template<> XString getValue<output_OUT>(Context ctx) {
+    return ctx->_node->output_OUT;
+}
+
+template<typename InputT> bool isInputDirty(Context ctx) {
+    static_assert(always_false<InputT>::value,
+            "Invalid input descriptor. Expected one of:" \
+            "");
+    return false;
+}
+
+template<typename OutputT> void emitValue(Context ctx, typename ValueType<OutputT>::T val) {
+    static_assert(always_false<OutputT>::value,
+            "Invalid output descriptor. Expected one of:" \
+            " output_OUT");
+}
+
+template<> void emitValue<output_OUT>(Context ctx, XString val) {
+    ctx->_node->output_OUT = val;
+}
+
+State* getState(Context ctx) {
+    return &ctx->_node->state;
+}
+
+void evaluate(Context ctx) {
+    auto state = getState(ctx);
+    auto num = getValue<input_IN>(ctx);
+    dtostrf(num, 0, 2, state->str);
+    emitValue<output_OUT>(ctx, XString(&state->view));
+}
+
+} // namespace xod__core__cast_number_to_string
+
 } // namespace xod
 
 
@@ -1473,8 +1473,8 @@ xod__common_hardware__text_lcd_16x2::Node node_16 = {
 };
 
 constexpr Logic node_17_output_OUT = false;
-xod__core__defer_boolean::Node node_17 = {
-    xod__core__defer_boolean::State(), // state default
+xod__core__defer__boolean::Node node_17 = {
+    xod__core__defer__boolean::State(), // state default
     0, // timeoutAt
     node_17_output_OUT, // output OUT default
     true, // OUT dirty
@@ -1502,11 +1502,11 @@ void runTransaction(bool firstRun) {
             XOD_TRACE_F("Trigger defer node #");
             XOD_TRACE_LN(17);
 
-            xod__core__defer_boolean::ContextObject ctxObj;
+            xod__core__defer__boolean::ContextObject ctxObj;
             ctxObj._node = &node_17;
             ctxObj._isInputDirty_IN = false;
 
-            xod__core__defer_boolean::evaluate(&ctxObj);
+            xod__core__defer__boolean::evaluate(&ctxObj);
 
             // mark downstream nodes dirty
             node_0.isNodeDirty |= node_17.isOutputDirty_OUT;
@@ -1636,12 +1636,12 @@ void runTransaction(bool firstRun) {
             // mark downstream nodes dirty
         }
     }
-    { // xod__core__defer_boolean #17
+    { // xod__core__defer__boolean #17
         if (node_17.isNodeDirty) {
             XOD_TRACE_F("Eval node #");
             XOD_TRACE_LN(17);
 
-            xod__core__defer_boolean::ContextObject ctxObj;
+            xod__core__defer__boolean::ContextObject ctxObj;
             ctxObj._node = &node_17;
 
             // copy data from upstream nodes into context
@@ -1649,7 +1649,7 @@ void runTransaction(bool firstRun) {
 
             ctxObj._isInputDirty_IN = true;
 
-            xod__core__defer_boolean::evaluate(&ctxObj);
+            xod__core__defer__boolean::evaluate(&ctxObj);
 
             // mark downstream nodes dirty
             node_0.isNodeDirty |= node_17.isOutputDirty_OUT;

--- a/workspace/count-with-feedback-loops/main/patch.xodp
+++ b/workspace/count-with-feedback-loops/main/patch.xodp
@@ -23,14 +23,25 @@
       }
     },
     {
-      "id": "rJem0p09W",
+      "id": "Sk-3086YM",
       "input": {
-        "nodeId": "HJJQA6CqW",
+        "nodeId": "rJwoRITYG",
         "pinKey": "BJI7P8t9Z"
       },
       "output": {
         "nodeId": "ryyAS2RqW",
         "pinKey": "B19RYS3lW"
+      }
+    },
+    {
+      "id": "rkRs08TtM",
+      "input": {
+        "nodeId": "r1etS3RcW",
+        "pinKey": "SkUjZA_L-"
+      },
+      "output": {
+        "nodeId": "rJwoRITYG",
+        "pinKey": "HJhXDIY9-"
       }
     },
     {
@@ -42,17 +53,6 @@
       "output": {
         "nodeId": "r1etS3RcW",
         "pinKey": "r1yhZRd8W"
-      }
-    },
-    {
-      "id": "ryfQ06A9Z",
-      "input": {
-        "nodeId": "r1etS3RcW",
-        "pinKey": "SkUjZA_L-"
-      },
-      "output": {
-        "nodeId": "HJJQA6CqW",
-        "pinKey": "HJhXDIY9-"
       }
     }
   ],
@@ -74,14 +74,6 @@
       "type": "xod/common-hardware/text-lcd-16x2"
     },
     {
-      "id": "HJJQA6CqW",
-      "position": {
-        "x": 612,
-        "y": 204
-      },
-      "type": "xod/core/defer-boolean"
-    },
-    {
       "boundValues": {
         "B13SCNhl-": 1
       },
@@ -99,6 +91,14 @@
         "y": 102
       },
       "type": "xod/core/count"
+    },
+    {
+      "id": "rJwoRITYG",
+      "position": {
+        "x": 612,
+        "y": 204
+      },
+      "type": "xod/core/defer(boolean)"
     },
     {
       "boundValues": {

--- a/workspace/lcd-time/__fixtures__/arduino.cpp
+++ b/workspace/lcd-time/__fixtures__/arduino.cpp
@@ -888,9 +888,9 @@ void evaluate(Context ctx) {
 } // namespace xod__common_hardware__text_lcd_16x2
 
 //-----------------------------------------------------------------------------
-// xod/core/cast_number_to_string implementation
+// xod/core/cast__number__string implementation
 //-----------------------------------------------------------------------------
-namespace xod__core__cast_number_to_string {
+namespace xod__core__cast__number__string {
 
 #pragma XOD dirtieness disable
 
@@ -971,7 +971,7 @@ void evaluate(Context ctx) {
     emitValue<output_OUT>(ctx, XString(&state->view));
 }
 
-} // namespace xod__core__cast_number_to_string
+} // namespace xod__core__cast__number__string
 
 //-----------------------------------------------------------------------------
 // xod/core/continuously implementation
@@ -1094,8 +1094,8 @@ xod__core__system_time::Node node_8 = {
 };
 
 constexpr XString node_9_output_OUT = XString();
-xod__core__cast_number_to_string::Node node_9 = {
-    xod__core__cast_number_to_string::State(), // state default
+xod__core__cast__number__string::Node node_9 = {
+    xod__core__cast__number__string::State(), // state default
     node_9_output_OUT, // output OUT default
     true // node itself dirty
 };
@@ -1157,18 +1157,18 @@ void runTransaction(bool firstRun) {
             node_9.isNodeDirty = true;
         }
     }
-    { // xod__core__cast_number_to_string #9
+    { // xod__core__cast__number__string #9
         if (node_9.isNodeDirty) {
             XOD_TRACE_F("Eval node #");
             XOD_TRACE_LN(9);
 
-            xod__core__cast_number_to_string::ContextObject ctxObj;
+            xod__core__cast__number__string::ContextObject ctxObj;
             ctxObj._node = &node_9;
 
             // copy data from upstream nodes into context
             ctxObj._input_IN = node_8.output_TIME;
 
-            xod__core__cast_number_to_string::evaluate(&ctxObj);
+            xod__core__cast__number__string::evaluate(&ctxObj);
 
             // mark downstream nodes dirty
             node_10.isNodeDirty = true;


### PR DESCRIPTION
Continues #1114 and #1128
