### PR TITLE
Fix canceling of open project in browser ide causes exception

### DIFF
--- a/packages/xod-client-browser/src/containers/App.jsx
+++ b/packages/xod-client-browser/src/containers/App.jsx
@@ -127,6 +127,8 @@ class App extends client.App {
   }
 
   onLoadChange(event) {
+    if (event.target.files.length === 0) return;
+
     const file = event.target.files[0];
     const reader = new window.FileReader();
 


### PR DESCRIPTION
There is no issue. 😬 
Minor bug, that does not corrupts IDE, but logs an error in the developers console.

**To reproduce:**
1. Open browser IDE
2. Click "File"->"Open Project..." and load any .xodball (it changes a value of the input and next time when User cancel selection of file it will fire the callback)
3. Click "File" -> "Open Project..." again. But then cancel opening.

You'll see an error in the DevTools.