### PR TITLE
Add IDE docker images building on release

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,30 +1,42 @@
 FROM node:9.2
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    wget
+# Let the apt-get know we’re not interactive while building the image
+ARG DEBIAN_FRONTEND=noninteractive
 
-# see https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+# Installations for later installations
+RUN apt-get update \
+    # Required for some later packages to be configured
+    && apt-get install -y --no-install-recommends apt-utils \
+    && apt-get install -y --no-install-recommends \
+        # apt-add-repository
+        software-properties-common \
+        # Required for Docker CE
+        apt-transport-https
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    # See https://crbug.com/795759
-    libgconf-2-4 \
-    # Install latest chrome dev package.
-    # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
-    # installs, work.
-    google-chrome-unstable \
-    # Dependencies for Electron, Spectron, electron-builder
-    libasound2 \
-    libgconf-2-4 \
-    libgtk2.0-0 \
-    libnss3 \
-    libx11-xcb-dev \
-    libxss1 \
-    libxtst6 \
-    rpm \
-    xvfb
+# See https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
+RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && add-apt-repository "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
 
-RUN rm -rf /var/lib/apt/lists/* \
-    && apt-get purge --auto-remove -y curl \
-    && rm -rf /src/*.deb
+# Add Docker CE repository. We use docker to build and push the browser IDE image
+RUN curl https://download.docker.com/linux/debian/gpg | apt-key add - \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        docker-ce \
+        # See https://crbug.com/795759
+        libgconf-2-4 \
+        # Install latest chrome dev package.
+        # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
+        # installs, work.
+        google-chrome-unstable \
+        # Dependencies for Electron, Spectron, electron-builder
+        libasound2 \
+        libgconf-2-4 \
+        libgtk2.0-0 \
+        libnss3 \
+        libx11-xcb-dev \
+        libxss1 \
+        libxtst6 \
+        rpm \
+        xvfb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defs:
   release-filters: &release-filters
     branches:
       only:
-        - /^prerelease-.*/
+        - /^prerelease-(patch|minor)-.*/
     tags:
       only:
         - /^v\d+\.\d+\.\d+/
@@ -33,8 +33,8 @@ defs:
     step-bump-version: &step-bump-version
       name: Bump version
       command: |
-        if [[ $CIRCLE_BRANCH == prerelease-* ]]; then
-          yarn lerna publish --skip-git --skip-npm --canary --yes
+        if [[ $CIRCLE_BRANCH =~ ^prerelease-(patch|minor)- ]]; then
+          yarn lerna publish --skip-git --skip-npm --canary --cd-version ${BASH_REMATCH[1]} --yes
         fi
 
     step-build: &step-build
@@ -76,7 +76,7 @@ jobs:
   #--------------------------------------------------------------------
   verify-linux:
     docker:
-      - image: xodio/cci-node:9.2-v2
+      - image: xodio/cci-node:9.2-v3
     environment:
       DISPLAY: ":99.0"
     steps:
@@ -119,7 +119,7 @@ jobs:
   #--------------------------------------------------------------------
   dist-linux:
     docker:
-      - image: xodio/cci-node:9.2-v2
+      - image: xodio/cci-node:9.2-v3
     environment:
       NODE_ENV: production
     steps:
@@ -164,9 +164,9 @@ jobs:
             - "*.zip"
 
   #--------------------------------------------------------------------
-  # Publish job
+  # Upload distros job
   #--------------------------------------------------------------------
-  publish:
+  upload-distros:
     docker:
       - image: google/cloud-sdk:alpine
     steps:
@@ -189,6 +189,68 @@ jobs:
             ls dist -1 | xargs -n 1 -I {} \
               gsutil setmeta -h 'Content-Disposition: attachment; filename="{}"' $GS_PATH/{}
 
+  #--------------------------------------------------------------------
+  # Docker image building jobs
+  #--------------------------------------------------------------------
+  dockerize-ide:
+    docker:
+      - image: xodio/cci-node:9.2-v3
+    environment:
+      NODE_ENV: production
+      IMAGE_NAME: "xodio/site-ide"
+      PKG: "./packages/xod-client-browser"
+    steps:
+      - checkout
+      - restore_cache: *restore-node_modules
+      - run: *step-install
+      - run: *step-bump-version
+      - run:
+          name: Querying version tag
+          command: |
+            mkdir $PKG/image
+            QUERY="console.log('v' + require('$PKG/package.json').version)"
+            TAG=$(node -e "$QUERY")
+            IMAGE_TAG="$IMAGE_NAME:$TAG"
+            echo "Tag set to: $TAG"
+            echo $IMAGE_TAG > $PKG/image/IMAGE_TAG
+      - run:
+          name: Build browser IDE app
+          command: yarn build:browser
+      - setup_remote_docker
+      - run:
+          name: Build docker image
+          command: yarn dockerize:browser --tag $(cat $PKG/image/IMAGE_TAG)
+      - run:
+          name: Tar docker image
+          command: |
+            docker image save \
+              --output $PKG/image/site-ide.tar \
+              $(cat $PKG/image/IMAGE_TAG)
+      - persist_to_workspace:
+          root: packages/xod-client-browser/image
+          paths:
+            - "IMAGE_TAG"
+            - "*.tar"
+
+  #--------------------------------------------------------------------
+  # Docker push
+  #--------------------------------------------------------------------
+  push-docker-images:
+    docker:
+      - image: docker
+    steps:
+      - attach_workspace:
+          at: image
+      - setup_remote_docker
+      - run:
+          name: Untar docker image
+          command: docker image load --input image/site-ide.tar
+      - run:
+          name: Push docker image
+          command: |
+            docker login -u xodbot -p $DOCKER_PASS
+            docker push $(cat image/IMAGE_TAG)
+
 #==============================================================================
 #
 # Workflows
@@ -200,11 +262,16 @@ workflows:
     jobs:
       - verify-linux
       - verify-macos
+      - dockerize-ide:
+          filters: *release-filters
+      - push-docker-images:
+          filters: *release-filters
+          requires: [ dockerize-ide, verify-linux ]
       - dist-linux:
           filters: *release-filters
       - dist-macos:
           filters: *release-filters
-      - publish:
+      - upload-distros:
           filters: *release-filters
           requires:
             - verify-linux

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dist:electron": "electron-builder --publish always --projectDir ./packages/xod-client-electron",
     "doc": "lerna run doc",
     "doc:fz": "cd docs && make",
+    "dockerize:browser": "docker build packages/xod-client-browser",
     "flow": "flow check",
     "lerna": "lerna",
     "lint": "eslint packages/*/src packages/*/test packages/*/test-func tools packages/*/tools packages/*/benchmark --ext js,jsx --max-warnings 0",

--- a/packages/xod-client-browser/Dockerfile
+++ b/packages/xod-client-browser/Dockerfile
@@ -1,2 +1,10 @@
-FROM nginx
-COPY dist/ /usr/share/nginx/html/
+FROM alpine:3.6
+MAINTAINER XOD Developers <dev@xod.io>
+
+WORKDIR /opt/
+ADD dist/ ide/
+
+# /opt/shared is a volume directory that should be mounted
+# by an orchestrator
+ENTRYPOINT ["sh", "-exc",  \
+  "rm -rf /opt/shared/ide && cp -a ide/ /opt/shared && sleep 365d"]

--- a/packages/xod-project/Dockerfile
+++ b/packages/xod-project/Dockerfile
@@ -1,2 +1,0 @@
-FROM nginx
-COPY doc/ /usr/share/nginx/html/


### PR DESCRIPTION
The PR adds docker image build & push for the browser IDE along with distros building. After merging it we will be able to release from any branch, specifically we are going to create a Git-flow stable branch to release from regardless of the state of `master`.

Also, this PR places a restriction on prerelease naming. Now the valid prefixes are:
- `prerelease-patch-` — creates canary release bumping the patch number
- `prerelease-minor-` — creates canary release bumping the minor number as it was before

The `prerelease-` prefix alone is no longer enough to schedule a prerelease.