### PR TITLE
Improve hiding of protruding scrollbars

### DIFF
--- a/packages/xod-client/package.json
+++ b/packages/xod-client/package.json
@@ -33,7 +33,7 @@
     "react-codemirror": "^1.0.0",
     "react-collapsible": "^2.0.3",
     "react-contextmenu": "^2.9.1",
-    "react-custom-scroll": "^2.0.0",
+    "react-custom-scroll": "^3.2.2",
     "react-dnd": "^2.5.1",
     "react-dnd-html5-backend": "^2.5.1",
     "react-dom": "^16.2",

--- a/packages/xod-client/src/core/styles/components/CustomScroll.scss
+++ b/packages/xod-client/src/core/styles/components/CustomScroll.scss
@@ -18,6 +18,13 @@
     overflow-x: hidden;
     overflow-y: scroll;
 
+    &::-webkit-scrollbar {
+      background: transparent;
+      border-color: transparent;
+      box-shadow: none;
+      width: 0;
+    }
+
     &:after{
       content: '';
       position: absolute;

--- a/packages/xod-client/src/core/styles/components/Sidebar.scss
+++ b/packages/xod-client/src/core/styles/components/Sidebar.scss
@@ -98,8 +98,9 @@
 }
 
 
+// Kludge to fix a protruding edge of scrollbar on some OS (Linux)
 .Sidebar .custom-scroll {
   .outer-container { width: 200px; }
-  .inner-container { margin-right: -2em; padding-right: 0; }
-  .content-wrapper { margin-right: 0; padding-right: 0; width: 200px; }
+  .inner-container { margin-right: -100px !important; }
+  .content-wrapper { width: 200px; }
 }

--- a/packages/xod-client/src/editor/components/SuggesterContainer.jsx
+++ b/packages/xod-client/src/editor/components/SuggesterContainer.jsx
@@ -32,7 +32,7 @@ class SuggesterContainer extends React.Component {
 
   getScrollPosition() {
     if (this.scrollRef) {
-      const contentWrapper = this.scrollRef.refs.contentWrapper;
+      const contentWrapper = this.scrollRef.contentWrapper;
 
       const highlighted = contentWrapper.getElementsByClassName(
         'is-highlighted'

--- a/yarn.lock
+++ b/yarn.lock
@@ -9763,9 +9763,9 @@ react-contextmenu@^2.9.1:
     classnames "^2.2.5"
     object-assign "^4.1.0"
 
-react-custom-scroll@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-custom-scroll/-/react-custom-scroll-2.0.1.tgz#4775761a48d66c4b1e576c0705fc6a59fc0d89b6"
+react-custom-scroll@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-custom-scroll/-/react-custom-scroll-3.2.2.tgz#c22dab0c3eab0138cb8d8afd1565c835feb01b6a"
 
 react-dnd-html5-backend@^2.5.1:
   version "2.5.4"


### PR DESCRIPTION
It's an addition to PR #1339.
Did update `react-custom-scroll` and tweak styles.

Tested on Ubuntu 18.04 (FF, Chrome, Electron).