### PR TITLE
Fix tracking of unsaved changes in desktop IDE

### DIFF
--- a/packages/xod-client-electron/src/view/containers/App.jsx
+++ b/packages/xod-client-electron/src/view/containers/App.jsx
@@ -169,7 +169,7 @@ class App extends client.App {
           throw new Error('Expected projectPath to be present');
         }
 
-        this.saveAs(projectPath, true).catch(noop);
+        this.saveAs(projectPath, true, false).catch(noop);
       });
       ipcRenderer.on(TRIGGER_LOAD_PROJECT, projectPath => {
         if (!projectPath) {

--- a/packages/xod-client/src/core/trackLastSavedChanges.js
+++ b/packages/xod-client/src/core/trackLastSavedChanges.js
@@ -22,7 +22,7 @@ export default function trackLastSavedChanges(state, action) {
       return updateLastSavedProject(state);
     }
     case SAVE_ALL: {
-      if (R.path(['data', 'updateLastSavedProject'], action)) {
+      if (R.path(['payload', 'data', 'updateLastSavedProject'], action)) {
         return updateLastSavedProject(state);
       }
       return state;


### PR DESCRIPTION
After #1282 desktop IDE was always thinking that there are unsaved changes