### PR TITLE
Avoid superfluous word clipping in node labels

### DIFF
--- a/packages/xod-client/src/core/styles/components/Node.scss
+++ b/packages/xod-client/src/core/styles/components/Node.scss
@@ -86,7 +86,7 @@
   .nodeLabel {
     display: block;
     text-align: center;
-    padding: 0 2px;
+    padding: 0;
     font-size: 12px;
     font-family: $font-family-condensed;
     color: $color-canvas-face-text;


### PR DESCRIPTION
The bug was introduced by me in PR #1375 😬 