### PR TITLE
Optimize memoized selector comparators

### DIFF
--- a/packages/xod-client/src/projectBrowser/selectors.js
+++ b/packages/xod-client/src/projectBrowser/selectors.js
@@ -52,9 +52,26 @@ const getLocalPatchesList = createSelector(
   XP.listLocalPatches
 );
 
+const patchListChangesKeepBrowserLook = XP.patchListEqualsBy(
+  R.both(XP.sameCategoryMarkers, XP.samePatchValidity)
+);
+
+const libChangesKeepBrowserLook = R.either(
+  (prev, next) => prev === next,
+  (prev, next) => {
+    const prevLibPatches = XP.listLibraryPatches(prev);
+    const nextLibPatches = XP.listLibraryPatches(next);
+    return XP.patchListEqualsBy(
+      XP.samePatchValidity,
+      prevLibPatches,
+      nextLibPatches
+    );
+  }
+);
+
 export const getLocalPatches = createMemoizedSelector(
   [getLocalPatchesList, ProjectSelectors.getProject],
-  [R.equals],
+  [patchListChangesKeepBrowserLook, libChangesKeepBrowserLook],
   (patches, project) =>
     R.compose(
       R.sortBy(XP.getPatchPath),

--- a/packages/xod-func-tools/src/objects.js
+++ b/packages/xod-func-tools/src/objects.js
@@ -1,5 +1,6 @@
 import * as R from 'ramda';
 import { def } from './types';
+import { setOfKeys, diffSet } from './sets';
 
 /**
  * Returns an object provided with all `null` and `undefined` values omitted
@@ -116,4 +117,29 @@ export const reverseLookup = def(
 export const invertMap = def(
   'invertMap :: Map a b -> Map b a',
   R.compose(R.fromPairs, R.map(R.reverse), R.toPairs)
+);
+
+/**
+ * Function compares two arguments by keys, produced by
+ * calling transformation function on each of arguments.
+ *
+ * E.G.
+ * Compare array of some objects:
+ * sameKeysetBy(R.indexBy(R.prop('id')), [{ id: 'a' }], [{ id: 'b' }]) -> false
+ */
+export const sameKeysetBy = def(
+  'sameKeysetBy :: (b -> StrMap a) -> b -> b -> Boolean',
+  (mapGetter, prev, next) => {
+    if (prev === next) return true;
+
+    const prevMap = mapGetter(prev);
+    const nextMap = mapGetter(next);
+    const prevMapKeys = setOfKeys(prevMap);
+    const nextMapKeys = setOfKeys(nextMap);
+    const diffMapKeys = diffSet(prevMapKeys, nextMapKeys);
+    // If there is some keys added/deleted — something changed
+    if (diffMapKeys.size > 0) return false;
+
+    return true;
+  }
 );

--- a/packages/xod-func-tools/src/sets.js
+++ b/packages/xod-func-tools/src/sets.js
@@ -1,6 +1,14 @@
 import * as R from 'ramda';
 
 // :: [a] -> Set a
-export const toSet = a => new Set(a);
+export const setOf = a => new Set(a);
 // :: a -> Set [a] -> Boolean
 export const inSet = R.curry((v, s) => (s.has && s.has(v)) || false);
+// :: StrMap a -> Set a
+export const setOfKeys = R.pipe(R.keys, x => new Set(x));
+// :: Set a -> Set a -> Set a
+export const diffSet = R.curry((aSet, bSet) => {
+  const a = Array.from(aSet).filter(x => !inSet(x, bSet));
+  const b = Array.from(bSet).filter(x => !inSet(x, aSet));
+  return new Set(a.concat(b));
+});

--- a/packages/xod-project/src/index.js
+++ b/packages/xod-project/src/index.js
@@ -62,6 +62,11 @@ export {
   isDeprecatedPatch,
   getDeprecationReason,
   isUtilityPatch,
+  haveAddedNodesOrChangedTypesOrBoundValues,
+  patchListEqualsBy,
+  sameCategoryMarkers,
+  sameDeducedTypes,
+  samePatchValidity,
 } from './patch';
 export {
   getFilename as getAttachmentFilename,

--- a/packages/xod-project/src/typeDeduction.js
+++ b/packages/xod-project/src/typeDeduction.js
@@ -10,7 +10,7 @@ import {
   fail,
   failOnNothing,
   prependTraceToError,
-  toSet,
+  setOf,
   inSet,
 } from 'xod-func-tools';
 
@@ -226,11 +226,11 @@ export const deducePinTypes = def(
       R.map(Link.getLinkNodeIds),
       R.filter(
         R.both(
-          // We use `toSet` and `inSet` cause it is faster than `isAmong` function.
-          R.pipe(Link.getLinkInputNodeId, inSet(R.__, toSet(abstractNodeIds))),
+          // We use `setOf` and `inSet` cause it is faster than `isAmong` function.
+          R.pipe(Link.getLinkInputNodeId, inSet(R.__, setOf(abstractNodeIds))),
           R.pipe(
             Link.getLinkOutputNodeId,
-            inSet(R.__, toSet(withoutDeferNodeIds))
+            inSet(R.__, setOf(withoutDeferNodeIds))
           )
         )
       ),


### PR DESCRIPTION
Still tweaks IDE performance, that was reduced in the v0.20.0 by adding generic types and type deduction.