### PR TITLE
Fix bound value migration for pulses

### DIFF
--- a/packages/xod-project/src/legacy.js
+++ b/packages/xod-project/src/legacy.js
@@ -26,7 +26,7 @@ export const ensureLiteral = def(
       case PIN_TYPE.PULSE:
         return R.compose(
           R.when(
-            R.equals(false),
+            R.either(R.equals(false), R.equals('false')),
             R.always(INPUT_PULSE_PIN_BINDING_OPTIONS.NEVER)
           ),
           R.when(

--- a/packages/xod-project/test/legacy.spec.js
+++ b/packages/xod-project/test/legacy.spec.js
@@ -73,6 +73,12 @@ describe('Legacy', () => {
         ensureLiteral(PIN_TYPE.PULSE, false),
         'Never'
       );
+      // Sometimes Never was a string "false"
+      // when User binds `Never` to terminal in the Inspector
+      assert.strictEqualJustValue(
+        ensureLiteral(PIN_TYPE.PULSE, 'false'),
+        'Never'
+      );
       assert.strictEqualJustValue(
         ensureLiteral(PIN_TYPE.PULSE, 'NEVER'),
         'Never'


### PR DESCRIPTION
There is no issue.
Some old bound values ("false" on pulses) was not converted into new literal "Never". This PR fixes it.
It's a part (1/2) of critical bug [reported on the forum](https://forum.xod.io/t/problem-xod-0-20-2/774).

The second half of the problem is about new bundled `xod/core` and old `xod/core` saved in the `user-workspace/__libs__` folder.