### PR TITLE
Fix: omit empty strings from bound literals

### DIFF
--- a/packages/xod-project/src/legacy.js
+++ b/packages/xod-project/src/legacy.js
@@ -107,6 +107,12 @@ const migrateNodeBoundValuesWithoutTypes = node =>
     R.propOr({}, LEGACY_BOUND_VALUES_PROP)
   )(node);
 
+// :: Node -> Node
+const omitEmptyBoundValues = R.when(
+  R.has(LEGACY_BOUND_VALUES_PROP),
+  R.over(R.lensProp(LEGACY_BOUND_VALUES_PROP), R.reject(R.isEmpty))
+);
+
 // :: Patch -> Project -> Project
 const migratePatchBoundValuesToBoundLiterals = R.curry((patch, project) =>
   R.compose(
@@ -132,6 +138,7 @@ const migratePatchBoundValuesToBoundLiterals = R.curry((patch, project) =>
         Project.getPatchByNode(R.__, project)
       )(node)
     ),
+    R.map(omitEmptyBoundValues),
     Patch.listNodes
   )(patch)
 );
@@ -152,5 +159,3 @@ export const migrateBoundValuesToBoundLiterals = def(
       Project.listPatchesWithoutBuiltIns
     )(project)
 );
-
-export default {};

--- a/workspace/__lib__/xod/core/analog-input/patch.xodp
+++ b/workspace/__lib__/xod/core/analog-input/patch.xodp
@@ -20,9 +20,6 @@
       "type": "xod/patch-nodes/not-implemented-in-xod"
     },
     {
-      "boundLiterals": {
-        "__in__": ""
-      },
       "description": "The latest read value in range 0.0 … 1.0",
       "id": "SyBtREhlW",
       "label": "VAL",

--- a/workspace/__lib__/xod/core/branch/patch.xodp
+++ b/workspace/__lib__/xod/core/branch/patch.xodp
@@ -35,9 +35,6 @@
       "type": "xod/patch-nodes/output-pulse"
     },
     {
-      "boundLiterals": {
-        "__in__": ""
-      },
       "description": "Pulses with `TRIG` when `GATE` is false",
       "id": "SyM2ATB-b",
       "label": "F",

--- a/workspace/__lib__/xod/core/clock/patch.xodp
+++ b/workspace/__lib__/xod/core/clock/patch.xodp
@@ -33,9 +33,6 @@
       "type": "xod/patch-nodes/not-implemented-in-xod"
     },
     {
-      "boundLiterals": {
-        "__in__": ""
-      },
       "description": "Pulses on each time interval end",
       "id": "HJU8CE2lW",
       "label": "TICK",

--- a/workspace/__lib__/xod/core/constant-number/patch.xodp
+++ b/workspace/__lib__/xod/core/constant-number/patch.xodp
@@ -1,9 +1,6 @@
 {
   "nodes": [
     {
-      "boundLiterals": {
-        "__in__": ""
-      },
       "id": "B1x2RV3eZ",
       "label": "VAL",
       "position": {

--- a/workspace/__lib__/xod/core/constant-string/patch.xodp
+++ b/workspace/__lib__/xod/core/constant-string/patch.xodp
@@ -1,9 +1,6 @@
 {
   "nodes": [
     {
-      "boundLiterals": {
-        "__in__": "\"\""
-      },
       "id": "B1x2RV3eZ",
       "label": "VAL",
       "position": {

--- a/workspace/__lib__/xod/core/greater/patch.xodp
+++ b/workspace/__lib__/xod/core/greater/patch.xodp
@@ -2,9 +2,6 @@
   "description": "Outputs true if `IN1` > `IN2`, and false otherwise",
   "nodes": [
     {
-      "boundLiterals": {
-        "__in__": ""
-      },
       "id": "B19RYS3lW",
       "position": {
         "x": 136,

--- a/workspace/lcd-time/__fixtures__/arduino.cpp
+++ b/workspace/lcd-time/__fixtures__/arduino.cpp
@@ -1096,17 +1096,17 @@ xod__core__continuously::Node node_0 = {
 
 constexpr Number node_1_output_VAL = 10;
 
-constexpr XString node_2_output_VAL = XString();
+constexpr Number node_2_output_VAL = 12;
 
-constexpr Number node_3_output_VAL = 12;
+constexpr Number node_3_output_VAL = 11;
 
-constexpr Number node_4_output_VAL = 11;
+constexpr Number node_4_output_VAL = 9;
 
-constexpr Number node_5_output_VAL = 9;
+constexpr Number node_5_output_VAL = 8;
 
-constexpr Number node_6_output_VAL = 8;
+constexpr Number node_6_output_VAL = 13;
 
-constexpr Number node_7_output_VAL = 13;
+constexpr XString node_7_output_VAL = XString();
 
 constexpr Number node_8_output_TIME = 0;
 xod__core__system_time::Node node_8 = {
@@ -1205,14 +1205,14 @@ void runTransaction() {
             ctxObj._node = &node_10;
 
             // copy data from upstream nodes into context
-            ctxObj._input_RS = node_6_output_VAL;
-            ctxObj._input_EN = node_5_output_VAL;
+            ctxObj._input_RS = node_5_output_VAL;
+            ctxObj._input_EN = node_4_output_VAL;
             ctxObj._input_D4 = node_1_output_VAL;
-            ctxObj._input_D5 = node_4_output_VAL;
-            ctxObj._input_D6 = node_3_output_VAL;
-            ctxObj._input_D7 = node_7_output_VAL;
+            ctxObj._input_D5 = node_3_output_VAL;
+            ctxObj._input_D6 = node_2_output_VAL;
+            ctxObj._input_D7 = node_6_output_VAL;
             ctxObj._input_L1 = node_9.output_OUT;
-            ctxObj._input_L2 = node_2_output_VAL;
+            ctxObj._input_L2 = node_7_output_VAL;
 
             xod__common_hardware__text_lcd_16x2::evaluate(&ctxObj);
 

--- a/workspace/lcd-time/main/patch.xodp
+++ b/workspace/lcd-time/main/patch.xodp
@@ -26,9 +26,7 @@
     },
     {
       "boundLiterals": {
-        "B1TSE9tZ-": "\"\"",
         "BJJqaX4Gb": "10",
-        "H1bLN9F-b": "\"\"",
         "HJysTXVMb": "12",
         "S1nqa7NMZ": "11",
         "SkBK6Q4fb": "9",


### PR DESCRIPTION
There was a bug: boundValue could contain an empty string, even if it's a bound value for boolean terminal Pin. So we have just to omit empty strings from bound values.

There is no regression, cause:
- empty strings were valid only for strings and this is a default value
- all other types should contain another values