### PR TITLE
Do not request switch workspace on any save/load error

### DIFF
--- a/packages/xod-client-electron/src/view/actions.js
+++ b/packages/xod-client-electron/src/view/actions.js
@@ -121,7 +121,12 @@ const createAsyncAction = ({
         processFailed({ processId, actionType, payload: err }, dispatch);
       }
       if (notify) {
-        dispatch(addError(errorMsg));
+        const extendedErrorMessage = R.mergeWith(
+          (a, b) => `${a}. ${b}`,
+          errorMsg,
+          { note: err.message }
+        );
+        dispatch(addError(extendedErrorMessage));
       }
 
       onError(err, dispatch);

--- a/packages/xod-client-electron/src/view/containers/App.jsx
+++ b/packages/xod-client-electron/src/view/containers/App.jsx
@@ -124,10 +124,6 @@ class App extends client.App {
       this.showCreateWorkspacePopup(path, force)
     );
     ipcRenderer.on(EVENTS.WORKSPACE_ERROR, (event, error) => {
-      // TODO: Catch CANT_OPEN_SELECTED_PROJECT and show something else
-      //       (its strange to ask to switch workspace if project has broken).
-      this.showPopupSetWorkspaceNotCancellable();
-      console.error(error); // eslint-disable-line no-console
       this.props.actions.addError(formatError(error));
     });
     ipcRenderer.on(EVENTS.REQUEST_CLOSE_WINDOW, () => {
@@ -651,11 +647,11 @@ class App extends client.App {
   }
 
   showPopupSetWorkspace() {
-    this.props.actions.requestSwitchWorkspace({ disposable: false });
+    this.props.actions.requestSwitchWorkspace({ disposable: true });
   }
 
   showPopupSetWorkspaceNotCancellable() {
-    this.props.actions.requestSwitchWorkspace({ disposable: true });
+    this.props.actions.requestSwitchWorkspace({ disposable: false });
   }
 
   showCreateWorkspacePopup(path, force) {


### PR DESCRIPTION
Just stop asking User for switch workspace and extend save/load error messages with a note, provided from original error.

Also, wanted to refactor error messages on failed save/load project, cause now some messages are old-fashioned (with "errorCodes") mixed with new-fashioned messages. So sometimes error message looks ugly (like "NOT_A_JSON {"input":{}}") or shows error message twice. But on a small part of this job I understood that is too large. So I stashed it for the future. 😬 