### PR TITLE
Fix bad literal value for i2c/request, input N

### DIFF
--- a/workspace/__lib__/xod/i2c/request/patch.xodp
+++ b/workspace/__lib__/xod/i2c/request/patch.xodp
@@ -53,7 +53,7 @@
     },
     {
       "boundLiterals": {
-        "__out__": "01h"
+        "__out__": "1"
       },
       "description": "Number of bytes to request",
       "id": "r1NONEn1m",


### PR DESCRIPTION
In #1256 I used to change `N` of `i2c/request` from Byte to Number and forgot to fix the default bound value. It was `1h` which translates to C++ as is and cause a compile error