### PR TITLE
Skip clashing pin labels check for expanded variadic patches

### DIFF
--- a/packages/xod-project/src/internal/patchPathUtils.js
+++ b/packages/xod-project/src/internal/patchPathUtils.js
@@ -22,22 +22,25 @@ const alphanumericWithHypens = `${alphanumeric}(-${alphanumeric})*`;
 const alphanumericWithHypensAndCommans = `${alphanumeric}(-${alphanumeric}|,${alphanumeric})*`;
 
 // -$5
-const variadicLevel = '(-\\$\\d+){0,1}';
+const variadicLevel = '(-\\$\\d+)';
+const maybeVariadicLevel = `${variadicLevel}{0,1}`;
 
 // (foo-2-bar,foo-5-bar)
 const types = `(\\(${alphanumericWithHypensAndCommans}\\)){0,1}`;
 
 // foo2(foo-2-bar,foo-5-bar)-$5
 const patchBaseNameRegExp = new RegExp(
-  `^${alphanumericWithHypens}${types}${variadicLevel}$`
+  `^${alphanumericWithHypens}${types}${maybeVariadicLevel}$`
 );
 
 const specializationPatchBasenameRegExp = new RegExp(
-  `^${alphanumericWithHypens}\\(${alphanumericWithHypensAndCommans}\\)${variadicLevel}$`
+  `^${alphanumericWithHypens}\\(${alphanumericWithHypensAndCommans}\\)${maybeVariadicLevel}$`
 );
 
 // foo-2-bar
 const identifierRegExp = new RegExp(`^${alphanumericWithHypens}$`);
+
+const variadicBasenameRegExp = new RegExp(`${variadicLevel}$`);
 
 // =============================================================================
 // Validating functions
@@ -123,4 +126,9 @@ export const isBuiltInLibName = R.equals(TERMINALS_LIB_NAME);
 // :: PatchPath -> Boolean
 export const isSpecializationPatchBasename = R.test(
   specializationPatchBasenameRegExp
+);
+
+export const isExpandedVariadicPatchBasename = R.both(
+  R.test(variadicBasenameRegExp),
+  isValidPatchBasename
 );

--- a/packages/xod-project/src/patchPathUtils.js
+++ b/packages/xod-project/src/patchPathUtils.js
@@ -17,6 +17,7 @@ export {
   isValidIdentifier,
   isValidPatchBasename,
   isSpecializationPatchBasename,
+  isExpandedVariadicPatchBasename,
   isPathLocal,
   isPathLibrary,
   isLibName,

--- a/packages/xod-project/test/patch.spec.js
+++ b/packages/xod-project/test/patch.spec.js
@@ -780,6 +780,39 @@ describe('Patch', () => {
           Patch.validatePinLabels(patchWithClashingPinLabels)
         );
       });
+
+      it('does not complain about duplicate labels of expanded variadic patches', () => {
+        const expandedVariadicPatch = Helper.defaultizePatch({
+          path: '@/my-variadic-$2',
+          nodes: {
+            in: {
+              type: 'xod/patch-nodes/input-boolean',
+              label: 'IN',
+            },
+            foo: {
+              type: 'xod/patch-nodes/input-boolean',
+              label: 'FOO',
+            },
+            'foo-$1': {
+              type: 'xod/patch-nodes/input-boolean',
+              label: 'FOO',
+            },
+            'foo-$2': {
+              type: 'xod/patch-nodes/input-boolean',
+              label: 'FOO',
+            },
+            out: {
+              type: 'xod/patch-nodes/output-boolean',
+              label: 'OUT',
+            },
+          },
+        });
+
+        Helper.expectEitherRight(
+          R.equals(expandedVariadicPatch),
+          Patch.validatePinLabels(expandedVariadicPatch)
+        );
+      });
     });
   });
 

--- a/packages/xod-project/test/patchPathUtils.spec.js
+++ b/packages/xod-project/test/patchPathUtils.spec.js
@@ -94,6 +94,30 @@ describe('PatchPathUtils', () => {
       );
     });
   });
+
+  describe('isExpandedVariadicPatchBasename', () => {
+    it('should ensure that it is a valid basename that contains variadic level suffix', () => {
+      assert.isTrue(PatchPathUtils.isExpandedVariadicPatchBasename('join-$5'));
+      assert.isTrue(
+        PatchPathUtils.isExpandedVariadicPatchBasename('sp(number,string)-$5')
+      );
+
+      assert.isFalse(
+        PatchPathUtils.isExpandedVariadicPatchBasename('my-regular-patch-123')
+      );
+      assert.isFalse(
+        PatchPathUtils.isExpandedVariadicPatchBasename(
+          'some-specialization(number,string)'
+        )
+      );
+      assert.isFalse(
+        PatchPathUtils.isExpandedVariadicPatchBasename(
+          'not-even-a-valid-basename-$b'
+        )
+      );
+    });
+  });
+
   describe('isValidPatchPath', () => {
     it('should accept local paths', () => {
       assert.isTrue(PatchPathUtils.isValidPatchPath('@/some-identifier'));


### PR DESCRIPTION
Duplicate labels in expanded variadics are totally expected, for example: https://github.com/xodio/xod/blob/master/packages/xod-project/test/fixtures/expanding.expected.xodball

Bug was introduced in #1356