### PR TITLE
Optimize patch search and suggester

### DIFF
--- a/packages/xod-client/src/editor/components/Suggester.jsx
+++ b/packages/xod-client/src/editor/components/Suggester.jsx
@@ -129,10 +129,10 @@ class Suggester extends React.Component {
     const { searchPatches } = this.props;
     const inputValue = value.trim().toLowerCase();
 
-    if (inputValue.length === 0) {
+    if (inputValue.length <= 1) {
       return [];
     }
-    return searchPatches(regExpEscape(inputValue));
+    return R.compose(R.take(20), searchPatches, regExpEscape)(inputValue);
   }
 
   storeRef(autosuggest) {

--- a/packages/xod-client/src/editor/components/Suggester.jsx
+++ b/packages/xod-client/src/editor/components/Suggester.jsx
@@ -126,13 +126,13 @@ class Suggester extends React.Component {
   }
 
   getSuggestions(value) {
-    const { index } = this.props;
+    const { searchPatches } = this.props;
     const inputValue = value.trim().toLowerCase();
 
     if (inputValue.length === 0) {
       return [];
     }
-    return index.search(regExpEscape(inputValue));
+    return searchPatches(regExpEscape(inputValue));
   }
 
   storeRef(autosuggest) {
@@ -247,7 +247,7 @@ Suggester.defaultProps = {
 
 Suggester.propTypes = {
   extraClassName: PropTypes.string,
-  index: PropTypes.object,
+  searchPatches: PropTypes.func.isRequired,
   onAddNode: PropTypes.func.isRequired,
   onHighlight: PropTypes.func,
   onBlur: PropTypes.func,

--- a/packages/xod-client/src/editor/containers/Editor.jsx
+++ b/packages/xod-client/src/editor/containers/Editor.jsx
@@ -201,11 +201,11 @@ class Editor extends React.Component {
   }
 
   render() {
-    const { patchesIndex } = this.props;
+    const { searchPatches } = this.props;
 
     const suggester = this.props.suggesterIsVisible ? (
       <Suggester
-        index={patchesIndex}
+        searchPatches={searchPatches}
         onAddNode={this.onAddNode}
         onBlur={this.hideSuggester}
         onHighlight={this.props.actions.highlightSugessterItem}
@@ -270,7 +270,7 @@ Editor.propTypes = {
   project: PropTypes.object,
   currentTab: sanctuaryPropType($Maybe($.Object)),
   implEditorTabs: PropTypes.array,
-  patchesIndex: PropTypes.object,
+  searchPatches: PropTypes.func.isRequired,
   isHelpboxVisible: PropTypes.bool,
   isDebugSessionRunning: PropTypes.bool,
   isDebugSessionOutdated: PropTypes.bool,
@@ -311,7 +311,7 @@ const mapStateToProps = R.applySpec({
   currentPatchPath: EditorSelectors.getCurrentPatchPath,
   currentTab: EditorSelectors.getCurrentTab,
   implEditorTabs: EditorSelectors.getImplEditorTabs,
-  patchesIndex: ProjectSelectors.getPatchSearchIndex,
+  searchPatches: ProjectSelectors.getSearchPatchesFn,
   suggesterIsVisible: EditorSelectors.isSuggesterVisible,
   suggesterPlacePosition: EditorSelectors.getSuggesterPlacePosition,
   isLibSuggesterVisible: EditorSelectors.isLibSuggesterVisible,

--- a/packages/xod-client/src/hinting/actionType.js
+++ b/packages/xod-client/src/hinting/actionType.js
@@ -1,0 +1,1 @@
+export default 'UPDATE_HINTING';

--- a/packages/xod-client/src/hinting/actionTypes.js
+++ b/packages/xod-client/src/hinting/actionTypes.js
@@ -1,6 +1,0 @@
-export const UPDATE_DEDUCED_TYPES = 'UPDATE_DEDUCED_TYPES';
-export const UPDATE_ERRORS = 'UPDATE_ERRORS';
-
-// Just for optimization: call next one once instead of calling two previvous actions
-// For flexibility: keep them
-export const UPDATE_HINTING = 'UPDATE_HINTING';

--- a/packages/xod-client/src/hinting/actionUtils.js
+++ b/packages/xod-client/src/hinting/actionUtils.js
@@ -1,0 +1,15 @@
+import * as R from 'ramda';
+import * as XP from 'xod-project';
+import { maybePath, isAmong } from 'xod-func-tools';
+
+// :: Action -> Maybe PatchPath
+export const getActingPatchPath = maybePath(['payload', 'patchPath']);
+
+// :: Action -> Patch -> Boolean
+export const bulkActionChangesTerminalNodes = R.curry((action, patch) =>
+  R.compose(
+    R.any(XP.isTerminalNode),
+    R.filter(R.pipe(XP.getNodeId, isAmong(action.payload.nodeIds))),
+    XP.listNodes
+  )(patch)
+);

--- a/packages/xod-client/src/hinting/actions.js
+++ b/packages/xod-client/src/hinting/actions.js
@@ -1,6 +1,6 @@
 import UPDATE_HINTING from './actionType';
 
-export default (deducedTypes, errors) => ({
+export default (deducedTypes, errors, patchSearchData) => ({
   type: UPDATE_HINTING,
-  payload: { deducedTypes, errors },
+  payload: { deducedTypes, errors, patchSearchData },
 });

--- a/packages/xod-client/src/hinting/actions.js
+++ b/packages/xod-client/src/hinting/actions.js
@@ -1,16 +1,6 @@
-import * as AT from './actionTypes';
+import UPDATE_HINTING from './actionType';
 
-export const updateDeducedTypes = deducedTypes => ({
-  type: AT.UPDATE_DEDUCED_TYPES,
-  payload: deducedTypes,
-});
-
-export const updateErrors = errors => ({
-  type: AT.UPDATE_ERRORS,
-  payload: errors,
-});
-
-export const updateHinting = (deducedTypes, errors) => ({
-  type: AT.UPDATE_HINTING,
+export default (deducedTypes, errors) => ({
+  type: UPDATE_HINTING,
   payload: { deducedTypes, errors },
 });

--- a/packages/xod-client/src/hinting/errorCollectors.js
+++ b/packages/xod-client/src/hinting/errorCollectors.js
@@ -62,5 +62,3 @@ export const getAllErrorsForPatch = R.curry((patchPath, errors) =>
     maybeProp(patchPath)
   )(errors)
 );
-
-export const getActingPatchPath = maybePath(['payload', 'patchPath']);

--- a/packages/xod-client/src/hinting/middleware.js
+++ b/packages/xod-client/src/hinting/middleware.js
@@ -1,9 +1,15 @@
+import { notEquals } from 'xod-func-tools';
+
 import { getProject } from '../project/selectors';
 
-import { getDeducedTypes, getErrors } from './selectors';
+import { getDeducedTypes, getErrors, getPatchSearchData } from './selectors';
 import updateHinting from './actions';
 import { shallDeduceTypes, deduceTypes } from './typeDeduction';
 import { shallValidate, validateProject } from './validation';
+import {
+  shallUpdatePatchSearchData,
+  getNewPatchSearchData,
+} from './patchSearchData';
 
 // =============================================================================
 //
@@ -33,12 +39,20 @@ export default store => next => action => {
     : prevErrors;
   const willUpdateErrors = notEquals(prevErrors, nextErrors);
 
+  // Patch Search Indexing
+  const prevSearchIndex = getPatchSearchData(newState);
+  const nextSearchIndex = shallUpdatePatchSearchData(newProject, action)
+    ? getNewPatchSearchData(prevSearchIndex, newProject, action)
+    : prevSearchIndex;
+  const willUpdateSearchIndex = notEquals(prevSearchIndex, nextSearchIndex);
+
   // Dispatch changes, if needed
-  if (willUpdateDeducedTypes || willUpdateErrors) {
+  if (willUpdateDeducedTypes || willUpdateErrors || willUpdateSearchIndex) {
     store.dispatch(
       updateHinting(
         willUpdateDeducedTypes ? nextDeducedTypes : null,
-        willUpdateErrors ? nextErrors : null
+        willUpdateErrors ? nextErrors : null,
+        willUpdateSearchIndex ? nextSearchIndex : null
       )
     );
   }

--- a/packages/xod-client/src/hinting/middleware.js
+++ b/packages/xod-client/src/hinting/middleware.js
@@ -3,7 +3,7 @@ import { notEquals } from 'xod-func-tools';
 import { getProject } from '../project/selectors';
 
 import { getDeducedTypes, getErrors } from './selectors';
-import { updateDeducedTypes, updateErrors, updateHinting } from './actions';
+import updateHinting from './actions';
 import { shallDeduceTypes, deduceTypes } from './typeDeduction';
 import { shallValidate, validateProject } from './validation';
 
@@ -33,12 +33,13 @@ export default store => next => action => {
     : prevErrors;
   const willUpdateErrors = notEquals(prevErrors, nextErrors);
 
-  if (willUpdateDeducedTypes && willUpdateErrors) {
-    store.dispatch(updateHinting(nextDeducedTypes, nextErrors));
-  } else if (willUpdateDeducedTypes) {
-    store.dispatch(updateDeducedTypes(nextDeducedTypes));
-  } else if (willUpdateErrors) {
-    store.dispatch(updateErrors(nextErrors));
+  if (willUpdateDeducedTypes || willUpdateErrors) {
+    store.dispatch(
+      updateHinting(
+        willUpdateDeducedTypes ? nextDeducedTypes : null,
+        willUpdateErrors ? nextErrors : null
+      )
+    );
   }
 
   return act;

--- a/packages/xod-client/src/hinting/middleware.js
+++ b/packages/xod-client/src/hinting/middleware.js
@@ -1,5 +1,3 @@
-import { notEquals } from 'xod-func-tools';
-
 import { getProject } from '../project/selectors';
 
 import { getDeducedTypes, getErrors } from './selectors';
@@ -21,18 +19,21 @@ export default store => next => action => {
 
   if (oldProject === newProject) return newState;
 
+  // Type deducing
   const prevDeducedTypes = getDeducedTypes(newState);
   const nextDeducedTypes = shallDeduceTypes(newProject, action)
     ? deduceTypes(newProject, action, prevDeducedTypes)
     : prevDeducedTypes;
   const willUpdateDeducedTypes = notEquals(prevDeducedTypes, nextDeducedTypes);
 
+  // Validation
   const prevErrors = getErrors(newState);
   const nextErrors = shallValidate(action, newProject, nextDeducedTypes)
     ? validateProject(action, newProject, nextDeducedTypes, prevErrors)
     : prevErrors;
   const willUpdateErrors = notEquals(prevErrors, nextErrors);
 
+  // Dispatch changes, if needed
   if (willUpdateDeducedTypes || willUpdateErrors) {
     store.dispatch(
       updateHinting(

--- a/packages/xod-client/src/hinting/patchSearchData.js
+++ b/packages/xod-client/src/hinting/patchSearchData.js
@@ -1,0 +1,93 @@
+import * as R from 'ramda';
+import * as XP from 'xod-project';
+import { isAmong, foldMaybe, notNil } from 'xod-func-tools';
+import { createIndexData } from 'xod-patch-search';
+
+import * as PAT from '../project/actionTypes';
+
+// PatchSearchData :: { path: String, keywords: [String], desription: String, fullDescription: string }
+
+// =============================================================================
+//
+// Utils
+//
+// =============================================================================
+
+// :: [PatchSearchData] -> Patch -> [PatchSearchData]
+const createPatchSearchDataForPatch = R.curry((prevIndex, patch) =>
+  R.compose(
+    newPatchData =>
+      R.compose(
+        R.concat(newPatchData),
+        R.reject(R.propEq('path', newPatchData[0].path))
+      )(prevIndex),
+    createIndexData,
+    R.of
+  )(patch)
+);
+
+// =============================================================================
+//
+// Api
+//
+// =============================================================================
+
+// :: Project -> Action -> Boolean
+export const shallUpdatePatchSearchData = R.curry((project, action) =>
+  // Blacklist
+  // Do not update index for these action types:
+  R.propSatisfies(
+    R.complement(
+      isAmong([
+        PAT.PROJECT_UPDATE_META,
+        PAT.NODE_CHANGE_ARITY_LEVEL,
+        PAT.NODE_RESIZE,
+        PAT.COMMENT_ADD,
+        PAT.COMMENT_RESIZE,
+        PAT.COMMENT_SET_CONTENT,
+        PAT.PATCH_NATIVE_IMPLEMENTATION_UPDATE,
+        PAT.NODE_UPDATE_PROPERTY,
+        PAT.BULK_MOVE_NODES_AND_COMMENTS,
+        PAT.NODE_ADD,
+        PAT.BULK_DELETE_ENTITIES,
+        // But update for:
+        // PAT.PATCH_DESCRIPTION_UPDATE,
+        // PAT.PATCH_ADD,
+        // PAT.PROJECT_CREATE,
+        // PAT.PROJECT_OPEN,
+        // PAT.PROJECT_IMPORT,
+        // PAT.PATCH_RENAME,
+      ])
+    ),
+    'type'
+  )(action)
+);
+
+// :: [PatchSearchData] -> Project -> Action -> [PatchSearchData]
+export const getNewPatchSearchData = R.curry((prevIndex, project, action) =>
+  R.cond([
+    [
+      R.propEq('type', PAT.PATCH_RENAME),
+      () =>
+        R.compose(
+          foldMaybe(
+            prevIndex,
+            R.compose(
+              R.reject(R.propEq('path', action.payload.oldPatchPath)),
+              createPatchSearchDataForPatch(prevIndex)
+            )
+          ),
+          XP.getPatchByPath(action.payload.newPatchPath)
+        )(project),
+    ],
+    [
+      R.pathSatisfies(notNil, ['payload', 'patchPath']),
+      R.compose(
+        foldMaybe(prevIndex, createPatchSearchDataForPatch(prevIndex)),
+        XP.getPatchByPath(R.__, project),
+        R.path(['payload', 'patchPath'])
+      ),
+    ],
+    [R.T, () => R.compose(createIndexData, XP.listPatches)(project)],
+  ])(action)
+);

--- a/packages/xod-client/src/hinting/reducer.js
+++ b/packages/xod-client/src/hinting/reducer.js
@@ -1,21 +1,23 @@
 import * as R from 'ramda';
 
 import initialState from './state';
-import * as AT from './actionTypes';
+import UPDATE_HINTING from './actionType';
 import { mergeErrors } from './validation';
 
 const errorsLens = R.lensProp('errors');
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case AT.UPDATE_DEDUCED_TYPES:
-      return R.assoc('deducedTypes', action.payload, state);
-    case AT.UPDATE_ERRORS:
-      return R.over(errorsLens, mergeErrors(R.__, action.payload), state);
-    case AT.UPDATE_HINTING:
+    case UPDATE_HINTING:
       return R.compose(
-        R.assoc('deducedTypes', action.payload.deducedTypes),
-        R.over(errorsLens, mergeErrors(R.__, action.payload.errors))
+        R.when(
+          () => action.payload.deducedTypes,
+          R.assoc('deducedTypes', action.payload.deducedTypes)
+        ),
+        R.when(
+          () => action.payload.errors,
+          R.over(errorsLens, mergeErrors(R.__, action.payload.errors))
+        )
       )(state);
     default:
       return state;

--- a/packages/xod-client/src/hinting/selectors.js
+++ b/packages/xod-client/src/hinting/selectors.js
@@ -15,6 +15,11 @@ export const getDeducedTypes = R.compose(
   getHintingState
 );
 
+export const getPatchSearchData = R.compose(
+  R.prop('patchSearchData'),
+  getHintingState
+);
+
 export const getErrors = R.compose(R.prop('errors'), getHintingState);
 
 // :: PatchPath -> NodeId -> PatchPath -> Map PatchPath PatchErrors -> [Error]

--- a/packages/xod-client/src/hinting/state.js
+++ b/packages/xod-client/src/hinting/state.js
@@ -32,4 +32,15 @@ export default {
     },
     **/
   },
+  patchSearchData: [
+    /**
+     * {
+     *   path: PatchPath,
+     *   lib: String,
+     *   keywords: [String],
+     *   description: String,
+     *   fullDescription: String,
+     * },
+     */
+  ],
 };

--- a/packages/xod-client/src/hinting/typeDeduction.js
+++ b/packages/xod-client/src/hinting/typeDeduction.js
@@ -11,7 +11,7 @@ import {
 
 import * as PAT from '../project/actionTypes';
 
-import { getActingPatchPath } from './errorCollectors';
+import { getActingPatchPath } from './actionUtils';
 
 // =============================================================================
 //

--- a/packages/xod-client/src/hinting/validation.internal.js
+++ b/packages/xod-client/src/hinting/validation.internal.js
@@ -3,7 +3,7 @@ import * as XP from 'xod-project';
 import { foldMaybeWith } from 'xod-func-tools';
 
 import { defaultValidateFunctions } from './validation.funcs';
-import { getActingPatchPath } from './errorCollectors';
+import { getActingPatchPath } from './actionUtils';
 
 // PinValidateFn :: Patch -> Project -> Map PinKey PinErrors
 // NodeValidateFn :: Patch -> Project -> Map NodeId NodeErrors

--- a/packages/xod-client/src/hinting/validation.js
+++ b/packages/xod-client/src/hinting/validation.js
@@ -1,6 +1,6 @@
 import * as R from 'ramda';
 import * as XP from 'xod-project';
-import { foldMaybe, catMaybies, isAmong } from 'xod-func-tools';
+import { foldMaybe, catMaybies } from 'xod-func-tools';
 
 import * as PAT from '../project/actionTypes';
 import * as EAT from '../editor/actionTypes';
@@ -21,6 +21,7 @@ import {
   validateBoundValues,
   validateLinkPins,
 } from './validation.funcs';
+import { bulkActionChangesTerminalNodes } from './actionUtils';
 
 /**
  * HOW IT WORKS AND HOW TO MAINTAIN IT
@@ -105,14 +106,7 @@ const shallValidateFunctions = {
     return R.compose(
       foldMaybe(
         false,
-        R.both(
-          XP.isVariadicPatch,
-          R.compose(
-            R.all(R.pipe(XP.getNodeType, XP.isTerminalPatchPath)),
-            R.filter(R.pipe(XP.getNodeId, isAmong(action.payload.nodeIds))),
-            XP.listNodes
-          )
-        )
+        R.both(XP.isVariadicPatch, bulkActionChangesTerminalNodes(action))
       ),
       XP.getPatchByPath(action.payload.patchPath)
     )(project);

--- a/packages/xod-client/src/project/actions.js
+++ b/packages/xod-client/src/project/actions.js
@@ -168,7 +168,7 @@ export const deletePatch = patchPath => ({
 export const updatePatchDescription = (patchDescription, patchPath) => ({
   type: ActionType.PATCH_DESCRIPTION_UPDATE,
   payload: {
-    path: patchPath,
+    patchPath,
     description: patchDescription,
   },
 });

--- a/packages/xod-client/src/project/reducer.js
+++ b/packages/xod-client/src/project/reducer.js
@@ -171,8 +171,8 @@ export default (state = {}, action) => {
     }
 
     case AT.PATCH_DESCRIPTION_UPDATE: {
-      const { path, description } = action.payload;
-      const patchLens = XP.lensPatch(path);
+      const { patchPath, description } = action.payload;
+      const patchLens = XP.lensPatch(patchPath);
       return R.over(patchLens, XP.setPatchDescription(description), state);
     }
 

--- a/packages/xod-client/test/hinting.spec.js
+++ b/packages/xod-client/test/hinting.spec.js
@@ -17,9 +17,11 @@ import {
   openProject,
   updateProjectMeta,
   addPatch,
+  renamePatch,
   updatePatchDescription,
   updateNodeProperty,
   bulkMoveNodesAndComments,
+  addNode,
 } from '../src/project/actions';
 import * as PAT from '../src/project/actionTypes';
 
@@ -43,12 +45,15 @@ const assertActionUpdatesErrors = action =>
     'Expected an action that updates hinting'
   );
 
-// :: Action -> ErrorsUpdateData
+// :: Action -> Nullable ErrorsUpdateData
 const getErrorsUpdateData = action =>
   R.cond([
     [R.propEq('type', UPDATE_HINTING), R.path(['payload', 'errors'])],
     [R.T, assertActionUpdatesErrors],
   ])(action);
+
+// :: Action -> Nullable [PatchSearchData]
+const getPatchSearchData = R.path(['payload', 'patchSearchData']);
 
 const assertPolicyEquals = (policy, action) => {
   const errData = getErrorsUpdateData(action);
@@ -62,7 +67,17 @@ const assertErrorsWith = R.curry((assertsFn, action) =>
   )
 );
 
+// :: (Function with asserts) -> Action -> _
+const assertPatchSearchDataWith = R.curry((assertsFn, action) =>
+  R.compose(data => assertsFn(data), getPatchSearchData)(action)
+);
+
 const assertErrorsUnchanged = R.compose(assert.isNull, getErrorsUpdateData);
+
+const assertPatchSearchDataUnchanged = R.compose(
+  assert.isNull,
+  getPatchSearchData
+);
 
 // =============================================================================
 //
@@ -74,22 +89,25 @@ describe('Hinting', () => {
   let store;
   let dispatchedActions = [];
 
+  const createMockStore = () =>
+    createStore(
+      generateReducers({}),
+      initialState,
+      applyMiddleware(
+        thunk,
+        hintingMiddleware,
+        // Next middleware collects dispatched actions for testing purposes
+        () => next => action => {
+          dispatchedActions = R.append(action, dispatchedActions);
+          return next(action);
+        }
+      )
+    );
+
   describe('Validation', () => {
     beforeEach(() => {
       dispatchedActions = [];
-      store = createStore(
-        generateReducers({}),
-        initialState,
-        applyMiddleware(
-          thunk,
-          hintingMiddleware,
-          // Next middleware collects dispatched actions for testing purposes
-          () => next => action => {
-            dispatchedActions = R.append(action, dispatchedActions);
-            return next(action);
-          }
-        )
-      );
+      store = createMockStore();
     });
 
     it('validates all patches on creating new project', () => {
@@ -235,6 +253,59 @@ describe('Hinting', () => {
           dispatchedActions[0]
         );
       });
+    });
+  });
+
+  describe('Patch Search Data', () => {
+    beforeEach(() => {
+      dispatchedActions = [];
+      store = createMockStore();
+    });
+
+    it('updates data on creating new project', () => {
+      store.dispatch(createProject());
+      assert.lengthOf(dispatchedActions, 2);
+      assertPatchSearchDataWith(assert.isNotEmpty, dispatchedActions[1]);
+    });
+
+    it('updates data on changing patch description', () => {
+      store.dispatch(updatePatchDescription('yo', '@/main'));
+      assert.lengthOf(dispatchedActions, 2);
+      assertActionTypeEqual(PAT.PATCH_DESCRIPTION_UPDATE, dispatchedActions[0]);
+      assertErrorsUnchanged(dispatchedActions[1]);
+      assertPatchSearchDataWith(
+        R.compose(
+          desc => assert.strictEqual(desc, 'yo'),
+          R.prop('description'),
+          R.find(R.propEq('path', '@/main'))
+        ),
+        dispatchedActions[1]
+      );
+    });
+
+    it('updates data on renaming patch', () => {
+      store.dispatch(renamePatch('@/main', 'new-one'));
+      assert.lengthOf(dispatchedActions, 2);
+      assertPatchSearchDataWith(data => {
+        assert.notExists(R.find(R.propEq('path', '@/main'), data));
+        assert.exists(R.find(R.propEq('path', '@/new-one'), data));
+      }, dispatchedActions[1]);
+    });
+
+    it('updates data on adding new patch', () => {
+      store.dispatch(addPatch('hey-ho'));
+      assert.lengthOf(dispatchedActions, 2);
+      assertPatchSearchDataWith(data => {
+        assert.exists(R.find(R.propEq('path', '@/hey-ho'), data));
+      }, dispatchedActions[1]);
+    });
+
+    it('do not updates data on node add', () => {
+      store.dispatch(
+        addNode('xod/patch-nodes/input-number', { x: 0, y: 0 }, '@/main')
+      );
+      assert.lengthOf(dispatchedActions, 2);
+      assertPatchSearchDataUnchanged(dispatchedActions[1]);
     });
   });
 });

--- a/packages/xod-client/test/hinting.spec.js
+++ b/packages/xod-client/test/hinting.spec.js
@@ -62,6 +62,8 @@ const assertErrorsWith = R.curry((assertsFn, action) =>
   )
 );
 
+const assertErrorsUnchanged = R.compose(assert.isNull, getErrorsUpdateData);
+
 // =============================================================================
 //
 // Tests
@@ -141,8 +143,9 @@ describe('Hinting', () => {
 
     it('do not validates anything on the patch description change', () => {
       store.dispatch(updatePatchDescription('yo', '@/main'));
-      assert.lengthOf(dispatchedActions, 1);
+      assert.lengthOf(dispatchedActions, 2);
       assertActionTypeEqual(PAT.PATCH_DESCRIPTION_UPDATE, dispatchedActions[0]);
+      assertErrorsUnchanged(dispatchedActions[1]);
     });
 
     describe('node property update', () => {

--- a/packages/xod-client/test/hinting.spec.js
+++ b/packages/xod-client/test/hinting.spec.js
@@ -25,7 +25,7 @@ import * as PAT from '../src/project/actionTypes';
 
 import { getProject } from '../src/project/selectors';
 
-import * as HAT from '../src/hinting/actionTypes';
+import UPDATE_HINTING from '../src/hinting/actionType';
 import { UPDATE_ERRORS_POLICY as POLICY } from '../src/hinting/validation.internal';
 
 // =============================================================================
@@ -37,17 +37,16 @@ import { UPDATE_ERRORS_POLICY as POLICY } from '../src/hinting/validation.intern
 const assertActionTypeEqual = (type, action) => assert.equal(action.type, type);
 
 const assertActionUpdatesErrors = action =>
-  assert.oneOf(
+  assert.equal(
     action.type,
-    [HAT.UPDATE_ERRORS, HAT.UPDATE_HINTING],
-    'Expected an action that updates errors'
+    UPDATE_HINTING,
+    'Expected an action that updates hinting'
   );
 
 // :: Action -> ErrorsUpdateData
 const getErrorsUpdateData = action =>
   R.cond([
-    [R.propEq('type', HAT.UPDATE_HINTING), R.path(['payload', 'errors'])],
-    [R.propEq('type', HAT.UPDATE_ERRORS), R.prop('payload')],
+    [R.propEq('type', UPDATE_HINTING), R.path(['payload', 'errors'])],
     [R.T, assertActionUpdatesErrors],
   ])(action);
 

--- a/packages/xod-project/src/node.js
+++ b/packages/xod-project/src/node.js
@@ -8,6 +8,7 @@ import { def } from './types';
 import {
   isInputTerminalPath,
   isOutputTerminalPath,
+  isTerminalPatchPath,
   getTerminalDataType,
   isPathLocal,
   getBaseName,
@@ -212,6 +213,16 @@ export const isInputPinNode = def(
 export const isOutputPinNode = def(
   'isOutputPinNode :: Node -> Boolean',
   R.compose(isOutputTerminalPath, getNodeType)
+);
+
+/**
+ * @function isTerminalNode
+ * @param {Node} node
+ * @returns {boolean}
+ */
+export const isTerminalNode = def(
+  'isTerminalNode :: Node -> Boolean',
+  R.compose(isTerminalPatchPath, getNodeType)
 );
 
 /**


### PR DESCRIPTION
There is no issue.

It optimizes the patch search engine by:
- move patch search data into `hinting` branch of the state and update it by middleware, instead of selectors
- update patch search data only on some actions (like `PATCH_DESCRIPTION_UPDATE` or `PROJECT_OPEN`).
- and update search data partially if it possible (updates only patch description, rename patch or add the new one — update only its search data).
- make `searchPatches` function pure and memoize it once
- Suggester component shows only 20 best search results
- Suggester searches when User types at least two symbols

In numbers:
- **Every change** on the patch will not call updating patch search index: ~53ms -> 0ms
- Little changes (description, rename, add): ~53ms -> ~2.5ms
- Change of the entire set of the patches (open/create a project): ~53ms -> ~23.5ms
- Suggester show first results faster on ~100ms