### PR TITLE
Fix crashing IDE on opening project with nodes from not installed libs

### DIFF
--- a/packages/xod-project/src/project.js
+++ b/packages/xod-project/src/project.js
@@ -575,7 +575,7 @@ export const getInvalidBoundNodePins = def(
     )(node);
 
     const nodePatch = R.compose(
-      getPatchByPathUnsafe(R.__, project),
+      getPatchByPath(R.__, project),
       Node.getNodeType
     )(node);
 
@@ -592,8 +592,8 @@ export const getInvalidBoundNodePins = def(
               trace: [patchPath, nodeName],
             });
           }),
-          Patch.getVariadicPinByKey
-        )(node, pinKey, nodePatch)
+          R.chain(Patch.getVariadicPinByKey(node, pinKey))
+        )(nodePatch)
       ),
       R.reject(Utils.isValidLiteral),
       R.omit(linkedPins),


### PR DESCRIPTION
There is no issue 😬 
Bug produced in the PR #1175 