### PR TITLE
Allow unbinding generic values in inspector

### DIFF
--- a/packages/xod-client/src/utils/normalizeGenericValue.js
+++ b/packages/xod-client/src/utils/normalizeGenericValue.js
@@ -40,4 +40,5 @@ export default R.cond([
   [R.test(almostByte), normalizeByte],
   [R.test(almostBool), capitalize],
   [R.test(almostPulse), normalizePulse],
+  [R.T, R.identity],
 ]);


### PR DESCRIPTION
Fixes #1221

Problem was introduced in #1192 and does not affect `0.20.x`.
