### PR TITLE
Fix screenshoter script for docs to run properly on MacOS

### DIFF
--- a/tools/update-docs-screenshots.sh
+++ b/tools/update-docs-screenshots.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
-export SHOT="$(dirname "$(readlink -f "$0")")/screenshot-xodball"
+SHOT="$(cd "$(dirname "$0")"; pwd)/screenshot-xodball"
+export SHOT
 find . -iname "update-screenshots.sh" \
   -execdir sh -c 'pwd && ./update-screenshots.sh' \;


### PR DESCRIPTION
`readlink` haven't flag `-f` on MacOS.
And it is not needed unless we run it through a symlink.
So I just replaced it with `$0`.