### PR TITLE
Fix crash when constructing message about wrong variadic pin types

### DIFF
--- a/packages/xod-project/src/messages.js
+++ b/packages/xod-project/src/messages.js
@@ -94,11 +94,11 @@ export default {
     note: `A variadic-${arityStep} patch with ${outputCount} outputs should have at least ${minInputs} inputs`,
     trace,
   }),
-  WRONG_VARIADIC_PIN_TYPES: ({ inputPinLabels, outputPinLabels, trace }) => ({
+  WRONG_VARIADIC_PIN_TYPES: ({ accPinLabels, outPinLabels, trace }) => ({
     title: 'Invalid variadic patch',
-    note: `Types of inputs ${inputPinLabels.join(
+    note: `Types of inputs ${accPinLabels.join(
       ', '
-    )} should match the types of outputs ${outputPinLabels.join(', ')}`,
+    )} should match the types of outputs ${outPinLabels.join(', ')}`,
     trace,
   }),
   VARIADIC_HAS_NO_OUTPUTS: ({ trace }) => ({

--- a/packages/xod-project/src/patch.js
+++ b/packages/xod-project/src/patch.js
@@ -1138,14 +1138,14 @@ export const computeVariadicPins = def(
     }
 
     const outputs = listOutputPins(patch);
-    const outputsCount = outputs.length;
+    const outputCount = outputs.length;
 
-    if (outputsCount === 0) {
+    if (outputCount === 0) {
       return fail('VARIADIC_HAS_NO_OUTPUTS', { trace: [patchPath] });
     }
 
     const inputs = listInputPins(patch);
-    const inputsCount = inputs.length;
+    const inputCount = inputs.length;
     const arityStep = R.compose(
       explodeMaybe(
         'Imposible error: we should catch Patch without arity markers on first check'
@@ -1153,19 +1153,19 @@ export const computeVariadicPins = def(
       getArityStepFromPatch
     )(patch);
 
-    if (inputsCount - arityStep < outputsCount) {
-      const minInputs = R.add(outputsCount, arityStep);
+    if (inputCount - arityStep < outputCount) {
+      const minInputs = R.add(outputCount, arityStep);
       return fail('NOT_ENOUGH_VARIADIC_INPUTS', {
         trace: [patchPath],
         arityStep,
-        outputsCount,
+        outputCount,
         minInputs,
       });
     }
 
     const valPins = R.takeLast(arityStep, inputs);
     const accPins = R.compose(
-      R.takeLast(outputsCount),
+      R.takeLast(outputCount),
       R.slice(0, R.negate(arityStep))
     )(inputs);
 

--- a/packages/xod-project/test/patch.spec.js
+++ b/packages/xod-project/test/patch.spec.js
@@ -1505,7 +1505,7 @@ describe('Patch', () => {
         const res = Patch.computeVariadicPins(patch);
 
         Helper.expectEitherError(
-          'NOT_ENOUGH_VARIADIC_INPUTS {"trace":["@/default-patch-path"],"arityStep":2,"outputsCount":1,"minInputs":3}',
+          'NOT_ENOUGH_VARIADIC_INPUTS {"trace":["@/default-patch-path"],"arityStep":2,"outputCount":1,"minInputs":3}',
           res
         );
       });


### PR DESCRIPTION
Fixes a bug that was [reported on our forum](https://forum.xod.io/t/xod-0-20-1-issue/751)

Bug could be reproduced by placing `variadic-1` node in a patch like this one:
[troublesome-variadic.xodball.zip](https://github.com/xodio/xod/files/1983331/troublesome-variadic.xodball.zip)
