### PR TITLE
Make possible to reopen project with the same file path in browser IDE

### DIFF
--- a/packages/xod-client-browser/src/containers/App.jsx
+++ b/packages/xod-client-browser/src/containers/App.jsx
@@ -134,6 +134,10 @@ class App extends client.App {
 
     reader.onload = e => {
       this.onLoad(e.target.result);
+
+      // drop the value of the file input to make possible to open
+      // the project with the same path again
+      this.menuRefs.openProject.value = '';
     };
 
     reader.readAsText(file);


### PR DESCRIPTION
There is no issue.
I found this bug when I test XOD in the browser version.

**How to reproduce**
1. Open a browser version of XOD IDE
2. Open some xodball
3. Make any change
4. Try to open the same xodball

**Expected**
It opens...

**Actual**
Nothing changed.