### PR TITLE
Proper file names for uploaded GCloud files containing spaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
             # Adjust metadata to give proper filenames for download
             # (otherwise they are dirname%3Ffilename where %3F is a slash)
             ls dist -1 | xargs -n 1 -I {} \
-              gsutil setmeta -h "Content-Disposition: attachment; filename="{}"" $GS_PATH/{}
+              gsutil setmeta -h 'Content-Disposition: attachment; filename="{}"' $GS_PATH/{}
 
 #==============================================================================
 #


### PR DESCRIPTION
Fixes the problem [reported](https://forum.xod.io/t/how-to-get-the-osx-download-working/397) on the forum: macOS gets improper distributive filename if downloaded from Firefox.