### PR TITLE
Fix label margins to fit labels with four characters

### DIFF
--- a/packages/xod-client/src/core/styles/components/Node.scss
+++ b/packages/xod-client/src/core/styles/components/Node.scss
@@ -79,7 +79,8 @@
     justify-content: center;
 
     // move from under pins
-    margin: 12px 4px;
+    // leave 1px margin on the sides to avoid "gluing" of two nearest labels
+    margin: 12px 1px;
     height: calc(100% - 24px);
   }
 


### PR DESCRIPTION
It fixes #1417.
But one important thing, without margins at all it still not fit "WWWW" 😬 