### PR TITLE
Make port type color green

### DIFF
--- a/packages/xod-client/src/core/styles/abstracts/variables.scss
+++ b/packages/xod-client/src/core/styles/abstracts/variables.scss
@@ -23,7 +23,7 @@ $color-datatype-number: $emerald;
 $color-datatype-boolean: $magenta;
 $color-datatype-pulse: $violet;
 $color-datatype-byte: $olive;
-$color-datatype-port: $blue;
+$color-datatype-port: $green;
 $color-datatype-generic: $chalk;
 $color-datatype-custom: $terracotta;
 $color-datatype-dead: $error;


### PR DESCRIPTION
Playing with new `gpio` made it obvious that the current blue color for type Port is easily confused with Pulse. Our UX designer suggested green for ports in the old mockups. We even have it’s definition (`$green`), but don’t use anyhow.

Well, it can be confused with a number. But it’s much better than pulse confusion as it is semantically close to a number. We use the number to emulate the port type after all. Also, we have a few statements about the greenness of PORT pins in the tutorial. So, I suggest making ports $green:

### Before

![before](https://user-images.githubusercontent.com/146383/40976095-b4a2277c-68d5-11e8-8b05-71bd743e91ad.png)

### After

![after](https://user-images.githubusercontent.com/146383/40976099-b851e1f0-68d5-11e8-9b00-79da6a47e6ff.png)
