### PR TITLE
New common-hardware library for a lps331 barometer

### DIFF
--- a/workspace/__lib__/xod/common-hardware/lps331-barometer/patch.xodp
+++ b/workspace/__lib__/xod/common-hardware/lps331-barometer/patch.xodp
@@ -1,0 +1,215 @@
+{
+  "description": "Reads temprature, pressure, altitude from a barometer based on LPS331 chip by STMicroelectronics. ",
+  "links": [
+    {
+      "id": "BJhNE6D-m",
+      "input": {
+        "nodeId": "rJByNpv-Q",
+        "pinKey": "Hk7Yk6D-m"
+      },
+      "output": {
+        "nodeId": "rkGKVETPbQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "BkB5AyuZ7",
+      "input": {
+        "nodeId": "rJ3dCyO-7",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "rJByNpv-Q",
+        "pinKey": "rkPHR1O-Q"
+      }
+    },
+    {
+      "id": "H1aN4avWQ",
+      "input": {
+        "nodeId": "rJByNpv-Q",
+        "pinKey": "SJ-7KJ6wbX"
+      },
+      "output": {
+        "nodeId": "BkWFEEpPZm",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HJrBEawWQ",
+      "input": {
+        "nodeId": "rJByNpv-Q",
+        "pinKey": "HJE0JTDWQ"
+      },
+      "output": {
+        "nodeId": "By7FVEaD-X",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "S1HUN6P-Q",
+      "input": {
+        "nodeId": "r17IVTPZQ",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "rJByNpv-Q",
+        "pinKey": "SyM-ETvZm"
+      }
+    },
+    {
+      "id": "SkZvLAOZX",
+      "input": {
+        "nodeId": "H1A88Cub7",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "rJByNpv-Q",
+        "pinKey": "SJlVI0O-7"
+      }
+    },
+    {
+      "id": "r1ZS4awZX",
+      "input": {
+        "nodeId": "B1xtN4aPWX",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "rJByNpv-Q",
+        "pinKey": "By4t7avZX"
+      }
+    },
+    {
+      "id": "ry8HNaPWQ",
+      "input": {
+        "nodeId": "rJByNpv-Q",
+        "pinKey": "H1lV0yTDbQ"
+      },
+      "output": {
+        "nodeId": "SkNYEEaDWQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "ryMBVTwb7",
+      "input": {
+        "nodeId": "SyYN4TwbQ",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "rJByNpv-Q",
+        "pinKey": "HkeEKQaPWm"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "description": "Fires when reading is done",
+      "id": "B1xtN4aPWX",
+      "label": "DONE",
+      "position": {
+        "x": 170,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "01011100b"
+      },
+      "description": "I²C address. 0b1011100 by default.",
+      "id": "BkWFEEpPZm",
+      "label": "ADDR",
+      "position": {
+        "x": 68,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-byte"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "On Boot"
+      },
+      "description": "Triggers initialization of the sensor ",
+      "id": "By7FVEaD-X",
+      "label": "INIT",
+      "position": {
+        "x": 102,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "description": "Geometric altitude value in meters ",
+      "id": "H1A88Cub7",
+      "label": "ALTT",
+      "position": {
+        "x": 136,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "Continuously"
+      },
+      "description": "Update. Triggers new sensor reading.",
+      "id": "SkNYEEaDWQ",
+      "label": "UPD",
+      "position": {
+        "x": 136,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "description": "Fires if reading failed",
+      "id": "SyYN4TwbQ",
+      "label": "ERR",
+      "position": {
+        "x": 204,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "description": "Temperature in degrees C",
+      "id": "r17IVTPZQ",
+      "label": "Tc",
+      "position": {
+        "x": 34,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "description": "Pressure in millibars (mbar)/hectopascals",
+      "id": "rJ3dCyO-7",
+      "label": "hPa",
+      "position": {
+        "x": 68,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "boundLiterals": {
+        "BJg7Fk6P-X": "20h"
+      },
+      "id": "rJByNpv-Q",
+      "position": {
+        "x": 34,
+        "y": 102
+      },
+      "type": "@/st-barometer-generic-sensor"
+    },
+    {
+      "id": "rkGKVETPbQ",
+      "label": "I2C",
+      "position": {
+        "x": 34,
+        "y": 0
+      },
+      "type": "xod/i2c/input-i2c"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/common-hardware/st-barometer-generic-sensor/patch.xodp
+++ b/workspace/__lib__/xod/common-hardware/st-barometer-generic-sensor/patch.xodp
@@ -1,0 +1,520 @@
+{
+  "links": [
+    {
+      "id": "B11vR1O-7",
+      "input": {
+        "nodeId": "rkPHR1O-Q",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "HkqI0Ju-m",
+        "pinKey": "BkqLCOSw1W"
+      }
+    },
+    {
+      "id": "BJFi0Cv-Q",
+      "input": {
+        "nodeId": "H1XsA0wZm",
+        "pinKey": "ryv7IRdSP1b"
+      },
+      "output": {
+        "nodeId": "SJLchCDW7",
+        "pinKey": "Bk4gU0drwJ-"
+      }
+    },
+    {
+      "id": "BJRLRJOWX",
+      "input": {
+        "nodeId": "HkqI0Ju-m",
+        "pinKey": "SkdIRuBD1b"
+      },
+      "output": {
+        "nodeId": "HJB9T1OWQ",
+        "pinKey": "HJ8UVik_Wm"
+      }
+    },
+    {
+      "id": "Bk2OACwbQ",
+      "input": {
+        "nodeId": "SJLchCDW7",
+        "pinKey": "SkSuD6LMb"
+      },
+      "output": {
+        "nodeId": "SyRVJaPbX",
+        "pinKey": "ryc-V1pPZX"
+      }
+    },
+    {
+      "id": "BkmGUA_bQ",
+      "input": {
+        "nodeId": "rJ-bUROWX",
+        "pinKey": "SkiCQ0O-X"
+      },
+      "output": {
+        "nodeId": "BkobRkO-X",
+        "pinKey": "BkqLCOSw1W"
+      }
+    },
+    {
+      "id": "ByJ6pyOW7",
+      "input": {
+        "nodeId": "By4t7avZX",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "HJB9T1OWQ",
+        "pinKey": "BySIViJ_bX"
+      }
+    },
+    {
+      "id": "ByYYJpP-m",
+      "input": {
+        "nodeId": "SyRVJaPbX",
+        "pinKey": "HywZE1aPWX"
+      },
+      "output": {
+        "nodeId": "SJ-7KJ6wbX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HJWyy1ObX",
+      "input": {
+        "nodeId": "H18GsAPZQ",
+        "pinKey": "BJnQUR_BwyZ"
+      },
+      "output": {
+        "nodeId": "ByHWiAPWQ",
+        "pinKey": "BkqLCOSw1W"
+      }
+    },
+    {
+      "id": "HJks7Tw-7",
+      "input": {
+        "nodeId": "H1-VK76P-m",
+        "pinKey": "ryv7IRdSP1b"
+      },
+      "output": {
+        "nodeId": "SyRVJaPbX",
+        "pinKey": "SyZVk6PbX"
+      }
+    },
+    {
+      "id": "HJtsp1O-X",
+      "input": {
+        "nodeId": "H1-VK76P-m",
+        "pinKey": "ByU7LRuSPkW-$1"
+      },
+      "output": {
+        "nodeId": "HJB9T1OWQ",
+        "pinKey": "HkVINj1dWX"
+      }
+    },
+    {
+      "id": "HkZo61_ZX",
+      "input": {
+        "nodeId": "HJB9T1OWQ",
+        "pinKey": "HJiL4s1_Zm"
+      },
+      "output": {
+        "nodeId": "SynQlav-Q",
+        "pinKey": "rkTm7x6DZm"
+      }
+    },
+    {
+      "id": "Hkci0CPWX",
+      "input": {
+        "nodeId": "SynQlav-Q",
+        "pinKey": "SkEg7mxpw-Q"
+      },
+      "output": {
+        "nodeId": "H1XsA0wZm",
+        "pinKey": "ByHmL0uHPk-"
+      }
+    },
+    {
+      "id": "S1GfA1dZX",
+      "input": {
+        "nodeId": "ryrMqyuWm",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "BkobRkO-X",
+        "pinKey": "BkqLCOSw1W"
+      }
+    },
+    {
+      "id": "S1uFy6vWQ",
+      "input": {
+        "nodeId": "SyRVJaPbX",
+        "pinKey": "rklbVJTv-m"
+      },
+      "output": {
+        "nodeId": "Hk7Yk6D-m",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "SJefRy_W7",
+      "input": {
+        "nodeId": "BkobRkO-X",
+        "pinKey": "SkdIRuBD1b"
+      },
+      "output": {
+        "nodeId": "HJB9T1OWQ",
+        "pinKey": "HJ8UVik_Wm"
+      }
+    },
+    {
+      "id": "SJt961uW7",
+      "input": {
+        "nodeId": "HJB9T1OWQ",
+        "pinKey": "HJOIEi1O-7"
+      },
+      "output": {
+        "nodeId": "SJ-7KJ6wbX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "SJzEYm6PWm",
+      "input": {
+        "nodeId": "HkeEKQaPWm",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "H1-VK76P-m",
+        "pinKey": "ByHmL0uHPk-"
+      }
+    },
+    {
+      "id": "Sk35p1u-7",
+      "input": {
+        "nodeId": "HJB9T1OWQ",
+        "pinKey": "rkLEsJdZQ"
+      },
+      "output": {
+        "nodeId": "Hk7Yk6D-m",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "Sk8SlpPWm",
+      "input": {
+        "nodeId": "SynQlav-Q",
+        "pinKey": "rJmXlaPZX"
+      },
+      "output": {
+        "nodeId": "Hk7Yk6D-m",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "SyV1kkdbm",
+      "input": {
+        "nodeId": "ByHWiAPWQ",
+        "pinKey": "SkdIRuBD1b"
+      },
+      "output": {
+        "nodeId": "SynQlav-Q",
+        "pinKey": "SyRXXeTDbm"
+      }
+    },
+    {
+      "id": "SydAJpvZm",
+      "input": {
+        "nodeId": "SyRVJaPbX",
+        "pinKey": "H1i-E1pDbQ"
+      },
+      "output": {
+        "nodeId": "HJE0JTDWQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "r1PjARwb7",
+      "input": {
+        "nodeId": "H1XsA0wZm",
+        "pinKey": "ByU7LRuSPkW"
+      },
+      "output": {
+        "nodeId": "H1lV0yTDbQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "r1hZL0_ZX",
+      "input": {
+        "nodeId": "H1-VK76P-m",
+        "pinKey": "ByU7LRuSPkW-$2"
+      },
+      "output": {
+        "nodeId": "rJ-bUROWX",
+        "pinKey": "Sy3aQCu-7"
+      }
+    },
+    {
+      "id": "r1mreTvZX",
+      "input": {
+        "nodeId": "SynQlav-Q",
+        "pinKey": "BJxgQ7e6vZX"
+      },
+      "output": {
+        "nodeId": "SJ-7KJ6wbX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "rk1J1J_-X",
+      "input": {
+        "nodeId": "SyM-ETvZm",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "H18GsAPZQ",
+        "pinKey": "SyomIRurDJ-"
+      }
+    },
+    {
+      "id": "rkgSLRuZX",
+      "input": {
+        "nodeId": "SJlVI0O-7",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "rJ-bUROWX",
+        "pinKey": "HJNsHRdWQ"
+      }
+    },
+    {
+      "id": "rkp576D-Q",
+      "input": {
+        "nodeId": "H1-VK76P-m",
+        "pinKey": "ByU7LRuSPkW"
+      },
+      "output": {
+        "nodeId": "SynQlav-Q",
+        "pinKey": "S137QgaDWQ"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "boundLiterals": {
+        "BytUCdHD1-": "40.96"
+      },
+      "id": "BkobRkO-X",
+      "position": {
+        "x": 884,
+        "y": 408
+      },
+      "type": "xod/core/divide"
+    },
+    {
+      "id": "By4t7avZX",
+      "label": "DONE",
+      "position": {
+        "x": 1054,
+        "y": 612
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "boundLiterals": {
+        "BytUCdHD1-": "480"
+      },
+      "id": "ByHWiAPWQ",
+      "position": {
+        "x": 680,
+        "y": 408
+      },
+      "type": "xod/core/divide"
+    },
+    {
+      "arityLevel": 3,
+      "id": "H1-VK76P-m",
+      "position": {
+        "x": 1122,
+        "y": 408
+      },
+      "type": "xod/core/any"
+    },
+    {
+      "boundLiterals": {
+        "HkqmLAOrD1W": "42.5"
+      },
+      "id": "H18GsAPZQ",
+      "position": {
+        "x": 680,
+        "y": 510
+      },
+      "type": "xod/core/add"
+    },
+    {
+      "id": "H1XsA0wZm",
+      "position": {
+        "x": 816,
+        "y": 102
+      },
+      "type": "xod/core/any"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "Continuously"
+      },
+      "description": "Triggers a new reading.",
+      "id": "H1lV0yTDbQ",
+      "label": "UPD",
+      "position": {
+        "x": 850,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "id": "HJB9T1OWQ",
+      "position": {
+        "x": 884,
+        "y": 204
+      },
+      "type": "@/st-barometer-read-pressue-raw"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "On Boot"
+      },
+      "id": "HJE0JTDWQ",
+      "label": "INIT",
+      "position": {
+        "x": 238,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "id": "Hk7Yk6D-m",
+      "label": "I2C",
+      "position": {
+        "x": 102,
+        "y": 0
+      },
+      "type": "xod/i2c/input-i2c"
+    },
+    {
+      "id": "HkeEKQaPWm",
+      "label": "ERR",
+      "position": {
+        "x": 1122,
+        "y": 612
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "boundLiterals": {
+        "BytUCdHD1-": "4096"
+      },
+      "id": "HkqI0Ju-m",
+      "position": {
+        "x": 782,
+        "y": 408
+      },
+      "type": "xod/core/divide"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "01011100b"
+      },
+      "description": "I²C address of the sensor",
+      "id": "SJ-7KJ6wbX",
+      "label": "ADDR",
+      "position": {
+        "x": 136,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-byte"
+    },
+    {
+      "boundLiterals": {
+        "Skre8ROSv1-": "0.1"
+      },
+      "id": "SJLchCDW7",
+      "position": {
+        "x": 68,
+        "y": 306
+      },
+      "type": "xod/core/delay"
+    },
+    {
+      "id": "SJlVI0O-7",
+      "label": "ALTT",
+      "position": {
+        "x": 952,
+        "y": 612
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "SyM-ETvZm",
+      "label": "Tc",
+      "position": {
+        "x": 680,
+        "y": 612
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "boundLiterals": {
+        "BkNZEy6PWX": "20h",
+        "H1HWNypP-Q": "11100000b"
+      },
+      "id": "SyRVJaPbX",
+      "position": {
+        "x": 102,
+        "y": 204
+      },
+      "type": "@/st-barometer-write-register"
+    },
+    {
+      "id": "SynQlav-Q",
+      "position": {
+        "x": 748,
+        "y": 204
+      },
+      "type": "@/st-barometer-read-temperature-raw"
+    },
+    {
+      "id": "SyzXFkTwZX",
+      "position": {
+        "x": 34,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/utility"
+    },
+    {
+      "id": "rJ-bUROWX",
+      "position": {
+        "x": 952,
+        "y": 510
+      },
+      "type": "@/st-barometer-read-altitude-gost4401"
+    },
+    {
+      "id": "rkPHR1O-Q",
+      "label": "hPa",
+      "position": {
+        "x": 782,
+        "y": 612
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "ryrMqyuWm",
+      "label": "Pa",
+      "position": {
+        "x": 884,
+        "y": 612
+      },
+      "type": "xod/patch-nodes/output-number"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/common-hardware/st-barometer-read-altitude-gost4401/patch.cpp
+++ b/workspace/__lib__/xod/common-hardware/st-barometer-read-altitude-gost4401/patch.cpp
@@ -1,0 +1,69 @@
+
+struct State {
+};
+
+typedef struct __attribute__((packed)) _GOST4401_RECORD{
+	float	  alt;		// Geopotentional altitude
+	float    temp;	    // degrees K
+	float  t_grad;		// degrees K per meter
+	float	press;		// pascals
+} GOST4401_RECORD;
+
+#define GOST4401_LUT_RECORDS 	6
+static const GOST4401_RECORD ag_table[] = {
+  {	 	0,  288.15, -0.0065, 101325.00 },
+  { 11000,  216.65,     0.0,  22632.04 },
+  { 20000,  216.65,  0.0010,   5474.87 },
+  { 32000,  228.65,  0.0028,  868.0146 },
+  { 47000,  270.65,     0.0,  110.9056 },
+  { 51000,  270.65, -0.0028,   6.69384 }
+};
+
+#define  GOST4401_G		 9.80665
+#define  GOST4401_R    287.05287
+#define  GOST4401_E      6356766
+
+#define GOST4401_MIN_PRESSURE	  6.69384
+#define GOST4401_MAX_PRESSURE   101325.00
+
+#define GOST4401_MIN_GPALT	0.00
+#define GOST4401_MAX_GPALT	51000.00
+
+{{ GENERATED_CODE }}
+
+
+
+float _GOST4401_geopotential2geometric(float altitude){
+	return altitude * GOST4401_E / (GOST4401_E - altitude);
+}
+
+void evaluate(Context ctx) {
+    auto pressurePa = getValue<input_Pa>(ctx);
+    if ((pressurePa <= GOST4401_MIN_PRESSURE) || (pressurePa > GOST4401_MAX_PRESSURE))
+        emitValue<output_ERR>(ctx, 1);
+
+    int idx = 0;
+    for (idx = 0; idx < GOST4401_LUT_RECORDS - 1; idx++){
+        if ((pressurePa <= ag_table[idx].press) && (pressurePa > ag_table[idx + 1].press))
+        break;
+    }
+
+    float Ps = ag_table[idx].press;
+    float Bm = ag_table[idx].t_grad;
+    float Tm = ag_table[idx].temp;
+    float Hb = ag_table[idx].alt;
+    float geopotH = 0;
+
+
+    if (Bm != 0.0) { 
+        geopotH = ((Tm * pow(Ps / pressurePa, Bm * GOST4401_R / GOST4401_G) - Tm) / Bm);
+    } else {
+        geopotH = log10(Ps / pressurePa) * (GOST4401_R * Tm) / (GOST4401_G * 0.434294);
+    }
+  
+  emitValue<output_ALTT>(ctx, _GOST4401_geopotential2geometric(Hb + geopotH));
+
+}
+
+
+

--- a/workspace/__lib__/xod/common-hardware/st-barometer-read-altitude-gost4401/patch.xodp
+++ b/workspace/__lib__/xod/common-hardware/st-barometer-read-altitude-gost4401/patch.xodp
@@ -1,0 +1,47 @@
+{
+  "nodes": [
+    {
+      "id": "HJNsHRdWQ",
+      "label": "ALTT",
+      "position": {
+        "x": 136,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "Hkj4XRuZQ",
+      "position": {
+        "x": 136,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "id": "SkRrXCubX",
+      "position": {
+        "x": -1,
+        "y": -1
+      },
+      "type": "xod/patch-nodes/utility"
+    },
+    {
+      "id": "SkiCQ0O-X",
+      "label": "Pa",
+      "position": {
+        "x": 136,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "Sy3aQCu-7",
+      "label": "ERR",
+      "position": {
+        "x": 204,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/common-hardware/st-barometer-read-pressue-raw/patch.xodp
+++ b/workspace/__lib__/xod/common-hardware/st-barometer-read-pressue-raw/patch.xodp
@@ -1,0 +1,481 @@
+{
+  "links": [
+    {
+      "id": "B1lx8EiJubX",
+      "input": {
+        "nodeId": "SyWUNs1dWX",
+        "pinKey": "Hk1dRQh17"
+      },
+      "output": {
+        "nodeId": "rkLEsJdZQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "BJ2iikOZQ",
+      "input": {
+        "nodeId": "H1yojyObQ",
+        "pinKey": "SkylK_Ed-"
+      },
+      "output": {
+        "nodeId": "r19I4ikOWm",
+        "pinKey": "rypZF_Nub"
+      }
+    },
+    {
+      "id": "BJCgINoy_Z7",
+      "input": {
+        "nodeId": "r12UVjJ_Wm",
+        "pinKey": "BJrcyE3y7"
+      },
+      "output": {
+        "nodeId": "rkLEsJdZQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "BJSgLVo1_-X",
+      "input": {
+        "nodeId": "SyYUVsJd-7",
+        "pinKey": "BJfKruVdb"
+      },
+      "output": {
+        "nodeId": "HJiL4s1_Zm",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "BybbLEs1Obm",
+      "input": {
+        "nodeId": "HJ7IEjku-7",
+        "pinKey": "ByU7LRuSPkW-$1"
+      },
+      "output": {
+        "nodeId": "SyYUVsJd-7",
+        "pinKey": "SyUMZQ2JQ"
+      }
+    },
+    {
+      "id": "BykW8Voyd-m",
+      "input": {
+        "nodeId": "SyYUVsJd-7",
+        "pinKey": "HJkfWmny7"
+      },
+      "output": {
+        "nodeId": "rkLEsJdZQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "H1Sb84oyOb7",
+      "input": {
+        "nodeId": "r12UVjJ_Wm",
+        "pinKey": "S1FFN4nkm"
+      },
+      "output": {
+        "nodeId": "r1pL4jyubX",
+        "pinKey": "rkgRyT6beM"
+      }
+    },
+    {
+      "id": "H1jlUEoJ_ZX",
+      "input": {
+        "nodeId": "SyWUNs1dWX",
+        "pinKey": "SJjmdOVOW"
+      },
+      "output": {
+        "nodeId": "SkDIEokdWX",
+        "pinKey": "ryviw_EOb"
+      }
+    },
+    {
+      "id": "HJ-xINoy_bm",
+      "input": {
+        "nodeId": "SkMUVskuZ7",
+        "pinKey": "SkylK_Ed-"
+      },
+      "output": {
+        "nodeId": "SyWUNs1dWX",
+        "pinKey": "Sk7BudNdZ"
+      }
+    },
+    {
+      "id": "HJNxUNo1O-7",
+      "input": {
+        "nodeId": "HJ7IEjku-7",
+        "pinKey": "ryv7IRdSP1b"
+      },
+      "output": {
+        "nodeId": "SkMUVskuZ7",
+        "pinKey": "SygH-3mhyX"
+      }
+    },
+    {
+      "id": "HJTUa1_ZQ",
+      "input": {
+        "nodeId": "HJ8UVik_Wm",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "HJxPnku-m",
+        "pinKey": "r1WVwX_W1Q"
+      }
+    },
+    {
+      "id": "HkMxUVoJOW7",
+      "input": {
+        "nodeId": "SyWUNs1dWX",
+        "pinKey": "BkRw4E3kX"
+      },
+      "output": {
+        "nodeId": "HJOIEi1O-7",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HkNOp1d-X",
+      "input": {
+        "nodeId": "HJxPnku-m",
+        "pinKey": "SJRsfob1m"
+      },
+      "output": {
+        "nodeId": "H1yojyObQ",
+        "pinKey": "SJeoE43JQ"
+      }
+    },
+    {
+      "id": "HyzbUNoydWX",
+      "input": {
+        "nodeId": "HJ7IEjku-7",
+        "pinKey": "ByU7LRuSPkW-$2"
+      },
+      "output": {
+        "nodeId": "r12UVjJ_Wm",
+        "pinKey": "rJxr5J42ym"
+      }
+    },
+    {
+      "id": "S11ua1_-X",
+      "input": {
+        "nodeId": "HJxPnku-m",
+        "pinKey": "rJvDQd-Jm"
+      },
+      "output": {
+        "nodeId": "SkMUVskuZ7",
+        "pinKey": "SJeoE43JQ"
+      }
+    },
+    {
+      "id": "S1cgI4j1uW7",
+      "input": {
+        "nodeId": "SyYUVsJd-7",
+        "pinKey": "SyssEEhJm"
+      },
+      "output": {
+        "nodeId": "HJOIEi1O-7",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "SJaeI4syO-Q",
+      "input": {
+        "nodeId": "r12UVjJ_Wm",
+        "pinKey": "S1dKPuVdW"
+      },
+      "output": {
+        "nodeId": "SyYUVsJd-7",
+        "pinKey": "HJbjB_Nd-"
+      }
+    },
+    {
+      "id": "SJmg8VjkOWQ",
+      "input": {
+        "nodeId": "SkDIEokdWX",
+        "pinKey": "Sk2oU_Vdb"
+      },
+      "output": {
+        "nodeId": "r12UVjJ_Wm",
+        "pinKey": "SJB3vO4uZ"
+      }
+    },
+    {
+      "id": "SkJlIVsku-7",
+      "input": {
+        "nodeId": "HkVINj1dWX",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "HJ7IEjku-7",
+        "pinKey": "ByHmL0uHPk-"
+      }
+    },
+    {
+      "id": "SkOl8Eo1_WQ",
+      "input": {
+        "nodeId": "r19I4ikOWm",
+        "pinKey": "SkylK_Ed-"
+      },
+      "output": {
+        "nodeId": "SkMUVskuZ7",
+        "pinKey": "rypZF_Nub"
+      }
+    },
+    {
+      "id": "SkwlIEjy_b7",
+      "input": {
+        "nodeId": "HJ7IEjku-7",
+        "pinKey": "ByU7LRuSPkW"
+      },
+      "output": {
+        "nodeId": "r19I4ikOWm",
+        "pinKey": "SygH-3mhyX"
+      }
+    },
+    {
+      "id": "Skznj1_-Q",
+      "input": {
+        "nodeId": "BySIViJ_bX",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "H1yojyObQ",
+        "pinKey": "rypZF_Nub"
+      }
+    },
+    {
+      "id": "r1LioJOWX",
+      "input": {
+        "nodeId": "HJ7IEjku-7",
+        "pinKey": "ByU7LRuSPkW-$5"
+      },
+      "output": {
+        "nodeId": "H1yojyObQ",
+        "pinKey": "SygH-3mhyX"
+      }
+    },
+    {
+      "id": "r1Ug8Eo1OZm",
+      "input": {
+        "nodeId": "r19I4ikOWm",
+        "pinKey": "ryBWhQhkm"
+      },
+      "output": {
+        "nodeId": "rkLEsJdZQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "r1XWLEoy_bX",
+      "input": {
+        "nodeId": "HJ7IEjku-7",
+        "pinKey": "ByU7LRuSPkW-$3"
+      },
+      "output": {
+        "nodeId": "SkDIEokdWX",
+        "pinKey": "SyewuY7nJm"
+      }
+    },
+    {
+      "id": "rJ2gUNoJ_-Q",
+      "input": {
+        "nodeId": "SkDIEokdWX",
+        "pinKey": "B1vdYXhkQ"
+      },
+      "output": {
+        "nodeId": "rkLEsJdZQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "rJKlUNo1O-m",
+      "input": {
+        "nodeId": "SkMUVskuZ7",
+        "pinKey": "ryBWhQhkm"
+      },
+      "output": {
+        "nodeId": "rkLEsJdZQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "rkMdpku-Q",
+      "input": {
+        "nodeId": "HJxPnku-m",
+        "pinKey": "B1gEDm_W1Q"
+      },
+      "output": {
+        "nodeId": "r19I4ikOWm",
+        "pinKey": "SJeoE43JQ"
+      }
+    },
+    {
+      "id": "rkNWUNjy_W7",
+      "input": {
+        "nodeId": "HJ7IEjku-7",
+        "pinKey": "ByU7LRuSPkW-$4"
+      },
+      "output": {
+        "nodeId": "SyWUNs1dWX",
+        "pinKey": "S1eJu0Q2JQ"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "id": "BySIViJ_bX",
+      "label": "DONE",
+      "position": {
+        "x": 374,
+        "y": 816
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "id": "H1yojyObQ",
+      "label": "ph",
+      "position": {
+        "x": 272,
+        "y": 612
+      },
+      "type": "xod/i2c/read-byte"
+    },
+    {
+      "arityLevel": 6,
+      "id": "HJ7IEjku-7",
+      "position": {
+        "x": 441,
+        "y": 714
+      },
+      "type": "xod/core/any"
+    },
+    {
+      "id": "HJ8UVik_Wm",
+      "label": "PRAW",
+      "position": {
+        "x": 102,
+        "y": 918
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "HJOIEi1O-7",
+      "label": "ADDR",
+      "position": {
+        "x": 134,
+        "y": -1
+      },
+      "type": "xod/patch-nodes/input-byte"
+    },
+    {
+      "id": "HJiL4s1_Zm",
+      "label": "R",
+      "position": {
+        "x": 168,
+        "y": -1
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "id": "HJxPnku-m",
+      "position": {
+        "x": 102,
+        "y": 816
+      },
+      "type": "xod/bits/i32-to-number"
+    },
+    {
+      "id": "HkVINj1dWX",
+      "label": "ERR",
+      "position": {
+        "x": 442,
+        "y": 816
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "id": "SkDIEokdWX",
+      "position": {
+        "x": 271,
+        "y": 204
+      },
+      "type": "xod/i2c/end-transmission"
+    },
+    {
+      "id": "SkMUVskuZ7",
+      "label": "pxl",
+      "position": {
+        "x": 0,
+        "y": 612
+      },
+      "type": "xod/i2c/read-byte"
+    },
+    {
+      "boundLiterals": {
+        "r1NONEn1m": "3"
+      },
+      "id": "SyWUNs1dWX",
+      "position": {
+        "x": 373,
+        "y": 204
+      },
+      "type": "xod/i2c/request"
+    },
+    {
+      "id": "SyYUVsJd-7",
+      "position": {
+        "x": -1,
+        "y": 204
+      },
+      "type": "xod/i2c/begin-transmission"
+    },
+    {
+      "boundLiterals": {
+        "S1FFN4nkm": "2Bh"
+      },
+      "id": "r12UVjJ_Wm",
+      "position": {
+        "x": 135,
+        "y": 204
+      },
+      "type": "xod/i2c/write-byte"
+    },
+    {
+      "id": "r19I4ikOWm",
+      "label": "pl",
+      "position": {
+        "x": 136,
+        "y": 612
+      },
+      "type": "xod/i2c/read-byte"
+    },
+    {
+      "boundLiterals": {
+        "SkC1aTZeM": "128d",
+        "r1zA16pbxM": "28h"
+      },
+      "id": "r1pL4jyubX",
+      "position": {
+        "x": 169,
+        "y": 102
+      },
+      "type": "xod/bits/bitwise-or"
+    },
+    {
+      "id": "rJeINiyuWQ",
+      "position": {
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/utility"
+    },
+    {
+      "id": "rkLEsJdZQ",
+      "label": "I2C",
+      "position": {
+        "x": 66,
+        "y": 407
+      },
+      "type": "xod/i2c/input-i2c"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/common-hardware/st-barometer-read-temperature-raw/patch.xodp
+++ b/workspace/__lib__/xod/common-hardware/st-barometer-read-temperature-raw/patch.xodp
@@ -1,0 +1,439 @@
+{
+  "links": [
+    {
+      "id": "B10ZQmxpvW7",
+      "input": {
+        "nodeId": "B17lQQxTvWQ",
+        "pinKey": "SkylK_Ed-"
+      },
+      "output": {
+        "nodeId": "B1tQQgaPWX",
+        "pinKey": "rypZF_Nub"
+      }
+    },
+    {
+      "id": "B1jUQpPbQ",
+      "input": {
+        "nodeId": "rkjmmlpDZ7",
+        "pinKey": "ByU7LRuSPkW-$3"
+      },
+      "output": {
+        "nodeId": "Sykx77lTD-X",
+        "pinKey": "SyewuY7nJm"
+      }
+    },
+    {
+      "id": "BJKIXpPbm",
+      "input": {
+        "nodeId": "rkjmmlpDZ7",
+        "pinKey": "ByU7LRuSPkW-$2"
+      },
+      "output": {
+        "nodeId": "B1Sg77g6DWX",
+        "pinKey": "rJxr5J42ym"
+      }
+    },
+    {
+      "id": "BJLlmXlpPZX",
+      "input": {
+        "nodeId": "S137QgaDWQ",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "rkjmmlpDZ7",
+        "pinKey": "ByHmL0uHPk-"
+      }
+    },
+    {
+      "id": "BkiMm7laP-X",
+      "input": {
+        "nodeId": "B1Sg77g6DWX",
+        "pinKey": "S1dKPuVdW"
+      },
+      "output": {
+        "nodeId": "HkMeXmlTwbm",
+        "pinKey": "HJbjB_Nd-"
+      }
+    },
+    {
+      "id": "ByWDUkObQ",
+      "input": {
+        "nodeId": "BkkwLkOZQ",
+        "pinKey": "rJvDQd-Jm"
+      },
+      "output": {
+        "nodeId": "B1tQQgaPWX",
+        "pinKey": "SJeoE43JQ"
+      }
+    },
+    {
+      "id": "H12f-aPZQ",
+      "input": {
+        "nodeId": "rkTm7x6DZm",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "B17lQQxTvWQ",
+        "pinKey": "rypZF_Nub"
+      }
+    },
+    {
+      "id": "H1GwUkub7",
+      "input": {
+        "nodeId": "BkkwLkOZQ",
+        "pinKey": "B1gEDm_W1Q"
+      },
+      "output": {
+        "nodeId": "B17lQQxTvWQ",
+        "pinKey": "SJeoE43JQ"
+      }
+    },
+    {
+      "id": "H1Qzmmx6vWQ",
+      "input": {
+        "nodeId": "HyUmQxpDZ7",
+        "pinKey": "SJjmdOVOW"
+      },
+      "output": {
+        "nodeId": "Sykx77lTD-X",
+        "pinKey": "ryviw_EOb"
+      }
+    },
+    {
+      "id": "H1kGXQxpw-Q",
+      "input": {
+        "nodeId": "B1tQQgaPWX",
+        "pinKey": "ryBWhQhkm"
+      },
+      "output": {
+        "nodeId": "rJmXlaPZX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HJNbXQgTv-X",
+      "input": {
+        "nodeId": "B17lQQxTvWQ",
+        "pinKey": "ryBWhQhkm"
+      },
+      "output": {
+        "nodeId": "rJmXlaPZX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HJkQXXe6vb7",
+      "input": {
+        "nodeId": "HkMeXmlTwbm",
+        "pinKey": "HJkfWmny7"
+      },
+      "output": {
+        "nodeId": "rJmXlaPZX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HkzWQmeTPbX",
+      "input": {
+        "nodeId": "rkjmmlpDZ7",
+        "pinKey": "ryv7IRdSP1b"
+      },
+      "output": {
+        "nodeId": "B1tQQgaPWX",
+        "pinKey": "SygH-3mhyX"
+      }
+    },
+    {
+      "id": "HypIXpvbX",
+      "input": {
+        "nodeId": "rkjmmlpDZ7",
+        "pinKey": "ByU7LRuSPkW-$4"
+      },
+      "output": {
+        "nodeId": "HyUmQxpDZ7",
+        "pinKey": "S1eJu0Q2JQ"
+      }
+    },
+    {
+      "id": "S1FGXXlaPWQ",
+      "input": {
+        "nodeId": "Sykx77lTD-X",
+        "pinKey": "B1vdYXhkQ"
+      },
+      "output": {
+        "nodeId": "rJmXlaPZX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "S1LIXTD-7",
+      "input": {
+        "nodeId": "rkjmmlpDZ7",
+        "pinKey": "ByU7LRuSPkW-$1"
+      },
+      "output": {
+        "nodeId": "HkMeXmlTwbm",
+        "pinKey": "SyUMZQ2JQ"
+      }
+    },
+    {
+      "id": "S1zRWCDWm",
+      "input": {
+        "nodeId": "B1Sg77g6DWX",
+        "pinKey": "S1FFN4nkm"
+      },
+      "output": {
+        "nodeId": "SyDp-0DZm",
+        "pinKey": "rkgRyT6beM"
+      }
+    },
+    {
+      "id": "Sk1bQQlawbm",
+      "input": {
+        "nodeId": "Sykx77lTD-X",
+        "pinKey": "Sk2oU_Vdb"
+      },
+      "output": {
+        "nodeId": "B1Sg77g6DWX",
+        "pinKey": "SJB3vO4uZ"
+      }
+    },
+    {
+      "id": "SkMfQml6vZm",
+      "input": {
+        "nodeId": "HkMeXmlTwbm",
+        "pinKey": "SyssEEhJm"
+      },
+      "output": {
+        "nodeId": "BJxgQ7e6vZX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "Sy2gmXl6D-7",
+      "input": {
+        "nodeId": "HyUmQxpDZ7",
+        "pinKey": "BkRw4E3kX"
+      },
+      "output": {
+        "nodeId": "BJxgQ7e6vZX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "r1IZ7mg6PWQ",
+      "input": {
+        "nodeId": "rkjmmlpDZ7",
+        "pinKey": "ByU7LRuSPkW"
+      },
+      "output": {
+        "nodeId": "B17lQQxTvWQ",
+        "pinKey": "SygH-3mhyX"
+      }
+    },
+    {
+      "id": "r1QWmQxpw-Q",
+      "input": {
+        "nodeId": "HkMeXmlTwbm",
+        "pinKey": "BJfKruVdb"
+      },
+      "output": {
+        "nodeId": "SkEg7mxpw-Q",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "rJ5gQQe6wWm",
+      "input": {
+        "nodeId": "B1tQQgaPWX",
+        "pinKey": "SkylK_Ed-"
+      },
+      "output": {
+        "nodeId": "HyUmQxpDZ7",
+        "pinKey": "Sk7BudNdZ"
+      }
+    },
+    {
+      "id": "rk2G77gTPZ7",
+      "input": {
+        "nodeId": "B1Sg77g6DWX",
+        "pinKey": "BJrcyE3y7"
+      },
+      "output": {
+        "nodeId": "rJmXlaPZX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "rkVD8y_WQ",
+      "input": {
+        "nodeId": "SyRXXeTDbm",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "BkkwLkOZQ",
+        "pinKey": "r1WVwX_W1Q"
+      }
+    },
+    {
+      "id": "rkYxX7e6v-m",
+      "input": {
+        "nodeId": "HyUmQxpDZ7",
+        "pinKey": "Hk1dRQh17"
+      },
+      "output": {
+        "nodeId": "rJmXlaPZX",
+        "pinKey": "__out__"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "id": "B17lQQxTvWQ",
+      "label": "th",
+      "position": {
+        "x": 68,
+        "y": 612
+      },
+      "type": "xod/i2c/read-byte"
+    },
+    {
+      "boundLiterals": {
+        "S1FFN4nkm": "2Bh"
+      },
+      "id": "B1Sg77g6DWX",
+      "position": {
+        "x": 68,
+        "y": 204
+      },
+      "type": "xod/i2c/write-byte"
+    },
+    {
+      "id": "B1tQQgaPWX",
+      "label": "tl",
+      "position": {
+        "x": -68,
+        "y": 612
+      },
+      "type": "xod/i2c/read-byte"
+    },
+    {
+      "id": "BJxgQ7e6vZX",
+      "label": "ADDR",
+      "position": {
+        "x": 67,
+        "y": -1
+      },
+      "type": "xod/patch-nodes/input-byte"
+    },
+    {
+      "id": "BkkwLkOZQ",
+      "position": {
+        "x": 0,
+        "y": 714
+      },
+      "type": "xod/bits/i16-to-number"
+    },
+    {
+      "id": "HkMeXmlTwbm",
+      "position": {
+        "x": -68,
+        "y": 204
+      },
+      "type": "xod/i2c/begin-transmission"
+    },
+    {
+      "boundLiterals": {
+        "r1NONEn1m": "2"
+      },
+      "id": "HyUmQxpDZ7",
+      "position": {
+        "x": 306,
+        "y": 204
+      },
+      "type": "xod/i2c/request"
+    },
+    {
+      "id": "S137QgaDWQ",
+      "label": "ERR",
+      "position": {
+        "x": 306,
+        "y": 816
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "id": "SkEg7mxpw-Q",
+      "label": "R",
+      "position": {
+        "x": 101,
+        "y": -1
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "boundLiterals": {
+        "SkC1aTZeM": "128d",
+        "r1zA16pbxM": "2Bh"
+      },
+      "id": "SyDp-0DZm",
+      "position": {
+        "x": 102,
+        "y": 102
+      },
+      "type": "xod/bits/bitwise-or"
+    },
+    {
+      "id": "SyRXXeTDbm",
+      "label": "TRAW",
+      "position": {
+        "x": 0,
+        "y": 816
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "Sykx77lTD-X",
+      "position": {
+        "x": 204,
+        "y": 204
+      },
+      "type": "xod/i2c/end-transmission"
+    },
+    {
+      "id": "rJ-QQlav-7",
+      "position": {
+        "x": -68,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/utility"
+    },
+    {
+      "id": "rJmXlaPZX",
+      "label": "I2C",
+      "position": {
+        "x": -1,
+        "y": 407
+      },
+      "type": "xod/i2c/input-i2c"
+    },
+    {
+      "id": "rkTm7x6DZm",
+      "label": "DONE",
+      "position": {
+        "x": 102,
+        "y": 816
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "arityLevel": 5,
+      "id": "rkjmmlpDZ7",
+      "position": {
+        "x": 306,
+        "y": 714
+      },
+      "type": "xod/core/any"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/common-hardware/st-barometer-write-register/patch.xodp
+++ b/workspace/__lib__/xod/common-hardware/st-barometer-write-register/patch.xodp
@@ -1,0 +1,311 @@
+{
+  "links": [
+    {
+      "id": "B1yxW4y6P-X",
+      "input": {
+        "nodeId": "ryc-V1pPZX",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "r1-ZNJ6w-Q",
+        "pinKey": "ryviw_EOb"
+      }
+    },
+    {
+      "id": "BJ-x-VkTP-Q",
+      "input": {
+        "nodeId": "SyMWN16D-m",
+        "pinKey": "SyssEEhJm"
+      },
+      "output": {
+        "nodeId": "HywZE1aPWX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "H1YxW4JpPWm",
+      "input": {
+        "nodeId": "HyKWVJ6PZm",
+        "pinKey": "BJrcyE3y7"
+      },
+      "output": {
+        "nodeId": "rklbVJTv-m",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "H1n-EJTwWm",
+      "input": {
+        "nodeId": "r1-ZNJ6w-Q",
+        "pinKey": "B1vdYXhkQ"
+      },
+      "output": {
+        "nodeId": "rklbVJTv-m",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HJQgW4JTv-Q",
+      "input": {
+        "nodeId": "SyMWN16D-m",
+        "pinKey": "HJkfWmny7"
+      },
+      "output": {
+        "nodeId": "rklbVJTv-m",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HkDxbNJaw-7",
+      "input": {
+        "nodeId": "r1-ZNJ6w-Q",
+        "pinKey": "Sk2oU_Vdb"
+      },
+      "output": {
+        "nodeId": "SJ7b4kaPZQ",
+        "pinKey": "SJB3vO4uZ"
+      }
+    },
+    {
+      "id": "HkUgbEJ6Pb7",
+      "input": {
+        "nodeId": "SJ7b4kaPZQ",
+        "pinKey": "S1FFN4nkm"
+      },
+      "output": {
+        "nodeId": "H1HWNypP-Q",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HyHxWE16wWQ",
+      "input": {
+        "nodeId": "ryLbN1TwWm",
+        "pinKey": "ByU7LRuSPkW"
+      },
+      "output": {
+        "nodeId": "HyKWVJ6PZm",
+        "pinKey": "rJxr5J42ym"
+      }
+    },
+    {
+      "id": "HyT-N1TP-X",
+      "input": {
+        "nodeId": "SyZVk6PbX",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "ryLbN1TwWm",
+        "pinKey": "ByHmL0uHPk-"
+      }
+    },
+    {
+      "id": "HyclZEJpw-m",
+      "input": {
+        "nodeId": "ryLbN1TwWm",
+        "pinKey": "ryv7IRdSP1b"
+      },
+      "output": {
+        "nodeId": "SyMWN16D-m",
+        "pinKey": "SyUMZQ2JQ"
+      }
+    },
+    {
+      "id": "SJ0bVk6Db7",
+      "input": {
+        "nodeId": "SJ7b4kaPZQ",
+        "pinKey": "BJrcyE3y7"
+      },
+      "output": {
+        "nodeId": "rklbVJTv-m",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "SJEeZNJ6vWQ",
+      "input": {
+        "nodeId": "HyKWVJ6PZm",
+        "pinKey": "S1dKPuVdW"
+      },
+      "output": {
+        "nodeId": "SyMWN16D-m",
+        "pinKey": "HJbjB_Nd-"
+      }
+    },
+    {
+      "id": "SJzlbNk6D-X",
+      "input": {
+        "nodeId": "ryLbN1TwWm",
+        "pinKey": "ByU7LRuSPkW-$2"
+      },
+      "output": {
+        "nodeId": "r1-ZNJ6w-Q",
+        "pinKey": "SyewuY7nJm"
+      }
+    },
+    {
+      "id": "Syxl-EJaPbQ",
+      "input": {
+        "nodeId": "HyKWVJ6PZm",
+        "pinKey": "S1FFN4nkm"
+      },
+      "output": {
+        "nodeId": "BkNZEy6PWX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "r1deZVkpP-Q",
+      "input": {
+        "nodeId": "SJ7b4kaPZQ",
+        "pinKey": "S1dKPuVdW"
+      },
+      "output": {
+        "nodeId": "HyKWVJ6PZm",
+        "pinKey": "SJB3vO4uZ"
+      }
+    },
+    {
+      "id": "r1seZNkpPW7",
+      "input": {
+        "nodeId": "SyMWN16D-m",
+        "pinKey": "BJfKruVdb"
+      },
+      "output": {
+        "nodeId": "H1i-E1pDbQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "rJnxb41TPW7",
+      "input": {
+        "nodeId": "ryLbN1TwWm",
+        "pinKey": "ByU7LRuSPkW-$1"
+      },
+      "output": {
+        "nodeId": "SJ7b4kaPZQ",
+        "pinKey": "rJxr5J42ym"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "id": "BkNZEy6PWX",
+      "label": "REG",
+      "position": {
+        "x": 238,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-byte"
+    },
+    {
+      "id": "H1HWNypP-Q",
+      "label": "VAL",
+      "position": {
+        "x": 372,
+        "y": -1
+      },
+      "type": "xod/patch-nodes/input-byte"
+    },
+    {
+      "id": "H1i-E1pDbQ",
+      "label": "W",
+      "position": {
+        "x": 509,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "id": "HkOWN1pD-7",
+      "position": {
+        "x": -1,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/utility"
+    },
+    {
+      "boundLiterals": {
+        "S1FFN4nkm": "20h"
+      },
+      "id": "HyKWVJ6PZm",
+      "position": {
+        "x": 202,
+        "y": 203
+      },
+      "type": "xod/i2c/write-byte"
+    },
+    {
+      "id": "HywZE1aPWX",
+      "label": "ADDR",
+      "position": {
+        "x": 101,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-byte"
+    },
+    {
+      "id": "SJ7b4kaPZQ",
+      "position": {
+        "x": 340,
+        "y": 204
+      },
+      "type": "xod/i2c/write-byte"
+    },
+    {
+      "boundLiterals": {
+        "BJfKruVdb": "On Boot"
+      },
+      "id": "SyMWN16D-m",
+      "position": {
+        "x": 68,
+        "y": 204
+      },
+      "type": "xod/i2c/begin-transmission"
+    },
+    {
+      "id": "SyZVk6PbX",
+      "label": "ERR",
+      "position": {
+        "x": 543,
+        "y": 408
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "id": "r1-ZNJ6w-Q",
+      "position": {
+        "x": 578,
+        "y": 204
+      },
+      "type": "xod/i2c/end-transmission"
+    },
+    {
+      "id": "rklbVJTv-m",
+      "label": "I2C",
+      "position": {
+        "x": 66,
+        "y": -1
+      },
+      "type": "xod/i2c/input-i2c"
+    },
+    {
+      "arityLevel": 3,
+      "id": "ryLbN1TwWm",
+      "position": {
+        "x": 543,
+        "y": 306
+      },
+      "type": "xod/core/any"
+    },
+    {
+      "id": "ryc-V1pPZX",
+      "label": "DONE",
+      "position": {
+        "x": 475,
+        "y": 408
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    }
+  ]
+}


### PR DESCRIPTION
Library for the lps331 based barometers from ST. 
Communicates by I2C.
Outputs current:
- tempreture in celsius; 
- pressure in hPa;
- attitude according to GOST4401.