### PR TITLE
Get rid of React warning in DebuggerTopPane

### DIFF
--- a/packages/xod-client/src/debugger/containers/DebuggerTopPane.jsx
+++ b/packages/xod-client/src/debugger/containers/DebuggerTopPane.jsx
@@ -2,7 +2,7 @@ import * as R from 'ramda';
 import React from 'react';
 import PropTypes from 'prop-types';
 import $ from 'sanctuary-def';
-import { $Maybe, foldMaybe } from 'xod-func-tools';
+import { $Maybe, foldMaybe, noop } from 'xod-func-tools';
 import { Icon } from 'react-fa';
 import { shouldUpdate } from 'recompose';
 
@@ -56,12 +56,13 @@ DebuggerTopPane.propTypes = {
   currentTab: sanctuaryPropType($Maybe($.Object)),
   isDebugSessionRunning: PropTypes.bool,
   isDebugSessionOutdated: PropTypes.bool,
-  stopDebuggerSession: PropTypes.func.isRequired,
+  stopDebuggerSession: PropTypes.func,
 };
 
 DebuggerTopPane.defaultProps = {
   isDebugSessionRunning: false,
   isDebugSessionOutdated: false,
+  stopDebuggerSession: noop,
 };
 
 export default shouldUpdate(


### PR DESCRIPTION
My bad. It was introduced in the PR #1374 🙈 