### PR TITLE
Reset metadata when creating new project

### DIFF
--- a/packages/xod-client/src/project/reducer.js
+++ b/packages/xod-client/src/project/reducer.js
@@ -94,19 +94,16 @@ export default (state = {}, action) => {
     // Project
     //
     case AT.PROJECT_CREATE: {
-      const oldLocalPatchesPaths = R.compose(
-        R.map(XP.getPatchPath),
-        XP.listLocalPatches
+      const libraryPatches = R.compose(
+        R.filter(XP.isGenuinePatch),
+        XP.listLibraryPatches
       )(state);
 
-      const mainPatch = XP.createPatch();
+      const mainPatch = XP.setPatchPath(MAIN_PATCH_PATH, XP.createPatch());
 
-      return R.compose(
-        explodeEither,
-        XP.assocPatch(MAIN_PATCH_PATH, mainPatch),
-        XP.setProjectName(''),
-        XP.omitPatches(oldLocalPatchesPaths)
-      )(state);
+      const newProject = XP.createProject();
+
+      return XP.mergePatchesList([mainPatch, ...libraryPatches], newProject);
     }
 
     case AT.PROJECT_IMPORT: {

--- a/packages/xod-project/src/index.js
+++ b/packages/xod-project/src/index.js
@@ -58,6 +58,7 @@ export {
   getArityStepFromPatch,
   isVariadicPatch,
   isAbstractPatch,
+  isGenuinePatch,
   isPatchNotImplementedInXod,
   doesPatchHaveGenericPins,
   validateAbstractPatch,


### PR DESCRIPTION
Previously project description, version, license etc persisted when user created new project via `File -> New Project...`