### PR TITLE
Correct reference to divide node in xod/math/log-bx

### DIFF
--- a/workspace/__lib__/xod/math/log-bx/patch.xodp
+++ b/workspace/__lib__/xod/math/log-bx/patch.xodp
@@ -90,7 +90,7 @@
         "x": 0,
         "y": 204
       },
-      "type": "@/divide"
+      "type": "xod/core/divide"
     },
     {
       "id": "Sy7_XQmkG",


### PR DESCRIPTION
`divide` is in `xod/core`, not `xod/math`
