### PR TITLE
Fix transpiling analog ports into another C++ literals

### DIFF
--- a/packages/xod-arduino/src/templates.js
+++ b/packages/xod-arduino/src/templates.js
@@ -131,14 +131,10 @@ const cppByteLiteral = def(
 // E.G.
 // 3 -> 3
 // D13 -> 13
-// A3 -> PIN_A3
+// A3 -> A3
 const cppPortLiteral = def(
   'cppPortLiteral :: String -> String',
-  R.cond([
-    [R.test(/^D\d+$/i), R.tail],
-    [R.test(/^A\d+$/i), R.pipe(R.tail, R.concat('PIN_A'))],
-    [R.T, R.identity],
-  ])
+  R.when(R.test(/^D\d+$/i), R.tail)
 );
 
 // =============================================================================


### PR DESCRIPTION
There is no issue, but it could be a problem for some boards...

Transpile analog ports into `A#` instead of `PIN_A#`, cause some boards do not have defined `PIN_A#`. Need a proof? See `pins_arduino.h` for Arduino Due.