### PR TITLE
Fix: remove implementation on removing `not-implemented-in-xod` Node

### DIFF
--- a/packages/xod-project/src/index.js
+++ b/packages/xod-project/src/index.js
@@ -11,6 +11,7 @@ export {
   hasImpl,
   getImpl,
   setImpl,
+  removeImpl,
   nodeIdEquals,
   listNodes,
   getNodeById,


### PR DESCRIPTION
There is no issue. 😬 

But you can reproduce a bug by next steps (without changes from this PR):
1. Open XOD IDE
2. Create new patch
3. Place few inputs/outputs
4. Place `not-implemented-in-xod` Node on the Patch
5. Delete it
6. Place some nodes from `xod/core`
7. Click "Deploy"->"Show Code for Arduino"

You'll see the bug like `Dead node reference error: Can not find patch "xod/core/add" in the project`.