### PR TITLE
Extract I2C-related nodes of standard library to `xod/i2c`

### DIFF
--- a/workspace/__lib__/xod/core/i2c-begin-transmission/patch.xodp
+++ b/workspace/__lib__/xod/core/i2c-begin-transmission/patch.xodp
@@ -34,6 +34,15 @@
         "y": 16
       },
       "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "description": "Use `xod/i2c/begin-transmission` instead.",
+      "id": "r1dfDm4gX",
+      "position": {
+        "x": 102,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/deprecated"
     }
   ]
 }

--- a/workspace/__lib__/xod/core/i2c-end-transmission/patch.xodp
+++ b/workspace/__lib__/xod/core/i2c-end-transmission/patch.xodp
@@ -18,6 +18,15 @@
       "type": "xod/patch-nodes/input-pulse"
     },
     {
+      "description": "Use `xod/i2c/end-transmission` instead.",
+      "id": "rJvVP7NlQ",
+      "position": {
+        "x": 102,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/deprecated"
+    },
+    {
       "id": "ryviw_EOb",
       "label": "DONE",
       "position": {

--- a/workspace/__lib__/xod/core/i2c-read/patch.xodp
+++ b/workspace/__lib__/xod/core/i2c-read/patch.xodp
@@ -1,6 +1,15 @@
 {
   "nodes": [
     {
+      "description": "Use `xod/i2c/read` instead.",
+      "id": "H1frwmNlm",
+      "position": {
+        "x": 136,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/deprecated"
+    },
+    {
       "description": "Timeout value. Exit after this delay if no data is available.",
       "id": "HyEhduNuZ",
       "label": "TOUT",

--- a/workspace/__lib__/xod/core/i2c-request-bytes-6/patch.xodp
+++ b/workspace/__lib__/xod/core/i2c-request-bytes-6/patch.xodp
@@ -243,6 +243,15 @@
       "type": "xod/patch-nodes/input-number"
     },
     {
+      "description": "Use `xod/i2c/request` along with a chain of `xod/i2c/read` instead.",
+      "id": "H1qLPQEgX",
+      "position": {
+        "x": 374,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/deprecated"
+    },
+    {
       "id": "HJM8TViP-",
       "label": "B5",
       "position": {

--- a/workspace/__lib__/xod/core/i2c-request/patch.xodp
+++ b/workspace/__lib__/xod/core/i2c-request/patch.xodp
@@ -11,6 +11,15 @@
       "type": "xod/patch-nodes/input-number"
     },
     {
+      "description": "Use `xod/i2c/request` instead.",
+      "id": "BkRBwmNxm",
+      "position": {
+        "x": 136,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/deprecated"
+    },
+    {
       "description": "Number of bytes to request",
       "id": "Hk3Wdu4dZ",
       "label": "N",

--- a/workspace/__lib__/xod/core/i2c-send-byte/patch.xodp
+++ b/workspace/__lib__/xod/core/i2c-send-byte/patch.xodp
@@ -87,6 +87,15 @@
       "type": "xod/patch-nodes/input-number"
     },
     {
+      "description": "Use a chain of `xod/i2c/begin-transmission` + `xod/i2c/write` + `xod/i2c/end-transmission` instead.",
+      "id": "SJMtwXVg7",
+      "position": {
+        "x": 408,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/deprecated"
+    },
+    {
       "id": "SJkn0d4d-",
       "position": {
         "x": 266,

--- a/workspace/__lib__/xod/core/i2c-send-bytes-2/patch.xodp
+++ b/workspace/__lib__/xod/core/i2c-send-bytes-2/patch.xodp
@@ -126,6 +126,15 @@
       "type": "@/i2c-end-transmission"
     },
     {
+      "description": "Use a chain of `xod/i2c/begin-transmission` + `xod/i2c/write` + `xod/i2c/end-transmission` instead.",
+      "id": "S1xy2v74lm",
+      "position": {
+        "x": 442,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/deprecated"
+    },
+    {
       "id": "SkDMTNjwW",
       "label": "DONE",
       "position": {

--- a/workspace/__lib__/xod/core/i2c-write/patch.xodp
+++ b/workspace/__lib__/xod/core/i2c-write/patch.xodp
@@ -34,6 +34,15 @@
         "y": 120
       },
       "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "description": "Use a chain of `xod/i2c/write` instead.",
+      "id": "ryPnPQNgQ",
+      "position": {
+        "x": 136,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/deprecated"
     }
   ]
 }

--- a/workspace/__lib__/xod/i2c/begin-transmission/patch.cpp
+++ b/workspace/__lib__/xod/i2c/begin-transmission/patch.cpp
@@ -1,0 +1,20 @@
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    if (!isInputDirty<input_SEND>(ctx))
+        return;
+
+    uint8_t addr = getValue<input_ADDR>(ctx);
+
+    if (addr > 127) {
+        emitValue<output_ERR>(ctx, 1);
+        return;
+    }
+
+    auto wire = getValue<input_I2C>(ctx);
+    wire->beginTransmission(addr);
+    emitValue<output_DONE>(ctx, 1);
+}

--- a/workspace/__lib__/xod/i2c/begin-transmission/patch.xodp
+++ b/workspace/__lib__/xod/i2c/begin-transmission/patch.xodp
@@ -1,0 +1,63 @@
+{
+  "description": "Begins a transmission to the I²C slave device",
+  "nodes": [
+    {
+      "id": "B13jr_VOW",
+      "position": {
+        "x": 0,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "description": "Triggers the transmission start",
+      "id": "BJfKruVdb",
+      "label": "SEND",
+      "position": {
+        "x": 136,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "description": "Pulses when the transmission successfully starts. Chain it to a `write-byte` node.",
+      "id": "HJbjB_Nd-",
+      "label": "DONE",
+      "position": {
+        "x": 0,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "description": "I²C interface object",
+      "id": "HJkfWmny7",
+      "label": "I2C",
+      "position": {
+        "x": 0,
+        "y": 0
+      },
+      "type": "@/input-i2c"
+    },
+    {
+      "description": "Triggers when the transmission fails to start. E.g., the `ADDR` is invalid.",
+      "id": "SyUMZQ2JQ",
+      "label": "ERR",
+      "position": {
+        "x": 68,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "description": "I²C address of the target slave device",
+      "id": "SyssEEhJm",
+      "label": "ADDR",
+      "position": {
+        "x": 68,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-byte"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/i2c/end-transmission/patch.cpp
+++ b/workspace/__lib__/xod/i2c/end-transmission/patch.cpp
@@ -1,0 +1,18 @@
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    if (!isInputDirty<input_SEND>(ctx))
+        return;
+
+    auto wire = getValue<input_I2C>(ctx);
+    auto res = wire->endTransmission();
+    if (res != 0) {
+      emitValue<output_ERR>(ctx, 1);
+      return;
+    }
+
+    emitValue<output_DONE>(ctx, 1);
+}

--- a/workspace/__lib__/xod/i2c/end-transmission/patch.xodp
+++ b/workspace/__lib__/xod/i2c/end-transmission/patch.xodp
@@ -1,0 +1,53 @@
+{
+  "description": "Ends a transmission to a slave device initiated with `begin-transmission`. All bytes queued for writing with `write-byte` will flush at the moment of this node trigerring.",
+  "nodes": [
+    {
+      "description": "I²C interface object",
+      "id": "B1vdYXhkQ",
+      "label": "I2C",
+      "position": {
+        "x": 34,
+        "y": 0
+      },
+      "type": "@/input-i2c"
+    },
+    {
+      "id": "SJJbvdEOb",
+      "position": {
+        "x": 34,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "description": "Triggers the transmission end. Use `DONE` output of a `write-byte` as the source of the pulse.",
+      "id": "Sk2oU_Vdb",
+      "label": "SEND",
+      "position": {
+        "x": 102,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "description": "Triggers when the transmission fails to end/flush.",
+      "id": "SyewuY7nJm",
+      "label": "ERR",
+      "position": {
+        "x": 102,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "description": "Pulses when the transmission successfully completes.",
+      "id": "ryviw_EOb",
+      "label": "DONE",
+      "position": {
+        "x": 34,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/i2c/i2c/patch.cpp
+++ b/workspace/__lib__/xod/i2c/i2c/patch.cpp
@@ -1,0 +1,15 @@
+{{#global}}
+#include <Wire.h>
+{{/global}}
+
+struct State {
+};
+
+using Type = TwoWire*;
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    Wire.begin();
+    emitValue<output_OUT>(ctx, &Wire);
+}

--- a/workspace/__lib__/xod/i2c/i2c/patch.xodp
+++ b/workspace/__lib__/xod/i2c/i2c/patch.xodp
@@ -1,0 +1,21 @@
+{
+  "description": "I²C interface object constructor. Returns hardware I²C #0.",
+  "nodes": [
+    {
+      "id": "HyvnPf3kQ",
+      "position": {
+        "x": 68,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-self"
+    },
+    {
+      "id": "Sy_mOfh1X",
+      "position": {
+        "x": 68,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/i2c/project.xod
+++ b/workspace/__lib__/xod/i2c/project.xod
@@ -1,0 +1,9 @@
+{
+  "authors": [
+    "XOD"
+  ],
+  "description": "I²C (aka I2C, IIC, TWI) bus interfacing",
+  "license": "AGPL-3.0",
+  "name": "i2c",
+  "version": "0.21.0"
+}

--- a/workspace/__lib__/xod/i2c/read-byte/patch.cpp
+++ b/workspace/__lib__/xod/i2c/read-byte/patch.cpp
@@ -1,0 +1,19 @@
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    if (!isInputDirty<input_READ>(ctx))
+        return;
+
+    auto wire = getValue<input_I2C>(ctx);
+    if (!wire->available()) {
+        emitValue<output_BYTE>(ctx, 0x00);
+        emitValue<output_ERR>(ctx, 1);
+        return;
+    }
+
+    emitValue<output_BYTE>(ctx, (uint8_t)wire->read());
+    emitValue<output_DONE>(ctx, 1);
+}

--- a/workspace/__lib__/xod/i2c/read-byte/patch.xodp
+++ b/workspace/__lib__/xod/i2c/read-byte/patch.xodp
@@ -1,0 +1,63 @@
+{
+  "description": "Reads the next byte received from an I²C device after `request` succeeded.",
+  "nodes": [
+    {
+      "description": "The byte read",
+      "id": "SJeoE43JQ",
+      "label": "BYTE",
+      "position": {
+        "x": 0,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-byte"
+    },
+    {
+      "description": "Triggers the read. Use another `read-byte` or `request` as a source signal.",
+      "id": "SkylK_Ed-",
+      "label": "READ",
+      "position": {
+        "x": 68,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "description": "Pulses when read fails. E.g., due to the buffer underflow.",
+      "id": "SygH-3mhyX",
+      "label": "ERR",
+      "position": {
+        "x": 136,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "id": "SyvJYdVdW",
+      "position": {
+        "x": 0,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "description": "I²C interface object",
+      "id": "ryBWhQhkm",
+      "label": "I2C",
+      "position": {
+        "x": 0,
+        "y": 0
+      },
+      "type": "@/input-i2c"
+    },
+    {
+      "description": "Pulses when read completes successfully. When multiple bytes should be read, send it to the next `read-byte` node in a chain.",
+      "id": "rypZF_Nub",
+      "label": "DONE",
+      "position": {
+        "x": 68,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/i2c/request/patch.cpp
+++ b/workspace/__lib__/xod/i2c/request/patch.cpp
@@ -1,0 +1,21 @@
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    if (!isInputDirty<input_SEND>(ctx))
+        return;
+
+    auto wire = getValue<input_I2C>(ctx);
+    auto addr = (uint8_t)getValue<input_ADDR>(ctx);
+    auto nBytes = (uint8_t)getValue<input_N>(ctx);
+
+    if (addr > 127) {
+        emitValue<output_ERR>(ctx, 1);
+        return;
+    }
+
+    wire->requestFrom(addr, nBytes);
+    emitValue<output_DONE>(ctx, 1);
+}

--- a/workspace/__lib__/xod/i2c/request/patch.xodp
+++ b/workspace/__lib__/xod/i2c/request/patch.xodp
@@ -1,0 +1,76 @@
+{
+  "description": "Requests N bytes from a given slave I²C device",
+  "nodes": [
+    {
+      "description": "Slave device I²C address to request from",
+      "id": "BkRw4E3kX",
+      "label": "ADDR",
+      "position": {
+        "x": 68,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-byte"
+    },
+    {
+      "description": "I2C interface object",
+      "id": "Hk1dRQh17",
+      "label": "I2C",
+      "position": {
+        "x": 0,
+        "y": 0
+      },
+      "type": "@/input-i2c"
+    },
+    {
+      "description": "Pulses if request failed. E.g., due to an invalid `ADDR`.",
+      "id": "S1eJu0Q2JQ",
+      "label": "ERR",
+      "position": {
+        "x": 68,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "description": "Sends the request",
+      "id": "SJjmdOVOW",
+      "label": "SEND",
+      "position": {
+        "x": 204,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "description": "Pulses when the request is successfully send. Send it to a `read-byte`.",
+      "id": "Sk7BudNdZ",
+      "label": "DONE",
+      "position": {
+        "x": 0,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "01h"
+      },
+      "description": "Number of bytes to request",
+      "id": "r1NONEn1m",
+      "label": "N",
+      "position": {
+        "x": 136,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "rkoN_dNOW",
+      "position": {
+        "x": 0,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/i2c/write-byte/patch.cpp
+++ b/workspace/__lib__/xod/i2c/write-byte/patch.cpp
@@ -1,0 +1,18 @@
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    if (!isInputDirty<input_SEND>(ctx))
+        return;
+
+    auto wire = getValue<input_I2C>(ctx);
+    auto written = wire->write(getValue<input_BYTE>(ctx));
+    if (written != 1) {
+      emitValue<output_ERR>(ctx, 1);
+      return;
+    }
+
+    emitValue<output_DONE>(ctx, 1);
+}

--- a/workspace/__lib__/xod/i2c/write-byte/patch.xodp
+++ b/workspace/__lib__/xod/i2c/write-byte/patch.xodp
@@ -1,0 +1,63 @@
+{
+  "description": "Pushes a byte to send queue.",
+  "nodes": [
+    {
+      "description": "I²C interface object",
+      "id": "BJrcyE3y7",
+      "label": "I2C",
+      "position": {
+        "x": 0,
+        "y": 0
+      },
+      "type": "@/input-i2c"
+    },
+    {
+      "description": "Datum to write",
+      "id": "S1FFN4nkm",
+      "label": "BYTE",
+      "position": {
+        "x": 68,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-byte"
+    },
+    {
+      "description": "Pushes the `BYTE` to the send queue. Use pulse outputs from `begin-transmission` or another `write-byte` as a source signal.",
+      "id": "S1dKPuVdW",
+      "label": "SEND",
+      "position": {
+        "x": 136,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "description": "Pulses when the `BYTE` queued successfully. Send the output pulse to another `write-byte` in a chain or an `end-transmission` node.",
+      "id": "SJB3vO4uZ",
+      "label": "DONE",
+      "position": {
+        "x": 0,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "id": "r1j2DdNO-",
+      "position": {
+        "x": 0,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "description": "Pulses when the write fails. E.g., due to buffer overflow.",
+      "id": "rJxr5J42ym",
+      "label": "ERR",
+      "position": {
+        "x": 68,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #1253 