### PR TITLE
Resolve abstract nodes placed deeply inside regular patches

### DIFF
--- a/packages/xod-project/test/fixtures/abstract-nodes-resolution.resolved-abstracts-inside-regular.xodball
+++ b/packages/xod-project/test/fixtures/abstract-nodes-resolution.resolved-abstracts-inside-regular.xodball
@@ -1,5 +1,4 @@
 {
-  "name": "",
   "patches": {
     "@/any": {
       "attachments": [
@@ -779,8 +778,8 @@
           "type": "xod/patch-nodes/not-implemented-in-xod"
         },
         "HylUEGgciz": {
-          "id": "HylUEGgciz",
           "label": "DUMP",
+          "id": "HylUEGgciz",
           "position": {
             "x": 136,
             "y": 0
@@ -788,8 +787,8 @@
           "type": "xod/patch-nodes/input-pulse"
         },
         "Sy84Mlcjz": {
-          "id": "Sy84Mlcjz",
           "label": "LINE",
+          "id": "Sy84Mlcjz",
           "position": {
             "x": 0,
             "y": 0
@@ -810,8 +809,8 @@
       "nodes": {
         "SJgl2rcoz": {
           "description": "Board GPIO port number to read from",
-          "id": "SJgl2rcoz",
           "label": "PORT",
+          "id": "SJgl2rcoz",
           "position": {
             "x": -1,
             "y": -1
@@ -831,8 +830,8 @@
             "__out__": "Continuously"
           },
           "description": "Triggers new read",
-          "id": "rJWgxhS9sf",
           "label": "UPD",
+          "id": "rJWgxhS9sf",
           "position": {
             "x": 127,
             "y": -1
@@ -844,8 +843,8 @@
             "__in__": "False"
           },
           "description": "The last read signal value",
-          "id": "rkegx3rqoz",
           "label": "SIG",
+          "id": "rkegx3rqoz",
           "position": {
             "x": -1,
             "y": 207
@@ -866,8 +865,8 @@
       "nodes": {
         "HJfTgQRsjM": {
           "description": "Formatted value",
-          "id": "HJfTgQRsjM",
           "label": "STR",
+          "id": "HJfTgQRsjM",
           "position": {
             "x": -1,
             "y": 207
@@ -887,8 +886,8 @@
             "__out__": "2"
           },
           "description": "Number of digits after dot",
-          "id": "SkepemRsjf",
           "label": "DIG",
+          "id": "SkepemRsjf",
           "position": {
             "x": 127,
             "y": -1
@@ -897,8 +896,8 @@
         },
         "r16xX0ioz": {
           "description": "Number to format",
-          "id": "r16xX0ioz",
           "label": "NUM",
+          "id": "r16xX0ioz",
           "position": {
             "x": -1,
             "y": -1
@@ -1079,8 +1078,8 @@
       "nodes": {
         "H1bfDMgqiz": {
           "description": "The latest read value in range 0.0 … 1.0",
-          "id": "H1bfDMgqiz",
           "label": "VAL",
+          "id": "H1bfDMgqiz",
           "position": {
             "x": 0,
             "y": 204
@@ -1100,8 +1099,8 @@
             "__out__": "Continuously"
           },
           "description": "Triggers new read",
-          "id": "HkGMwGgqsG",
           "label": "UPD",
+          "id": "HkGMwGgqsG",
           "position": {
             "x": 102,
             "y": 0
@@ -1110,8 +1109,8 @@
         },
         "HkGPfxcjM": {
           "description": "Number of a board ADC port to read from",
-          "id": "HkGPfxcjM",
           "label": "PORT",
+          "id": "HkGPfxcjM",
           "position": {
             "x": -1,
             "y": -1
@@ -1239,7 +1238,7 @@
           "id": "H1dYrOfaM",
           "input": {
             "nodeId": "Hk0UB_GTM",
-            "pinKey": "BJx1NLmvnG"
+            "pinKey": "ByWe0IXv2G"
           },
           "output": {
             "nodeId": "r1vuBOM6f",
@@ -1254,14 +1253,14 @@
           },
           "output": {
             "nodeId": "Hk0UB_GTM",
-            "pinKey": "BJfJE8Xwhf"
+            "pinKey": "HkzlCL7w2M"
           }
         },
         "Sk6urdzaM": {
           "id": "Sk6urdzaM",
           "input": {
             "nodeId": "Hk0UB_GTM",
-            "pinKey": "SyJNU7P3z"
+            "pinKey": "SkxCU7whG"
           },
           "output": {
             "nodeId": "B14OSOG6G",
@@ -1292,7 +1291,7 @@
             "x": 170,
             "y": 204
           },
-          "type": "@/concat"
+          "type": "@/concat(number)"
         },
         "Skjqr_Maz": {
           "id": "Skjqr_Maz",
@@ -1630,5 +1629,6 @@
       },
       "path": "@/with-non-generic-pins(number)"
     }
-  }
+  },
+  "name": ""
 }

--- a/packages/xod-project/test/fixtures/abstract-nodes-resolution.resolved-bound-nongenerics.xodball
+++ b/packages/xod-project/test/fixtures/abstract-nodes-resolution.resolved-bound-nongenerics.xodball
@@ -464,8 +464,8 @@
         },
         "SkFcfNz2G": {
           "boundLiterals": {
-            "H1GGdM4Mhz": "222",
-            "S1mGOG4MhG": "\"don't lose this value as well\""
+            "S1mGOG4MhG": "\"don't lose this value as well\"",
+            "H1GGdM4Mhz": "222"
           },
           "id": "SkFcfNz2G",
           "position": {
@@ -476,8 +476,8 @@
         },
         "r1RtzVznz": {
           "boundLiterals": {
-            "H1GGdM4Mhz": "111",
-            "S1mGOG4MhG": "\"don't lose this value\""
+            "S1mGOG4MhG": "\"don't lose this value\"",
+            "H1GGdM4Mhz": "111"
           },
           "id": "r1RtzVznz",
           "position": {
@@ -488,6 +488,70 @@
         }
       },
       "path": "@/case4-bound-non-generic-pins"
+    },
+    "@/case5-abstracts-deep-inside-regular-patches": {
+      "links": {
+        "B1VCHOfTz": {
+          "id": "B1VCHOfTz",
+          "input": {
+            "nodeId": "r1LhSOzTM",
+            "pinKey": "r1vuBOM6f"
+          },
+          "output": {
+            "nodeId": "B1xRH_zaG",
+            "pinKey": "H1bfDMgqiz"
+          }
+        },
+        "H19pBuGaz": {
+          "id": "H19pBuGaz",
+          "input": {
+            "nodeId": "BJuaB_M6z",
+            "pinKey": "Sy84Mlcjz"
+          },
+          "output": {
+            "nodeId": "r1LhSOzTM",
+            "pinKey": "Skjqr_Maz"
+          }
+        },
+        "S1fRSdGaG": {
+          "id": "S1fRSdGaG",
+          "input": {
+            "nodeId": "r1LhSOzTM",
+            "pinKey": "B14OSOG6G"
+          },
+          "output": {
+            "nodeId": "B1xRH_zaG",
+            "pinKey": "H1bfDMgqiz"
+          }
+        }
+      },
+      "nodes": {
+        "B1xRH_zaG": {
+          "id": "B1xRH_zaG",
+          "position": {
+            "x": 102,
+            "y": 102
+          },
+          "type": "@/pot"
+        },
+        "BJuaB_M6z": {
+          "id": "BJuaB_M6z",
+          "position": {
+            "x": 102,
+            "y": 306
+          },
+          "type": "@/console-log"
+        },
+        "r1LhSOzTM": {
+          "id": "r1LhSOzTM",
+          "position": {
+            "x": 102,
+            "y": 204
+          },
+          "type": "@/regular-with-abstract-inside"
+        }
+      },
+      "path": "@/case5-abstracts-deep-inside-regular-patches"
     },
     "@/concat": {
       "nodes": {
@@ -1013,7 +1077,6 @@
       ],
       "nodes": {
         "H1bfDMgqiz": {
-          "boundLiterals": {},
           "description": "The latest read value in range 0.0 … 1.0",
           "label": "VAL",
           "id": "H1bfDMgqiz",
@@ -1157,6 +1220,97 @@
         }
       },
       "path": "@/pulse-on-change(number)"
+    },
+    "@/regular-with-abstract-inside": {
+      "links": {
+        "BJpqrufpz": {
+          "id": "BJpqrufpz",
+          "input": {
+            "nodeId": "Skjqr_Maz",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "H10KS_Gpf",
+            "pinKey": "HJfTgQRsjM"
+          }
+        },
+        "H1dYrOfaM": {
+          "id": "H1dYrOfaM",
+          "input": {
+            "nodeId": "Hk0UB_GTM",
+            "pinKey": "BJx1NLmvnG"
+          },
+          "output": {
+            "nodeId": "r1vuBOM6f",
+            "pinKey": "__out__"
+          }
+        },
+        "SJg5HdM6G": {
+          "id": "SJg5HdM6G",
+          "input": {
+            "nodeId": "H10KS_Gpf",
+            "pinKey": "r16xX0ioz"
+          },
+          "output": {
+            "nodeId": "Hk0UB_GTM",
+            "pinKey": "BJfJE8Xwhf"
+          }
+        },
+        "Sk6urdzaM": {
+          "id": "Sk6urdzaM",
+          "input": {
+            "nodeId": "Hk0UB_GTM",
+            "pinKey": "SyJNU7P3z"
+          },
+          "output": {
+            "nodeId": "B14OSOG6G",
+            "pinKey": "__out__"
+          }
+        }
+      },
+      "nodes": {
+        "B14OSOG6G": {
+          "id": "B14OSOG6G",
+          "position": {
+            "x": 102,
+            "y": 0
+          },
+          "type": "xod/patch-nodes/input-number"
+        },
+        "H10KS_Gpf": {
+          "id": "H10KS_Gpf",
+          "position": {
+            "x": 170,
+            "y": 306
+          },
+          "type": "@/format-number"
+        },
+        "Hk0UB_GTM": {
+          "id": "Hk0UB_GTM",
+          "position": {
+            "x": 170,
+            "y": 204
+          },
+          "type": "@/concat"
+        },
+        "Skjqr_Maz": {
+          "id": "Skjqr_Maz",
+          "position": {
+            "x": 170,
+            "y": 510
+          },
+          "type": "xod/patch-nodes/output-string"
+        },
+        "r1vuBOM6f": {
+          "id": "r1vuBOM6f",
+          "position": {
+            "x": 306,
+            "y": 0
+          },
+          "type": "xod/patch-nodes/input-number"
+        }
+      },
+      "path": "@/regular-with-abstract-inside"
     },
     "@/when-either-changes": {
       "links": {

--- a/packages/xod-project/test/fixtures/abstract-nodes-resolution.resolved-variadics.xodball
+++ b/packages/xod-project/test/fixtures/abstract-nodes-resolution.resolved-variadics.xodball
@@ -464,8 +464,8 @@
         },
         "SkFcfNz2G": {
           "boundLiterals": {
-            "r1-UGNGnM": "222",
-            "ByLUGVz2M": "\"don't lose this value as well\""
+            "ByLUGVz2M": "\"don't lose this value as well\"",
+            "r1-UGNGnM": "222"
           },
           "id": "SkFcfNz2G",
           "position": {
@@ -476,8 +476,8 @@
         },
         "r1RtzVznz": {
           "boundLiterals": {
-            "r1-UGNGnM": "111",
-            "ByLUGVz2M": "\"don't lose this value\""
+            "ByLUGVz2M": "\"don't lose this value\"",
+            "r1-UGNGnM": "111"
           },
           "id": "r1RtzVznz",
           "position": {
@@ -488,6 +488,70 @@
         }
       },
       "path": "@/case4-bound-non-generic-pins"
+    },
+    "@/case5-abstracts-deep-inside-regular-patches": {
+      "links": {
+        "B1VCHOfTz": {
+          "id": "B1VCHOfTz",
+          "input": {
+            "nodeId": "r1LhSOzTM",
+            "pinKey": "r1vuBOM6f"
+          },
+          "output": {
+            "nodeId": "B1xRH_zaG",
+            "pinKey": "H1bfDMgqiz"
+          }
+        },
+        "H19pBuGaz": {
+          "id": "H19pBuGaz",
+          "input": {
+            "nodeId": "BJuaB_M6z",
+            "pinKey": "Sy84Mlcjz"
+          },
+          "output": {
+            "nodeId": "r1LhSOzTM",
+            "pinKey": "Skjqr_Maz"
+          }
+        },
+        "S1fRSdGaG": {
+          "id": "S1fRSdGaG",
+          "input": {
+            "nodeId": "r1LhSOzTM",
+            "pinKey": "B14OSOG6G"
+          },
+          "output": {
+            "nodeId": "B1xRH_zaG",
+            "pinKey": "H1bfDMgqiz"
+          }
+        }
+      },
+      "nodes": {
+        "B1xRH_zaG": {
+          "id": "B1xRH_zaG",
+          "position": {
+            "x": 102,
+            "y": 102
+          },
+          "type": "@/pot"
+        },
+        "BJuaB_M6z": {
+          "id": "BJuaB_M6z",
+          "position": {
+            "x": 102,
+            "y": 306
+          },
+          "type": "@/console-log"
+        },
+        "r1LhSOzTM": {
+          "id": "r1LhSOzTM",
+          "position": {
+            "x": 102,
+            "y": 204
+          },
+          "type": "@/regular-with-abstract-inside"
+        }
+      },
+      "path": "@/case5-abstracts-deep-inside-regular-patches"
     },
     "@/concat": {
       "nodes": {
@@ -1013,7 +1077,6 @@
       ],
       "nodes": {
         "H1bfDMgqiz": {
-          "boundLiterals": {},
           "description": "The latest read value in range 0.0 … 1.0",
           "label": "VAL",
           "id": "H1bfDMgqiz",
@@ -1157,6 +1220,97 @@
         }
       },
       "path": "@/pulse-on-change(number)"
+    },
+    "@/regular-with-abstract-inside": {
+      "links": {
+        "BJpqrufpz": {
+          "id": "BJpqrufpz",
+          "input": {
+            "nodeId": "Skjqr_Maz",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "H10KS_Gpf",
+            "pinKey": "HJfTgQRsjM"
+          }
+        },
+        "H1dYrOfaM": {
+          "id": "H1dYrOfaM",
+          "input": {
+            "nodeId": "Hk0UB_GTM",
+            "pinKey": "BJx1NLmvnG"
+          },
+          "output": {
+            "nodeId": "r1vuBOM6f",
+            "pinKey": "__out__"
+          }
+        },
+        "SJg5HdM6G": {
+          "id": "SJg5HdM6G",
+          "input": {
+            "nodeId": "H10KS_Gpf",
+            "pinKey": "r16xX0ioz"
+          },
+          "output": {
+            "nodeId": "Hk0UB_GTM",
+            "pinKey": "BJfJE8Xwhf"
+          }
+        },
+        "Sk6urdzaM": {
+          "id": "Sk6urdzaM",
+          "input": {
+            "nodeId": "Hk0UB_GTM",
+            "pinKey": "SyJNU7P3z"
+          },
+          "output": {
+            "nodeId": "B14OSOG6G",
+            "pinKey": "__out__"
+          }
+        }
+      },
+      "nodes": {
+        "B14OSOG6G": {
+          "id": "B14OSOG6G",
+          "position": {
+            "x": 102,
+            "y": 0
+          },
+          "type": "xod/patch-nodes/input-number"
+        },
+        "H10KS_Gpf": {
+          "id": "H10KS_Gpf",
+          "position": {
+            "x": 170,
+            "y": 306
+          },
+          "type": "@/format-number"
+        },
+        "Hk0UB_GTM": {
+          "id": "Hk0UB_GTM",
+          "position": {
+            "x": 170,
+            "y": 204
+          },
+          "type": "@/concat"
+        },
+        "Skjqr_Maz": {
+          "id": "Skjqr_Maz",
+          "position": {
+            "x": 170,
+            "y": 510
+          },
+          "type": "xod/patch-nodes/output-string"
+        },
+        "r1vuBOM6f": {
+          "id": "r1vuBOM6f",
+          "position": {
+            "x": 306,
+            "y": 0
+          },
+          "type": "xod/patch-nodes/input-number"
+        }
+      },
+      "path": "@/regular-with-abstract-inside"
     },
     "@/when-either-changes": {
       "links": {

--- a/packages/xod-project/test/fixtures/abstract-nodes-resolution.resolved.xodball
+++ b/packages/xod-project/test/fixtures/abstract-nodes-resolution.resolved.xodball
@@ -464,8 +464,8 @@
         },
         "SkFcfNz2G": {
           "boundLiterals": {
-            "r1-UGNGnM": "222",
-            "ByLUGVz2M": "\"don't lose this value as well\""
+            "ByLUGVz2M": "\"don't lose this value as well\"",
+            "r1-UGNGnM": "222"
           },
           "id": "SkFcfNz2G",
           "position": {
@@ -476,8 +476,8 @@
         },
         "r1RtzVznz": {
           "boundLiterals": {
-            "r1-UGNGnM": "111",
-            "ByLUGVz2M": "\"don't lose this value\""
+            "ByLUGVz2M": "\"don't lose this value\"",
+            "r1-UGNGnM": "111"
           },
           "id": "r1RtzVznz",
           "position": {
@@ -488,6 +488,70 @@
         }
       },
       "path": "@/case4-bound-non-generic-pins"
+    },
+    "@/case5-abstracts-deep-inside-regular-patches": {
+      "links": {
+        "B1VCHOfTz": {
+          "id": "B1VCHOfTz",
+          "input": {
+            "nodeId": "r1LhSOzTM",
+            "pinKey": "r1vuBOM6f"
+          },
+          "output": {
+            "nodeId": "B1xRH_zaG",
+            "pinKey": "H1bfDMgqiz"
+          }
+        },
+        "H19pBuGaz": {
+          "id": "H19pBuGaz",
+          "input": {
+            "nodeId": "BJuaB_M6z",
+            "pinKey": "Sy84Mlcjz"
+          },
+          "output": {
+            "nodeId": "r1LhSOzTM",
+            "pinKey": "Skjqr_Maz"
+          }
+        },
+        "S1fRSdGaG": {
+          "id": "S1fRSdGaG",
+          "input": {
+            "nodeId": "r1LhSOzTM",
+            "pinKey": "B14OSOG6G"
+          },
+          "output": {
+            "nodeId": "B1xRH_zaG",
+            "pinKey": "H1bfDMgqiz"
+          }
+        }
+      },
+      "nodes": {
+        "B1xRH_zaG": {
+          "id": "B1xRH_zaG",
+          "position": {
+            "x": 102,
+            "y": 102
+          },
+          "type": "@/pot"
+        },
+        "BJuaB_M6z": {
+          "id": "BJuaB_M6z",
+          "position": {
+            "x": 102,
+            "y": 306
+          },
+          "type": "@/console-log"
+        },
+        "r1LhSOzTM": {
+          "id": "r1LhSOzTM",
+          "position": {
+            "x": 102,
+            "y": 204
+          },
+          "type": "@/regular-with-abstract-inside"
+        }
+      },
+      "path": "@/case5-abstracts-deep-inside-regular-patches"
     },
     "@/concat": {
       "nodes": {
@@ -1013,7 +1077,6 @@
       ],
       "nodes": {
         "H1bfDMgqiz": {
-          "boundLiterals": {},
           "description": "The latest read value in range 0.0 … 1.0",
           "label": "VAL",
           "id": "H1bfDMgqiz",
@@ -1157,6 +1220,97 @@
         }
       },
       "path": "@/pulse-on-change(number)"
+    },
+    "@/regular-with-abstract-inside": {
+      "links": {
+        "BJpqrufpz": {
+          "id": "BJpqrufpz",
+          "input": {
+            "nodeId": "Skjqr_Maz",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "H10KS_Gpf",
+            "pinKey": "HJfTgQRsjM"
+          }
+        },
+        "H1dYrOfaM": {
+          "id": "H1dYrOfaM",
+          "input": {
+            "nodeId": "Hk0UB_GTM",
+            "pinKey": "BJx1NLmvnG"
+          },
+          "output": {
+            "nodeId": "r1vuBOM6f",
+            "pinKey": "__out__"
+          }
+        },
+        "SJg5HdM6G": {
+          "id": "SJg5HdM6G",
+          "input": {
+            "nodeId": "H10KS_Gpf",
+            "pinKey": "r16xX0ioz"
+          },
+          "output": {
+            "nodeId": "Hk0UB_GTM",
+            "pinKey": "BJfJE8Xwhf"
+          }
+        },
+        "Sk6urdzaM": {
+          "id": "Sk6urdzaM",
+          "input": {
+            "nodeId": "Hk0UB_GTM",
+            "pinKey": "SyJNU7P3z"
+          },
+          "output": {
+            "nodeId": "B14OSOG6G",
+            "pinKey": "__out__"
+          }
+        }
+      },
+      "nodes": {
+        "B14OSOG6G": {
+          "id": "B14OSOG6G",
+          "position": {
+            "x": 102,
+            "y": 0
+          },
+          "type": "xod/patch-nodes/input-number"
+        },
+        "H10KS_Gpf": {
+          "id": "H10KS_Gpf",
+          "position": {
+            "x": 170,
+            "y": 306
+          },
+          "type": "@/format-number"
+        },
+        "Hk0UB_GTM": {
+          "id": "Hk0UB_GTM",
+          "position": {
+            "x": 170,
+            "y": 204
+          },
+          "type": "@/concat"
+        },
+        "Skjqr_Maz": {
+          "id": "Skjqr_Maz",
+          "position": {
+            "x": 170,
+            "y": 510
+          },
+          "type": "xod/patch-nodes/output-string"
+        },
+        "r1vuBOM6f": {
+          "id": "r1vuBOM6f",
+          "position": {
+            "x": 306,
+            "y": 0
+          },
+          "type": "xod/patch-nodes/input-number"
+        }
+      },
+      "path": "@/regular-with-abstract-inside"
     },
     "@/when-either-changes": {
       "links": {

--- a/packages/xod-project/test/typeDeduction.spec.js
+++ b/packages/xod-project/test/typeDeduction.spec.js
@@ -276,4 +276,16 @@ describe('autoresolveTypes', () => {
       );
     }, autoresolveTypes('@/case4-bound-non-generic-pins', project));
   });
+  it('resolves abstract nodes in patches that have no generic inputs', () => {
+    const expectedResolvedProject = Helper.loadXodball(
+      './fixtures/abstract-nodes-resolution.resolved-abstracts-inside-regular.xodball'
+    );
+
+    Helper.expectEitherRight(actualResolvedProject => {
+      assert.sameDeepMembers(
+        listPatchesWithoutBuiltIns(actualResolvedProject),
+        listPatchesWithoutBuiltIns(expectedResolvedProject)
+      );
+    }, autoresolveTypes('@/case5-abstracts-deep-inside-regular-patches', project));
+  });
 });


### PR DESCRIPTION
Fixes a quite nasty problem reported on our forum.

Main changes are in `packages/xod-project/src/typeDeduction.js`, the rest are fixtures/tests.
