### PR TITLE
Make normalizeByte reject invalid integer values

### DIFF
--- a/packages/xod-client/src/utils/normalizeByte.js
+++ b/packages/xod-client/src/utils/normalizeByte.js
@@ -1,6 +1,7 @@
 import * as R from 'ramda';
 import { DEFAULT_VALUE_OF_TYPE, PIN_TYPE } from 'xod-project';
 
+const parseDec = x => parseInt(x, 10);
 const parseBin = x => parseInt(x, 2);
 const parseHex = x => parseInt(x, 16);
 
@@ -33,10 +34,15 @@ const toHex = R.compose(
 // 15 -> 15d
 const toDec = R.pipe(limitByte, x => x.toString(10), R.concat(R.__, 'd'));
 
-const decValueOrDefault = R.pipe(
-  x => parseInt(x, 10),
-  R.ifElse(x => isNaN(x), R.always(DEFAULT_VALUE_OF_TYPE[PIN_TYPE.BYTE]), toDec)
-);
+const decValueOrDefault = inputStr =>
+  R.compose(
+    R.ifElse(
+      parsed => isNaN(parsed) || parsed.toString(10) !== inputStr,
+      R.always(DEFAULT_VALUE_OF_TYPE[PIN_TYPE.BYTE]),
+      toDec
+    ),
+    parseDec
+  )(inputStr);
 
 // :: String -> String
 export default R.cond([

--- a/packages/xod-client/test/normalizeByte.spec.js
+++ b/packages/xod-client/test/normalizeByte.spec.js
@@ -22,6 +22,8 @@ describe('normalizeByte', () => {
     test('-2', '0d'); // underflow
     test('999', '255d'); // overflow
     test('-3d', '0d');
+    test('5C', '00h');
+    test('15abc', '00h');
   });
   describe('bin', () => {
     test('10001000b', '10001000b');


### PR DESCRIPTION
Before:
`15abc` -> `15d`
`7C` -> `7d`

Now:
`15abc` -> `00h`
`7C` -> `00h`
