### PR TITLE
Fix bug in the transpilation: wrong output pin labels

### DIFF
--- a/packages/xod-arduino/src/transpiler.js
+++ b/packages/xod-arduino/src/transpiler.js
@@ -1,7 +1,7 @@
 import * as R from 'ramda';
 import { Either } from 'ramda-fantasy';
 
-import { explodeMaybe, reverseLookup } from 'xod-func-tools';
+import { explodeMaybe, reverseLookup, maybeProp } from 'xod-func-tools';
 // TODO: rename to XP
 import * as Project from 'xod-project';
 import { def } from './types';
@@ -248,11 +248,8 @@ const getOutputPinLabelByLink = def(
       explodeMaybe(
         `Can’t find pin with key ${pinKey} for link ${link} on patch ${patch}`
       ),
-      R.map(
-        R.compose(Project.getPinLabel, R.head, Project.normalizePinLabels, R.of)
-      ),
-      R.chain(Project.getPinByKey(pinKey)),
-      R.chain(Project.getPatchByNode(R.__, project)),
+      R.chain(maybeProp(pinKey)),
+      R.map(getNodePinLabels(R.__, project)),
       Project.getNodeById(R.__, patch),
       Project.getLinkOutputNodeId
     )(link);


### PR DESCRIPTION
There is no issue. But it's a critical bug 😬 

If you make some Node that have few unnamed output ports — it will fail in C++ compilation, cause linked Nodes points to not normalized pin label (`output_OUT` instead of `output_OUT1`, `output_OUT2` and so on).