### PR TITLE
Fix [Object object] in deploy pane messages

### DIFF
--- a/packages/xod-client-electron/src/shared/errorFormatter.js
+++ b/packages/xod-client-electron/src/shared/errorFormatter.js
@@ -9,23 +9,27 @@ import composeMessage from './composeMessage';
 import * as EC from './errorCodes';
 
 const UNKNOWN_ERROR = err =>
-  composeMessage('Unknown error occurred', err.message || JSON.stringify(err));
+  composeMessage('You have found a bug', err.message || JSON.stringify(err));
 
+// :: StrMap(Error -> { title :: String, note :: Nullable(String) })
 const ERROR_FORMATTERS = {
-  // Errors that will showed in the upload popup
-  [EC.TRANSPILE_ERROR]: err => `Error occurred during transpilation: ${err}`,
+  [EC.TRANSPILE_ERROR]: err =>
+    composeMessage('Transpilation failed', R.toString(err)),
   [EC.PORT_NOT_FOUND]: err =>
-    `Could not find Arduino device on port: ${
-      err.port.comName
-    }. Available ports: ${R.map(R.prop('comName'), err.ports)}`,
-  [EC.UPLOAD_ERROR]: err => `Error occured during uploading: ${err}`,
+    composeMessage(
+      'Serial port not found',
+      `Tried to use ${err.port.comName}, ` +
+        `but available ports are: ${R.map(R.prop('comName'), err.ports)}`
+    ),
+  [EC.UPLOAD_ERROR]: err => composeMessage('Upload failed', R.toString(err)),
   [EC.INDEX_LIST_ERROR]: err =>
-    `Could not connect to Arduino Packages Index at ${err.request.path}: ${
-      err.error.message
-    }`,
-  [EC.CANT_INSTALL_ARCHITECTURE]: err => `Could not install tools: ${err}`,
+    composeMessage(
+      'Package index not available',
+      `A request to ${err.request.path} failed: ${err.error.message}`
+    ),
+  [EC.CANT_INSTALL_ARCHITECTURE]: err =>
+    composeMessage('Tools failed to install', R.toString(err)),
 
-  // Snackbar errors
   [XFS_EC.INVALID_WORKSPACE_PATH]: err =>
     composeMessage(
       'Invalid workspace path',

--- a/packages/xod-client-electron/src/view/containers/App.jsx
+++ b/packages/xod-client-electron/src/view/containers/App.jsx
@@ -272,13 +272,15 @@ class App extends client.App {
         }
       }
       if (payload.failure) {
-        console.error(payload.error); // eslint-disable-line no-console
-        const failureMessage = R.compose(R.join('\n\n'), R.reject(R.isNil))([
-          payload.message,
+        console.error(payload); // eslint-disable-line no-console
+        const stanza = payload.message; // result of legacy `composeMessage`
+        const joinNonNil = sep => R.compose(R.join(sep), R.reject(R.isNil));
+        const messageForConsole = joinNonNil('\n\n')([
+          joinNonNil('. ')([stanza.title, stanza.note]),
           payload.error.stdout,
           payload.stderr,
         ]);
-        proc.fail(failureMessage, payload.percentage);
+        proc.fail(messageForConsole, payload.percentage);
       }
       // Remove listener if process is finished.
       ipcRenderer.removeAllListeners(UPLOAD_TO_ARDUINO);


### PR DESCRIPTION
Fixes #1080 

The root cause is `ERROR_FORMATTERS` had an impossible type. Some values were strings, other were objects. A non-uniform typing became a source of troubles, again. Please, don’t use such magic in your code: if something can’t have a sane signature it is wrong and should be rewritten.