### PR TITLE
Char literal for byte type

### DIFF
--- a/docs/reference/data-types/README.md
+++ b/docs/reference/data-types/README.md
@@ -279,6 +279,14 @@ In some inputs IDE or CLI can normalize almost valid literals like lower-cased
       <td class="right aligned"><code>006d</code></td>
       <td>The leading zeros are allowed but may be omitted</td>
     </tr>
+    <tr>
+      <td class="right aligned"><code>'a'</code></td>
+      <td>A character surrounded by single quotes is translated to a byte value equal to its ASCII code</td>
+    </tr>
+    <tr>
+      <td class="right aligned"><code>'\n'</code></td>
+      <td>A backslashed character specifies a <a href="https://en.wikipedia.org/wiki/Control_character">control ASCII character</a> like line feed, carriage return, tab, etc</td>
+    </tr>
   </tbody>
 </table>
 

--- a/packages/xod-arduino/src/templates.js
+++ b/packages/xod-arduino/src/templates.js
@@ -102,26 +102,32 @@ const cppStringLiteral = def(
 // FAh -> 0xFA
 // 29d -> 0x1D
 // 10 -> 0xA
+// and leave char literals as is
+// 'a' -> 'a'
+// '\n' -> '\n'
 const cppByteLiteral = def(
   'cppByteLiteral :: String -> String',
-  R.compose(
-    R.concat('0x'),
-    R.toUpper,
-    x => x.toString(16),
-    R.ifElse(
-      R.test(/(b|h|d)$/),
-      R.converge(parseInt, [
-        R.init,
-        R.compose(
-          R.prop(R.__, {
-            b: 2,
-            h: 16,
-            d: 10,
-          }),
-          R.last
-        ),
-      ]),
-      plainDecimal => parseInt(plainDecimal, 10)
+  R.unless(
+    XP.isValidCharLiteral,
+    R.compose(
+      R.concat('0x'),
+      R.toUpper,
+      x => x.toString(16),
+      R.ifElse(
+        R.test(/(b|h|d)$/),
+        R.converge(parseInt, [
+          R.init,
+          R.compose(
+            R.prop(R.__, {
+              b: 2,
+              h: 16,
+              d: 10,
+            }),
+            R.last
+          ),
+        ]),
+        plainDecimal => parseInt(plainDecimal, 10)
+      )
     )
   )
 );

--- a/packages/xod-client/src/utils/normalizeByte.js
+++ b/packages/xod-client/src/utils/normalizeByte.js
@@ -1,5 +1,9 @@
 import * as R from 'ramda';
-import { DEFAULT_VALUE_OF_TYPE, PIN_TYPE } from 'xod-project';
+import {
+  DEFAULT_VALUE_OF_TYPE,
+  PIN_TYPE,
+  isLikeCharLiteral,
+} from 'xod-project';
 
 const parseDec = x => parseInt(x, 10);
 const parseBin = x => parseInt(x, 2);
@@ -44,8 +48,15 @@ const decValueOrDefault = inputStr =>
     parseDec
   )(inputStr);
 
+const escapeSpecialChars = R.cond([
+  [R.equals("'''"), R.always("'\\''")],
+  [R.equals("'\\'"), R.always("'\\\\'")],
+  [R.T, R.identity],
+]);
+
 // :: String -> String
 export default R.cond([
+  [isLikeCharLiteral, escapeSpecialChars],
   // 0b1011 -> 00001011b
   [R.startsWith('0b'), R.pipe(R.drop(2), parseBin, toBin)],
   // 1011b -> 00001011b

--- a/packages/xod-client/test/normalizeByte.spec.js
+++ b/packages/xod-client/test/normalizeByte.spec.js
@@ -32,4 +32,17 @@ describe('normalizeByte', () => {
     test('1111111111b', '11111111b'); // overflow
     test('-101b', '00000000b'); // underflow
   });
+  describe('char', () => {
+    test("'a'", "'a'");
+    test("'\\n'", "'\\n'");
+    // auto-escaping of ''' and '\'
+    test("'''", "'\\''");
+    test("'\\'", "'\\\\'");
+    // invalid input
+    test("''", '00h');
+    test("'a", '00h');
+    test("a'", '00h');
+    test("'a'h", '00h');
+    test("'too many'", '00h');
+  });
 });

--- a/packages/xod-project/src/utils.js
+++ b/packages/xod-project/src/utils.js
@@ -196,6 +196,17 @@ export const isValidNumberDataValue = R.test(numberDataTypeRegExp);
 // getting type from literal value
 //
 
+export const isLikeCharLiteral = def(
+  'isLikeCharLiteral :: String -> Boolean',
+  R.test(/^'\\?.'$/)
+);
+
+const unescapedCharLiterals = ["'''", "'\\'"];
+export const isValidCharLiteral = def(
+  'isValidCharLiteral :: String -> Boolean',
+  R.both(isLikeCharLiteral, R.complement(isAmong(unescapedCharLiterals)))
+);
+
 export const getTypeFromLiteral = def(
   'getTypeFromLiteral :: DataValue -> Either Error DataType',
   literal => {
@@ -210,7 +221,12 @@ export const getTypeFromLiteral = def(
 
     if (R.test(/^".*"$/gi, literal)) return Either.of(CONST.PIN_TYPE.STRING);
 
-    if (R.test(/^[0-9a-f]{2}h|[0,1]{8}b|\d{1,3}d$/gi, literal))
+    if (
+      R.either(
+        isValidCharLiteral,
+        R.test(/^[0-9a-f]{2}h|[0,1]{8}b|\d{1,3}d$/gi)
+      )(literal)
+    )
       return Either.of(CONST.PIN_TYPE.BYTE);
 
     if (isValidNumberDataValue(literal))

--- a/packages/xod-project/test/utils.spec.js
+++ b/packages/xod-project/test/utils.spec.js
@@ -3,6 +3,8 @@ import { assert } from 'chai';
 import shortid from 'shortid';
 
 import * as Utils from '../src/utils';
+import { PIN_TYPE } from '../src/constants';
+import * as Helpers from './helpers';
 
 describe('Utils', () => {
   // transforming node ids
@@ -116,6 +118,64 @@ describe('Utils', () => {
       assert.isFalse(Utils.isValidNumberDataValue('.e5'));
       assert.isFalse(Utils.isValidNumberDataValue('-+56.3'));
       assert.isFalse(Utils.isValidNumberDataValue('--35'));
+    });
+  });
+
+  describe('getTypeFromLiteral', () => {
+    const expectType = (literal, expectedType) =>
+      R.compose(
+        Helpers.expectEitherRight(actualType =>
+          assert.strictEqual(
+            actualType,
+            expectedType,
+            `${literal} should be a ${expectedType}`
+          )
+        ),
+        Utils.getTypeFromLiteral
+      )(literal);
+
+    it('should recognise string literals', () => {
+      expectType('""', PIN_TYPE.STRING);
+      expectType('"Hello there"', PIN_TYPE.STRING);
+    });
+
+    it('should recognise number literals', () => {
+      expectType('0', PIN_TYPE.NUMBER);
+      expectType('111', PIN_TYPE.NUMBER);
+      expectType('123.45', PIN_TYPE.NUMBER);
+      expectType('-50.5', PIN_TYPE.NUMBER);
+      expectType('NaN', PIN_TYPE.NUMBER);
+      // test for isValidNumberDataValue covers the rest
+    });
+
+    it('should recognise boolean literals', () => {
+      expectType('True', PIN_TYPE.BOOLEAN);
+      expectType('False', PIN_TYPE.BOOLEAN);
+    });
+
+    it('should recognise pulse literals', () => {
+      expectType('Never', PIN_TYPE.PULSE);
+      expectType('Continuously', PIN_TYPE.PULSE);
+      expectType('On Boot', PIN_TYPE.PULSE);
+    });
+
+    it('should recognise byte literals', () => {
+      expectType('01011010b', PIN_TYPE.BYTE);
+      expectType('12d', PIN_TYPE.BYTE);
+      expectType('025d', PIN_TYPE.BYTE);
+      expectType('255d', PIN_TYPE.BYTE);
+      expectType('3Ah', PIN_TYPE.BYTE);
+      expectType("'a'", PIN_TYPE.BYTE);
+      expectType("'\\n'", PIN_TYPE.BYTE);
+      expectType("'\\\\'", PIN_TYPE.BYTE);
+      expectType("'\\''", PIN_TYPE.BYTE);
+    });
+
+    it('should recognise port literals', () => {
+      expectType('A0', PIN_TYPE.PORT);
+      expectType('A13', PIN_TYPE.PORT);
+      expectType('D0', PIN_TYPE.PORT);
+      expectType('D13', PIN_TYPE.PORT);
     });
   });
 });


### PR DESCRIPTION
Now in addition to hex, dec and bin literals, you can bind chars into `byte` inputs in the form `'a'` or `'\n'`. Should be very handy for processing strings.
