### PR TITLE
Run tabular tests when doing CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,32 @@ jobs:
       - run: *step-test-func
       - run: *step-verify-git-clean
 
+  test-cpp:
+    docker:
+      - image: xodio/cci-node:9.2-v3
+    environment:
+      TAB_SUITE_DIR: /tmp/xod-tabtest
+    steps:
+      - checkout
+      - restore_cache: *restore-node_modules
+      - run: *step-install
+      - run:
+          name: Build CLI
+          command: yarn build:cli
+      - run:
+          name: Generate tabtests
+          command: |
+            ls -d workspace/__lib__/xod/* | xargs -n 1 \
+              yarn xodc tabtest \
+                --no-build \
+                --output-dir=$TAB_SUITE_DIR
+      - run:
+          name: Build tabtests
+          command: make -C $TAB_SUITE_DIR
+      - run:
+          name: Run tabtests
+          command: make -C $TAB_SUITE_DIR test
+
   #--------------------------------------------------------------------
   # Distro jobs
   #--------------------------------------------------------------------
@@ -262,11 +288,12 @@ workflows:
     jobs:
       - verify-linux
       - verify-macos
+      - test-cpp
       - dockerize-ide:
           filters: *release-filters
       - push-docker-images:
           filters: *release-filters
-          requires: [ dockerize-ide, verify-linux ]
+          requires: [ dockerize-ide, verify-linux, test-cpp ]
       - dist-linux:
           filters: *release-filters
       - dist-macos:
@@ -276,5 +303,6 @@ workflows:
           requires:
             - verify-linux
             - verify-macos
+            - test-cpp
             - dist-linux
             - dist-macos

--- a/packages/xod-cli/src/xodc-tabtest.js
+++ b/packages/xod-cli/src/xodc-tabtest.js
@@ -77,6 +77,15 @@ export default (projectPath, patchPath, opts) => {
       ? Tabtest.generatePatchSuite(project, patchPath)
       : Tabtest.generateProjectSuite(project);
 
+  const build = () =>
+    opts.noBuild
+      ? Promise.resolve()
+      : Promise.resolve()
+          .then(tapProgress('Compiling...'))
+          .then(() => spawn('make', [], childProcessOpts))
+          .then(tapProgress('Testing...'))
+          .then(() => spawn('make', ['test'], childProcessOpts));
+
   msg.notice(`Preparing test directory: ${outDir} ...`);
 
   fs
@@ -92,9 +101,6 @@ export default (projectPath, patchPath, opts) => {
     .then(R.append(fs.copy(tabtestSources, outDir)))
     .then(R.append(fs.copy(catch2Sources, outDir)))
     .then(allPromises)
-    .then(tapProgress('Compiling...'))
-    .then(() => spawn('make', [], childProcessOpts))
-    .then(tapProgress('Testing...'))
-    .then(() => spawn('make', ['test'], childProcessOpts))
+    .then(build)
     .catch(showErrorAndExit);
 };

--- a/packages/xod-cli/src/xodc.js
+++ b/packages/xod-cli/src/xodc.js
@@ -31,7 +31,7 @@ Usage:
   xodc transpile [--output=<filename>] [--workspace=<dir>] <input> <patchPath>
   xodc publish [--swagger=<swagger>] [--orgname=<orgname>] [<projectDir>]
   xodc install [--swagger=<swagger>] [--workspace=<dir>] <libUri>
-  xodc tabtest [--workspace=<dir>] [--output-dir=<dir>] <projectPath> [<patchPath>]
+  xodc tabtest [--workspace=<dir>] [--output-dir=<dir>] [--no-build] <projectPath> [<patchPath>]
   xodc resave [--workspace=<workspace>] <input> <output>
 
 Commands:
@@ -71,6 +71,7 @@ const programs = {
     tabtest(o['<projectPath>'], o['<patchPath>'], {
       outputDir: o['--output-dir'],
       workspace: o['--workspace'],
+      noBuild: o['--no-build'],
     }),
   resave: o => resave(o['<input>'], o['<output>'], o['--workspace']),
 };

--- a/packages/xod-cli/src/xodc.js
+++ b/packages/xod-cli/src/xodc.js
@@ -31,7 +31,7 @@ Usage:
   xodc transpile [--output=<filename>] [--workspace=<dir>] <input> <patchPath>
   xodc publish [--swagger=<swagger>] [--orgname=<orgname>] [<projectDir>]
   xodc install [--swagger=<swagger>] [--workspace=<dir>] <libUri>
-  xodc tabtest [--workspace=<dir>] <input> <patchPath>
+  xodc tabtest [--workspace=<dir>] [--output-dir=<dir>] <projectPath> [<patchPath>]
   xodc resave [--workspace=<workspace>] <input> <output>
 
 Commands:
@@ -68,7 +68,8 @@ const programs = {
   install: o =>
     install(o['--swagger'] || PM_SWAGGER_URL, o['<libUri>'], o['--workspace']),
   tabtest: o =>
-    tabtest(o['<input>'], o['<patchPath>'], {
+    tabtest(o['<projectPath>'], o['<patchPath>'], {
+      outputDir: o['--output-dir'],
       workspace: o['--workspace'],
     }),
   resave: o => resave(o['<input>'], o['<output>'], o['--workspace']),

--- a/packages/xod-tabtest/cpp/Makefile
+++ b/packages/xod-tabtest/cpp/Makefile
@@ -1,6 +1,9 @@
 
-SRC:=$(wildcard *.cpp)
-OBJ:=$(SRC:.cpp=.o) $(FRAMEWORK_SRC:.cpp=.o)
+SOURCES := $(wildcard *.cpp)
+SKETCHES := $(wildcard *.sketch.cpp)
+OBJECTS := $(SOURCES:.cpp=.o)
+RUNNERS := $(SKETCHES:.sketch.cpp=.run)
+FRAMEWORK_OBJECTS := main.o Arduino.o
 
 CXX:=g++
 CXX_FLAGS:=-std=c++11 -I.
@@ -8,12 +11,15 @@ CXX_FLAGS:=-std=c++11 -I.
 %.o: %.cpp
 	$(CXX) $(CXX_FLAGS) -o $@ -c $<
 
-runTest: $(OBJ)
+%.run: %.sketch.o $(FRAMEWORK_OBJECTS)
 	$(CXX) -o $@ $^
 
 .PHONY: all
-all: runTest
+all: $(RUNNERS)
 
 .PHONY: test
-test: runTest
-	./runTest
+test: $(RUNNERS)
+	@for x in $(RUNNERS); do \
+	  echo ./$$x; \
+	  ./$$x; \
+	done

--- a/packages/xod-tabtest/src/Holes/Holes_Map_String.re
+++ b/packages/xod-tabtest/src/Holes/Holes_Map_String.re
@@ -18,3 +18,11 @@ let keepMap = (xs: t('v), fn: 'v => option('v2)) : t('v2) =>
   keepMapWithKey(xs, (_, v) => fn(v));
 
 let innerJoin = (xs, ys) => keepMap(xs, v => ys |. Map.String.get(v));
+
+let mergeOverride = (xs, ys) =>
+  Map.String.merge(xs, ys, (_key, ox, oy) =>
+    switch (oy) {
+    | Some(y) => Some(y)
+    | None => ox
+    }
+  );

--- a/packages/xod-tabtest/src/Holes/Holes_Map_String.rei
+++ b/packages/xod-tabtest/src/Holes/Holes_Map_String.rei
@@ -23,3 +23,7 @@ let mapKeys: (t('a), k => k) => t('a);
     mapped to a value defined by the second map lookup. If a key/value is missing from
     either side, the pair will not appear in the result */
 let innerJoin: (t(k), t('v)) => t('v);
+
+/** Merges two maps extending the first map with contents of the second. If a key
+    presents in both maps, the value of the second map wins. */
+let mergeOverride: (t('v), t('v)) => t('v);

--- a/packages/xod-tabtest/src/Tabtest.rei
+++ b/packages/xod-tabtest/src/Tabtest.rei
@@ -7,4 +7,7 @@ open Belt;
 type t = Map.String.t(string);
 
 /** Returns a test suite for the given patch of a project */
-let generateSuite: (Project.t, Patch.path) => XResult.t(t);
+let generatePatchSuite: (Project.t, Patch.path) => XResult.t(t);
+
+/** Returns a test suite for all patches with tabtests in the given project */
+let generateProjectSuite: Project.t => XResult.t(t);

--- a/packages/xod-tabtest/src/Tabtest_Js.re
+++ b/packages/xod-tabtest/src/Tabtest_Js.re
@@ -1,6 +1,11 @@
 open Belt;
 
-let generateSuite = (project, patchPath) =>
-  Tabtest.generateSuite(project, patchPath)
+let generatePatchSuite = (project, patchPath) =>
+  Tabtest.generatePatchSuite(project, patchPath)
+  |. Holes.Result.map(files => files |. Map.String.toList |. Js.Dict.fromList)
+  |. Either.fromResult;
+
+let generateProjectSuite = project =>
+  Tabtest.generateProjectSuite(project)
   |. Holes.Result.map(files => files |. Map.String.toList |. Js.Dict.fromList)
   |. Either.fromResult;

--- a/packages/xod-tabtest/src/XodProject/Attachment.re
+++ b/packages/xod-tabtest/src/XodProject/Attachment.re
@@ -8,3 +8,5 @@ external getContent : t => string = "getAttachmentContent";
 
 [@bs.module "xod-project"]
 external getEncoding : t => string = "getAttachmentEncoding";
+
+let isTabtest = att => getFilename(att) == "patch.test.tsv";

--- a/packages/xod-tabtest/src/XodProject/Attachment.rei
+++ b/packages/xod-tabtest/src/XodProject/Attachment.rei
@@ -5,3 +5,5 @@ let getFilename: t => string;
 let getContent: t => string;
 
 let getEncoding: t => string;
+
+let isTabtest: t => bool;

--- a/packages/xod-tabtest/src/XodProject/Patch.re
+++ b/packages/xod-tabtest/src/XodProject/Patch.re
@@ -66,6 +66,8 @@ let getAttachments = t => _getAttachments(t) |. List.fromArray;
 
 let getTabtestContent = t =>
   getAttachments(t)
-  |. List.keep(att => Attachment.getFilename(att) == "patch.test.tsv")
+  |. List.keep(Attachment.isTabtest)
   |. List.head
   |. Option.map(Attachment.getContent);
+
+let hasTabtest = t => getAttachments(t) |. List.some(Attachment.isTabtest);

--- a/packages/xod-tabtest/src/XodProject/Patch.rei
+++ b/packages/xod-tabtest/src/XodProject/Patch.rei
@@ -25,3 +25,5 @@ let findPinByLabel:
 let getAttachments: t => list(Attachment.t);
 
 let getTabtestContent: t => option(string);
+
+let hasTabtest: t => bool;

--- a/packages/xod-tabtest/src/XodProject/PatchPath.re
+++ b/packages/xod-tabtest/src/XodProject/PatchPath.re
@@ -1,0 +1,3 @@
+type t = string;
+
+[@bs.module "xod-project"] external getBaseName : t => string = "";

--- a/packages/xod-tabtest/src/XodProject/PatchPath.rei
+++ b/packages/xod-tabtest/src/XodProject/PatchPath.rei
@@ -1,1 +1,3 @@
 type t = string;
+
+let getBaseName: t => string;

--- a/packages/xod-tabtest/src/XodProject/Project.re
+++ b/packages/xod-tabtest/src/XodProject/Project.re
@@ -1,4 +1,16 @@
+open Belt;
+
 type t = Js.Types.obj_val;
+
+[@bs.module "xod-project"]
+external _listPatches : t => array(Patch.t) = "listPatches";
+
+let listPatches = project => _listPatches(project) |. List.fromArray;
+
+[@bs.module "xod-project"]
+external _listLocalPatches : t => array(Patch.t) = "listLocalPatches";
+
+let listLocalPatches = project => _listLocalPatches(project) |. List.fromArray;
 
 [@bs.module "xod-project"]
 external _assocPatch : (PatchPath.t, Patch.t, t) => Either.t(Js.Exn.t, t) =

--- a/packages/xod-tabtest/src/XodProject/Project.rei
+++ b/packages/xod-tabtest/src/XodProject/Project.rei
@@ -1,5 +1,9 @@
 type t;
 
+let listPatches: t => list(Patch.t);
+
+let listLocalPatches: t => list(Patch.t);
+
 let assocPatch: (t, PatchPath.t, Patch.t) => XResult.t(t);
 
 let getPatchByPath: (t, PatchPath.t) => option(Patch.t);

--- a/packages/xod-tabtest/test/Holes_Map_String_jest.re
+++ b/packages/xod-tabtest/test/Holes_Map_String_jest.re
@@ -76,3 +76,23 @@ describe("Inner join", () =>
     expect(outMap) |> toEqualMap(expectedMap);
   })
 );
+
+describe("mergeOverride", () =>
+  test("merges preferring keys from second arg", () => {
+    let left =
+      Map.String.empty
+      |. Map.String.set("quad", "four")
+      |. Map.String.set("hexa", "six");
+    let right =
+      Map.String.empty
+      |. Map.String.set("quad", "4")
+      |. Map.String.set("octo", "8");
+    let outMap = Holes.Map.String.mergeOverride(left, right);
+    let expectedMap =
+      Map.String.empty
+      |. Map.String.set("quad", "4")
+      |. Map.String.set("hexa", "six")
+      |. Map.String.set("octo", "8");
+    expect(outMap) |> toEqualMap(expectedMap);
+  })
+);


### PR DESCRIPTION
- Closes #1227 
- Adds support to test a whole XOD project, not a particular patch
- Adds `xodc tabtest --output-dir=/path/to/dir` switch
- Adds `xodc tabtest --no-build` switch