### PR TITLE
Tweak performance of type deduction

### DIFF
--- a/packages/xod-client/src/project/selectors.js
+++ b/packages/xod-client/src/project/selectors.js
@@ -70,8 +70,9 @@ export const getCurrentPatch = createSelector(
   (patchPath, project) => R.chain(XP.getPatchByPath(R.__, project), patchPath)
 );
 
-export const getDeducedPinTypes = createSelector(
+export const getDeducedPinTypes = createMemoizedSelector(
   [getProject, getCurrentPatch],
+  [R.equals, R.equals],
   (project, maybeCurrentPatch) =>
     foldMaybe({}, patch => XP.deducePinTypes(patch, project), maybeCurrentPatch)
 );

--- a/packages/xod-func-tools/src/index.js
+++ b/packages/xod-func-tools/src/index.js
@@ -8,3 +8,4 @@ export * from './types';
 export * from './typeUtils';
 export * from './utils';
 export * from './strings';
+export * from './sets';

--- a/packages/xod-func-tools/src/sets.js
+++ b/packages/xod-func-tools/src/sets.js
@@ -1,0 +1,6 @@
+import * as R from 'ramda';
+
+// :: [a] -> Set a
+export const toSet = a => new Set(a);
+// :: a -> Set [a] -> Boolean
+export const inSet = R.curry((v, s) => (s.has && s.has(v)) || false);

--- a/packages/xod-project/src/patch.js
+++ b/packages/xod-project/src/patch.js
@@ -805,7 +805,7 @@ const toposortGraph = def(
  * This will not affect correctness of the resulting program,
  * and gives some optimisation possibilities.
  */
-const sendDeferNodesToBottom = def(
+export const sendDeferNodesToBottom = def(
   'sendDeferNodesToBottom :: Patch -> [NodeId] -> [NodeId]',
   (patch, toposortedNodeIds) =>
     R.compose(


### PR DESCRIPTION
It tweaks IDE performance, that was reduced in the v0.20.0 by adding generic types and type deduction.

The same as https://github.com/xodio/xod/pull/1211
But based on another branch (0.20.x)