### PR TITLE
Fix IDE crash when opening missing patch

### DIFF
--- a/packages/xod-client/src/editor/actions.js
+++ b/packages/xod-client/src/editor/actions.js
@@ -287,6 +287,14 @@ export const switchPatchUnsafe = patchPath => ({
 export const switchPatch = patchPath => (dispatch, getState) => {
   const state = getState();
 
+  const patchDoesNotExist = R.compose(
+    Maybe.isNothing,
+    XP.getPatchByPath(patchPath),
+    ProjectSelectors.getProject
+  )(state);
+
+  if (patchDoesNotExist) return;
+
   const isSamePatchPath = foldMaybe(
     false,
     R.equals(patchPath),

--- a/packages/xod-client/src/project/selectors.js
+++ b/packages/xod-client/src/project/selectors.js
@@ -35,15 +35,10 @@ const listPatches = R.compose(XP.listPatches, getProject);
 
 // :: (Patch -> a) -> Project -> Maybe PatchPath -> a
 const getIndexedPatchEntitiesBy = R.curry((getter, project, maybePatchPath) =>
-  foldMaybe(
-    {},
-    R.compose(
-      R.indexBy(R.prop('id')),
-      getter,
-      XP.getPatchByPathUnsafe(R.__, project)
-    ),
-    maybePatchPath
-  )
+  R.compose(
+    foldMaybe({}, R.compose(R.indexBy(R.prop('id')), getter)),
+    R.chain(XP.getPatchByPath(R.__, project))
+  )(maybePatchPath)
 );
 
 // :: State -> StrMap Comment
@@ -179,6 +174,7 @@ const addDeadRefErrors = R.curry((project, renderableNode) =>
           R.always(renderableNode)
         ),
         XP.validatePatchContents(R.__, project),
+        // we just checked that patch exists
         XP.getPatchByPathUnsafe(R.__, project)
       )
     ),

--- a/packages/xod-client/src/project/utils.js
+++ b/packages/xod-client/src/project/utils.js
@@ -74,12 +74,17 @@ export const isPatchPathTaken = (state, newPatchPath) => {
 
 // :: PatchPath -> Project -> Position
 export const getInitialPatchOffset = R.compose(
-  getOptimalPanningOffset,
-  R.converge(R.concat, [
-    R.compose(R.map(XP.getNodePosition), XP.listNodes),
-    R.compose(R.map(XP.getCommentPosition), XP.listComments),
-  ]),
-  XP.getPatchByPathUnsafe
+  foldMaybe(
+    { x: 0, y: 0 },
+    R.compose(
+      getOptimalPanningOffset,
+      R.converge(R.concat, [
+        R.compose(R.map(XP.getNodePosition), XP.listNodes),
+        R.compose(R.map(XP.getCommentPosition), XP.listComments),
+      ])
+    )
+  ),
+  XP.getPatchByPath
 );
 
 // extract information from Patch that is required to render it with Node component

--- a/packages/xod-project/src/project.js
+++ b/packages/xod-project/src/project.js
@@ -315,7 +315,7 @@ export const getPatchByPath = def(
  * @throws Error if patch was not found
  */
 export const getPatchByPathUnsafe = def(
-  'getPatchByPath :: PatchPath -> Project -> Patch',
+  'getPatchByPathUnsafe :: PatchPath -> Project -> Patch',
   (path, project) =>
     explodeMaybe(
       `Can't find the patch in the project with specified path: "${path}"`,


### PR DESCRIPTION
When double-clicking on missing patch current version of IDE crashes.
Here is a xodball to reproduce the issue: [missing-patch.xodball.zip](https://github.com/xodio/xod/files/2030601/missing-patch.xodball.zip)

