### PR TITLE
Deprecate xod/uart/begin, call begin right in constructor nodes

### DIFF
--- a/workspace/__lib__/xod/uart/begin/patch.xodp
+++ b/workspace/__lib__/xod/uart/begin/patch.xodp
@@ -12,6 +12,15 @@
       "type": "xod/patch-nodes/output-pulse"
     },
     {
+      "description": "Just use `uart` constructor nodes directly, they now have `INIT` and `DONE` pins to begin communication",
+      "id": "BkpwfDI_X",
+      "position": {
+        "x": 136,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/deprecated"
+    },
+    {
       "boundLiterals": {
         "__out__": "On Boot"
       },

--- a/workspace/__lib__/xod/uart/example-print/patch.xodp
+++ b/workspace/__lib__/xod/uart/example-print/patch.xodp
@@ -12,17 +12,6 @@
       }
     },
     {
-      "id": "BJ1MgIXhvWm",
-      "input": {
-        "nodeId": "S1xgIQ3wbQ",
-        "pinKey": "HkeKDhI-7"
-      },
-      "output": {
-        "nodeId": "BJXx8Q2vWQ",
-        "pinKey": "rycxytIZQ"
-      }
-    },
-    {
       "id": "BJLNeIm3v-7",
       "input": {
         "nodeId": "SJ-WeI72D-7",
@@ -34,17 +23,6 @@
       }
     },
     {
-      "id": "BJO4lLQ2v-7",
-      "input": {
-        "nodeId": "rk1bg8m3vbm",
-        "pinKey": "HkeKDhI-7"
-      },
-      "output": {
-        "nodeId": "BJXx8Q2vWQ",
-        "pinKey": "rycxytIZQ"
-      }
-    },
-    {
       "id": "Bk-MgUQ2vbm",
       "input": {
         "nodeId": "S1xgIQ3wbQ",
@@ -53,6 +31,28 @@
       "output": {
         "nodeId": "S1wlL7nPbQ",
         "pinKey": "Hkeetvn8-Q"
+      }
+    },
+    {
+      "id": "Bk3BPRv8_X",
+      "input": {
+        "nodeId": "B1ebg8Xnwbm",
+        "pinKey": "HkeKDhI-7"
+      },
+      "output": {
+        "nodeId": "S1jSD0PUO7",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "BkMgHPCP8_m",
+      "input": {
+        "nodeId": "HyQZlImnvWm",
+        "pinKey": "HkeKDhI-7"
+      },
+      "output": {
+        "nodeId": "Hyblrv0PLuX",
+        "pinKey": "__out__"
       }
     },
     {
@@ -100,14 +100,25 @@
       }
     },
     {
-      "id": "Byf4e8Q3D-Q",
+      "id": "H1ASDAvIOQ",
       "input": {
-        "nodeId": "H1plx87hDZX",
+        "nodeId": "BkHWx8m3vWm",
         "pinKey": "HkeKDhI-7"
       },
       "output": {
+        "nodeId": "SJTSwAvIdX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "H1VOCvUOm",
+      "input": {
         "nodeId": "BJXx8Q2vWQ",
-        "pinKey": "rycxytIZQ"
+        "pinKey": "S1gjHAPL_7"
+      },
+      "output": {
+        "nodeId": "SJlSN2v-m",
+        "pinKey": "Bk4gU0drwJ-"
       }
     },
     {
@@ -119,17 +130,6 @@
       "output": {
         "nodeId": "BJEPQ2PWQ",
         "pinKey": "rkl6IK3L-7"
-      }
-    },
-    {
-      "id": "H1rBe8mnvbX",
-      "input": {
-        "nodeId": "HyD-xLQnP-7",
-        "pinKey": "HkeKDhI-7"
-      },
-      "output": {
-        "nodeId": "BJXx8Q2vWQ",
-        "pinKey": "rycxytIZQ"
       }
     },
     {
@@ -155,17 +155,6 @@
       }
     },
     {
-      "id": "HkIv7nDWX",
-      "input": {
-        "nodeId": "BJEPQ2PWQ",
-        "pinKey": "HkT8KhLWm"
-      },
-      "output": {
-        "nodeId": "BJXx8Q2vWQ",
-        "pinKey": "rycxytIZQ"
-      }
-    },
-    {
       "id": "S1-Ne8mhDWQ",
       "input": {
         "nodeId": "H1plx87hDZX",
@@ -174,39 +163,6 @@
       "output": {
         "nodeId": "S1xgIQ3wbQ",
         "pinKey": "Hkeetvn8-Q"
-      }
-    },
-    {
-      "id": "S18BgLmnDbX",
-      "input": {
-        "nodeId": "BkYWgUQ2DW7",
-        "pinKey": "HkeKDhI-7"
-      },
-      "output": {
-        "nodeId": "BJXx8Q2vWQ",
-        "pinKey": "rycxytIZQ"
-      }
-    },
-    {
-      "id": "S1Y4xU72DZm",
-      "input": {
-        "nodeId": "B1ebg8Xnwbm",
-        "pinKey": "HkeKDhI-7"
-      },
-      "output": {
-        "nodeId": "BJXx8Q2vWQ",
-        "pinKey": "rycxytIZQ"
-      }
-    },
-    {
-      "id": "S1dDQnwZ7",
-      "input": {
-        "nodeId": "BJEPQ2PWQ",
-        "pinKey": "H1VpIKnLb7"
-      },
-      "output": {
-        "nodeId": "HkeL7nvZ7",
-        "pinKey": "B1SyPhUWm"
       }
     },
     {
@@ -221,14 +177,25 @@
       }
     },
     {
-      "id": "SJNre8Qhvbm",
+      "id": "SJ9HvAwLdX",
       "input": {
-        "nodeId": "BkHWx8m3vWm",
+        "nodeId": "BkYWgUQ2DW7",
         "pinKey": "HkeKDhI-7"
       },
       "output": {
-        "nodeId": "BJXx8Q2vWQ",
-        "pinKey": "rycxytIZQ"
+        "nodeId": "B1FSwRPId7",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "SJMBvCwUOQ",
+      "input": {
+        "nodeId": "S1xgIQ3wbQ",
+        "pinKey": "HkeKDhI-7"
+      },
+      "output": {
+        "nodeId": "BkWrPRv8d7",
+        "pinKey": "__out__"
       }
     },
     {
@@ -265,6 +232,17 @@
       }
     },
     {
+      "id": "SJlBvCw8OQ",
+      "input": {
+        "nodeId": "S1HDCwIOQ",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "BJXx8Q2vWQ",
+        "pinKey": "rycxytIZQ"
+      }
+    },
+    {
       "id": "SkTNg8QhPb7",
       "input": {
         "nodeId": "SkcZgU7nwZX",
@@ -298,36 +276,36 @@
       }
     },
     {
-      "id": "SyDHVhDZ7",
+      "id": "SyESPAvLum",
       "input": {
-        "nodeId": "HkeL7nvZ7",
-        "pinKey": "H16YPnI-Q"
+        "nodeId": "rk1bg8m3vbm",
+        "pinKey": "HkeKDhI-7"
       },
       "output": {
-        "nodeId": "SJlSN2v-m",
-        "pinKey": "Bk4gU0drwJ-"
+        "nodeId": "HJ7SvCvL_m",
+        "pinKey": "__out__"
       }
     },
     {
-      "id": "SyGMeLX3D-m",
+      "id": "SylxBvCD8_X",
       "input": {
         "nodeId": "S1wlL7nPbQ",
         "pinKey": "HkeKDhI-7"
       },
       "output": {
-        "nodeId": "BJXx8Q2vWQ",
-        "pinKey": "rycxytIZQ"
+        "nodeId": "BJJxBP0D8dm",
+        "pinKey": "__out__"
       }
     },
     {
-      "id": "SyXrl873Dbm",
+      "id": "r1K2CPUuQ",
       "input": {
-        "nodeId": "HyQZlImnvWm",
-        "pinKey": "HkeKDhI-7"
+        "nodeId": "BJEPQ2PWQ",
+        "pinKey": "H1VpIKnLb7"
       },
       "output": {
         "nodeId": "BJXx8Q2vWQ",
-        "pinKey": "rycxytIZQ"
+        "pinKey": "HJoHCvU_Q"
       }
     },
     {
@@ -386,14 +364,25 @@
       }
     },
     {
-      "id": "rJoWgI73DbX",
+      "id": "rJdHvCwUum",
       "input": {
-        "nodeId": "HkeL7nvZ7",
-        "pinKey": "rJV3I2I-Q"
+        "nodeId": "HyD-xLQnP-7",
+        "pinKey": "HkeKDhI-7"
       },
       "output": {
-        "nodeId": "BJXx8Q2vWQ",
-        "pinKey": "rycxytIZQ"
+        "nodeId": "S1vHw0D8um",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "rkl5DAD8dQ",
+      "input": {
+        "nodeId": "BJEPQ2PWQ",
+        "pinKey": "HkT8KhLWm"
+      },
+      "output": {
+        "nodeId": "Bk5w0PL_Q",
+        "pinKey": "__out__"
       }
     },
     {
@@ -408,14 +397,25 @@
       }
     },
     {
-      "id": "ryxzxIX2vZm",
+      "id": "ry8rwCwI_m",
+      "input": {
+        "nodeId": "H1plx87hDZX",
+        "pinKey": "HkeKDhI-7"
+      },
+      "output": {
+        "nodeId": "HJBrD0PLO7",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "ryVlBv0PIOX",
       "input": {
         "nodeId": "HJUe87hP-7",
         "pinKey": "Sk9EvnL-7"
       },
       "output": {
-        "nodeId": "BJXx8Q2vWQ",
-        "pinKey": "rycxytIZQ"
+        "nodeId": "rJQgrPADI_7",
+        "pinKey": "__out__"
       }
     },
     {
@@ -432,6 +432,15 @@
   ],
   "nodes": [
     {
+      "id": "B1FSwRPId7",
+      "label": "UART",
+      "position": {
+        "x": 849,
+        "y": 407
+      },
+      "type": "xod/patch-nodes/from-bus"
+    },
+    {
       "id": "B1ebg8Xnwbm",
       "position": {
         "x": 441,
@@ -445,10 +454,19 @@
       },
       "id": "BJEPQ2PWQ",
       "position": {
-        "x": 68,
+        "x": 102,
         "y": 204
       },
       "type": "@/print"
+    },
+    {
+      "id": "BJJxBP0D8dm",
+      "label": "UART",
+      "position": {
+        "x": 33,
+        "y": 407
+      },
+      "type": "xod/patch-nodes/from-bus"
     },
     {
       "id": "BJVWxLQ3P-X",
@@ -465,10 +483,19 @@
       },
       "id": "BJXx8Q2vWQ",
       "position": {
-        "x": 476,
-        "y": 102
+        "x": 136,
+        "y": -102
       },
       "type": "@/soft-uart"
+    },
+    {
+      "id": "Bk5w0PL_Q",
+      "label": "UART",
+      "position": {
+        "x": 102,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/from-bus"
     },
     {
       "id": "BkHWx8m3vWm",
@@ -485,6 +512,15 @@
         "y": 611
       },
       "type": "xod/core/watch"
+    },
+    {
+      "id": "BkWrPRv8d7",
+      "label": "UART",
+      "position": {
+        "x": 135,
+        "y": 407
+      },
+      "type": "xod/patch-nodes/from-bus"
     },
     {
       "id": "BkYWgUQ2DW7",
@@ -519,6 +555,24 @@
       "type": "@/read-byte"
     },
     {
+      "id": "HJ7SvCvL_m",
+      "label": "UART",
+      "position": {
+        "x": 339,
+        "y": 407
+      },
+      "type": "xod/patch-nodes/from-bus"
+    },
+    {
+      "id": "HJBrD0PLO7",
+      "label": "UART",
+      "position": {
+        "x": 237,
+        "y": 407
+      },
+      "type": "xod/patch-nodes/from-bus"
+    },
+    {
       "id": "HJUe87hP-7",
       "position": {
         "x": 986,
@@ -532,18 +586,10 @@
       },
       "id": "HkKxeUX3vZ7",
       "position": {
-        "x": 34,
+        "x": 68,
         "y": 408
       },
       "type": "xod/core/gate"
-    },
-    {
-      "id": "HkeL7nvZ7",
-      "position": {
-        "x": 135,
-        "y": 101
-      },
-      "type": "@/begin"
     },
     {
       "id": "HyD-xLQnP-7",
@@ -560,6 +606,42 @@
         "y": 509
       },
       "type": "@/read-byte"
+    },
+    {
+      "id": "Hyblrv0PLuX",
+      "label": "UART",
+      "position": {
+        "x": 543,
+        "y": 407
+      },
+      "type": "xod/patch-nodes/from-bus"
+    },
+    {
+      "id": "S1HDCwIOQ",
+      "label": "UART",
+      "position": {
+        "x": 136,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/to-bus"
+    },
+    {
+      "id": "S1jSD0PUO7",
+      "label": "UART",
+      "position": {
+        "x": 441,
+        "y": 407
+      },
+      "type": "xod/patch-nodes/from-bus"
+    },
+    {
+      "id": "S1vHw0D8um",
+      "label": "UART",
+      "position": {
+        "x": 747,
+        "y": 407
+      },
+      "type": "xod/patch-nodes/from-bus"
     },
     {
       "id": "S1wlL7nPbQ",
@@ -594,6 +676,15 @@
       "type": "xod/core/watch"
     },
     {
+      "id": "SJTSwAvIdX",
+      "label": "UART",
+      "position": {
+        "x": 645,
+        "y": 407
+      },
+      "type": "xod/patch-nodes/from-bus"
+    },
+    {
       "id": "SJhle8QnDbm",
       "position": {
         "x": 1020,
@@ -609,8 +700,8 @@
       "description": "Hack to make watch nodes works on Leonardo",
       "id": "SJlSN2v-m",
       "position": {
-        "x": 34,
-        "y": 102
+        "x": 0,
+        "y": -102
       },
       "type": "xod/core/delay"
     },
@@ -641,10 +732,19 @@
     {
       "id": "SyqllLXnwWQ",
       "position": {
-        "x": 68,
+        "x": 102,
         "y": 306
       },
       "type": "xod/core/flip-flop"
+    },
+    {
+      "id": "rJQgrPADI_7",
+      "label": "UART",
+      "position": {
+        "x": 986,
+        "y": 408
+      },
+      "type": "xod/patch-nodes/from-bus"
     },
     {
       "id": "rJfgUm2DZQ",

--- a/workspace/__lib__/xod/uart/example-read/patch.xodp
+++ b/workspace/__lib__/xod/uart/example-read/patch.xodp
@@ -1,17 +1,6 @@
 {
   "links": [
     {
-      "id": "B1HzG2apwWm",
-      "input": {
-        "nodeId": "HJsf2aTDZX",
-        "pinKey": "H16YPnI-Q"
-      },
-      "output": {
-        "nodeId": "S1XgMnT6DWm",
-        "pinKey": "Bk4gU0drwJ-"
-      }
-    },
-    {
       "id": "Bk6WJeO-m",
       "input": {
         "nodeId": "H1sZygu-m",
@@ -45,14 +34,14 @@
       }
     },
     {
-      "id": "HyaMz3a6DW7",
+      "id": "HJxh1_IdX",
       "input": {
-        "nodeId": "HJsf2aTDZX",
-        "pinKey": "rJV3I2I-Q"
+        "nodeId": "SylfhpTDZm",
+        "pinKey": "H1VpIKnLb7"
       },
       "output": {
         "nodeId": "rJGM36TvZ7",
-        "pinKey": "rycxytIZQ"
+        "pinKey": "HJoHCvU_Q"
       }
     },
     {
@@ -67,6 +56,17 @@
       }
     },
     {
+      "id": "SkMhydLd7",
+      "input": {
+        "nodeId": "rJGM36TvZ7",
+        "pinKey": "S1gjHAPL_7"
+      },
+      "output": {
+        "nodeId": "S1XgMnT6DWm",
+        "pinKey": "Bk4gU0drwJ-"
+      }
+    },
+    {
       "id": "Sybf1l_W7",
       "input": {
         "nodeId": "H1sZygu-m",
@@ -75,17 +75,6 @@
       "output": {
         "nodeId": "SylfhpTDZm",
         "pinKey": "rkl6IK3L-7"
-      }
-    },
-    {
-      "id": "Syh-GnTTDbQ",
-      "input": {
-        "nodeId": "SylfhpTDZm",
-        "pinKey": "H1VpIKnLb7"
-      },
-      "output": {
-        "nodeId": "HJsf2aTDZX",
-        "pinKey": "B1SyPhUWm"
       }
     },
     {
@@ -121,14 +110,6 @@
       "type": "@/read-bytes"
     },
     {
-      "id": "HJsf2aTDZX",
-      "position": {
-        "x": 34,
-        "y": 0
-      },
-      "type": "@/begin"
-    },
-    {
       "id": "HkdbAKXzQ",
       "position": {
         "x": 34,
@@ -144,7 +125,7 @@
       "description": "Hack to make watch nodes works on Leonardo",
       "id": "S1XgMnT6DWm",
       "position": {
-        "x": 170,
+        "x": 34,
         "y": -102
       },
       "type": "xod/core/delay"
@@ -168,7 +149,7 @@
       "id": "rJGM36TvZ7",
       "position": {
         "x": 34,
-        "y": -102
+        "y": 0
       },
       "type": "@/soft-uart"
     }

--- a/workspace/__lib__/xod/uart/example-uart/patch.xodp
+++ b/workspace/__lib__/xod/uart/example-uart/patch.xodp
@@ -12,14 +12,14 @@
       }
     },
     {
-      "id": "B1npKu9-X",
+      "id": "B1RT1d8dm",
       "input": {
-        "nodeId": "SJB8Quc-X",
-        "pinKey": "HkT8KhLWm"
+        "nodeId": "rJKaK_qWX",
+        "pinKey": "SJCqmwIO7"
       },
       "output": {
-        "nodeId": "rJKaK_qWX",
-        "pinKey": "ByJ65dU-X"
+        "nodeId": "BJAIVuqZm",
+        "pinKey": "Bk4gU0drwJ-"
       }
     },
     {
@@ -34,17 +34,6 @@
       }
     },
     {
-      "id": "ByxCF_c-7",
-      "input": {
-        "nodeId": "By_4VdqbX",
-        "pinKey": "Sk9EvnL-7"
-      },
-      "output": {
-        "nodeId": "rJKaK_qWX",
-        "pinKey": "ByJ65dU-X"
-      }
-    },
-    {
       "id": "H1_wEd5Wm",
       "input": {
         "nodeId": "BkwPEuc-Q",
@@ -53,6 +42,17 @@
       "output": {
         "nodeId": "BJAIVuqZm",
         "pinKey": "HkU3vNoTW"
+      }
+    },
+    {
+      "id": "H1nlgdUdm",
+      "input": {
+        "nodeId": "SJB8Quc-X",
+        "pinKey": "H1VpIKnLb7"
+      },
+      "output": {
+        "nodeId": "rJKaK_qWX",
+        "pinKey": "rJAd7vLOQ"
       }
     },
     {
@@ -67,17 +67,6 @@
       }
     },
     {
-      "id": "Hyi6tuqZX",
-      "input": {
-        "nodeId": "Skk4VOqbQ",
-        "pinKey": "rJV3I2I-Q"
-      },
-      "output": {
-        "nodeId": "rJKaK_qWX",
-        "pinKey": "ByJ65dU-X"
-      }
-    },
-    {
       "id": "SJOk0YQGX",
       "input": {
         "nodeId": "BJR8Q_c-X",
@@ -89,32 +78,43 @@
       }
     },
     {
-      "id": "SkzEVd9-X",
+      "id": "SyzVxlOIdQ",
       "input": {
         "nodeId": "SJB8Quc-X",
-        "pinKey": "H1VpIKnLb7"
+        "pinKey": "HkT8KhLWm"
       },
       "output": {
-        "nodeId": "Skk4VOqbQ",
-        "pinKey": "B1SyPhUWm"
+        "nodeId": "B1bNgeO8_X",
+        "pinKey": "__out__"
       }
     },
     {
-      "id": "rJbPN_5b7",
-      "input": {
-        "nodeId": "Skk4VOqbQ",
-        "pinKey": "H16YPnI-Q"
-      },
-      "output": {
-        "nodeId": "BJAIVuqZm",
-        "pinKey": "Bk4gU0drwJ-"
-      }
-    },
-    {
-      "id": "rkRTFu5Z7",
+      "id": "rJ8Nle_I_m",
       "input": {
         "nodeId": "BJR8Q_c-X",
         "pinKey": "SJaxW1ubX"
+      },
+      "output": {
+        "nodeId": "B1SVlxu8_Q",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "ry4VxxdIdm",
+      "input": {
+        "nodeId": "By_4VdqbX",
+        "pinKey": "Sk9EvnL-7"
+      },
+      "output": {
+        "nodeId": "rJmEll_8_Q",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "ryeVleOU_7",
+      "input": {
+        "nodeId": "Sk4xluU_X",
+        "pinKey": "__in__"
       },
       "output": {
         "nodeId": "rJKaK_qWX",
@@ -124,14 +124,32 @@
   ],
   "nodes": [
     {
+      "id": "B1SVlxu8_Q",
+      "label": "UART",
+      "position": {
+        "x": 238,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/from-bus"
+    },
+    {
+      "id": "B1bNgeO8_X",
+      "label": "UART",
+      "position": {
+        "x": 102,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/from-bus"
+    },
+    {
       "boundLiterals": {
         "SkSuD6LMb": "On Boot",
         "Skre8ROSv1-": "1"
       },
       "id": "BJAIVuqZm",
       "position": {
-        "x": 136,
-        "y": 0
+        "x": 170,
+        "y": -102
       },
       "type": "xod/core/delay"
     },
@@ -141,7 +159,7 @@
       },
       "id": "BJR8Q_c-X",
       "position": {
-        "x": 34,
+        "x": 238,
         "y": 306
       },
       "type": "@/read-bytes"
@@ -149,16 +167,16 @@
     {
       "id": "BkwPEuc-Q",
       "position": {
-        "x": 238,
-        "y": 0
+        "x": 272,
+        "y": -102
       },
       "type": "xod/core/watch"
     },
     {
       "id": "By_4VdqbX",
       "position": {
-        "x": 102,
-        "y": 408
+        "x": 408,
+        "y": 306
       },
       "type": "@/end"
     },
@@ -168,34 +186,44 @@
       },
       "id": "SJB8Quc-X",
       "position": {
-        "x": 34,
-        "y": 204
+        "x": 102,
+        "y": 306
       },
       "type": "@/print"
     },
     {
+      "id": "Sk4xluU_X",
+      "label": "UART",
+      "position": {
+        "x": 136,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/to-bus"
+    },
+    {
       "id": "SkFwQdcZ7",
       "position": {
-        "x": 34,
+        "x": 306,
         "y": 408
       },
       "type": "xod/core/console-log"
     },
     {
-      "id": "Skk4VOqbQ",
-      "position": {
-        "x": 34,
-        "y": 102
-      },
-      "type": "@/begin"
-    },
-    {
       "id": "rJKaK_qWX",
       "position": {
-        "x": 34,
+        "x": 136,
         "y": 0
       },
       "type": "@/uart"
+    },
+    {
+      "id": "rJmEll_8_Q",
+      "label": "UART",
+      "position": {
+        "x": 408,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/from-bus"
     }
   ]
 }

--- a/workspace/__lib__/xod/uart/example-write/patch.xodp
+++ b/workspace/__lib__/xod/uart/example-write/patch.xodp
@@ -1,28 +1,6 @@
 {
   "links": [
     {
-      "id": "B117hnLbQ",
-      "input": {
-        "nodeId": "B14z2h8-7",
-        "pinKey": "rJV3I2I-Q"
-      },
-      "output": {
-        "nodeId": "HJtfh3LWm",
-        "pinKey": "rycxytIZQ"
-      }
-    },
-    {
-      "id": "BJUKf2P-m",
-      "input": {
-        "nodeId": "SyBDM2PZQ",
-        "pinKey": "HkeKDhI-7"
-      },
-      "output": {
-        "nodeId": "HJtfh3LWm",
-        "pinKey": "rycxytIZQ"
-      }
-    },
-    {
       "id": "BJZdof2wb7",
       "input": {
         "nodeId": "rkldofnDb7",
@@ -31,6 +9,17 @@
       "output": {
         "nodeId": "HJdiznwW7",
         "pinKey": "Skw_dnU-Q"
+      }
+    },
+    {
+      "id": "BJgbLgovIdX",
+      "input": {
+        "nodeId": "ryLHh2UWQ",
+        "pinKey": "HkeKDhI-7"
+      },
+      "output": {
+        "nodeId": "Hk1-UloD8d7",
+        "pinKey": "__out__"
       }
     },
     {
@@ -45,6 +34,17 @@
       }
     },
     {
+      "id": "BkVLxoDLum",
+      "input": {
+        "nodeId": "SyBDM2PZQ",
+        "pinKey": "HkeKDhI-7"
+      },
+      "output": {
+        "nodeId": "SkXIgjDIuQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
       "id": "BkZnz2PZQ",
       "input": {
         "nodeId": "ry7D2nU-X",
@@ -56,25 +56,14 @@
       }
     },
     {
-      "id": "By_fbnDbm",
+      "id": "Byh8govLdX",
       "input": {
-        "nodeId": "By8z-3Dbm",
-        "pinKey": "BkiJZ2wWQ"
+        "nodeId": "r1vsfnvZX",
+        "pinKey": "HkeKDhI-7"
       },
       "output": {
-        "nodeId": "HJtfh3LWm",
-        "pinKey": "rycxytIZQ"
-      }
-    },
-    {
-      "id": "BydqlhP-X",
-      "input": {
-        "nodeId": "B14z2h8-7",
-        "pinKey": "H16YPnI-Q"
-      },
-      "output": {
-        "nodeId": "SkG9l2DbQ",
-        "pinKey": "Bk4gU0drwJ-"
+        "nodeId": "ryoUgjwI_7",
+        "pinKey": "__out__"
       }
     },
     {
@@ -89,14 +78,36 @@
       }
     },
     {
-      "id": "H1q8zhDWm",
+      "id": "H1CIloDLOQ",
       "input": {
-        "nodeId": "ry78znP-Q",
+        "nodeId": "rkYoMnDbX",
         "pinKey": "HkeKDhI-7"
       },
       "output": {
-        "nodeId": "HJtfh3LWm",
-        "pinKey": "rycxytIZQ"
+        "nodeId": "Bk6IgjvUOQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "H1MgLxiPUdQ",
+      "input": {
+        "nodeId": "HyjNTjv-7",
+        "pinKey": "BkHrP2I-m"
+      },
+      "output": {
+        "nodeId": "BkWgIgswUum",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "H1qeIxjvLOm",
+      "input": {
+        "nodeId": "S1M7powbm",
+        "pinKey": "BkHrP2I-m"
+      },
+      "output": {
+        "nodeId": "rJYeUeivUdm",
+        "pinKey": "__out__"
       }
     },
     {
@@ -111,6 +122,17 @@
       }
     },
     {
+      "id": "HJ2e8xowU_X",
+      "input": {
+        "nodeId": "ry7D2nU-X",
+        "pinKey": "Sk9EvnL-7"
+      },
+      "output": {
+        "nodeId": "SJsl8esPIOQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
       "id": "HJ2jMnv-7",
       "input": {
         "nodeId": "r1vsfnvZX",
@@ -122,14 +144,14 @@
       }
     },
     {
-      "id": "HJ4V6swZ7",
+      "id": "HJOx8eoDLOQ",
       "input": {
-        "nodeId": "H1GNToPWX",
-        "pinKey": "BkHrP2I-m"
+        "nodeId": "rkVwG2PZm",
+        "pinKey": "HkeKDhI-7"
       },
       "output": {
-        "nodeId": "HJtfh3LWm",
-        "pinKey": "rycxytIZQ"
+        "nodeId": "SkDe8xsPIuQ",
+        "pinKey": "__out__"
       }
     },
     {
@@ -152,6 +174,17 @@
       "output": {
         "nodeId": "HyjNTjv-7",
         "pinKey": "HJxHrv3I-m"
+      }
+    },
+    {
+      "id": "HkdLxiD8dm",
+      "input": {
+        "nodeId": "ry78znP-Q",
+        "pinKey": "HkeKDhI-7"
+      },
+      "output": {
+        "nodeId": "BywLesv8dm",
+        "pinKey": "__out__"
       }
     },
     {
@@ -188,28 +221,6 @@
       }
     },
     {
-      "id": "HydhM2wbm",
-      "input": {
-        "nodeId": "r1vsfnvZX",
-        "pinKey": "HkeKDhI-7"
-      },
-      "output": {
-        "nodeId": "HJtfh3LWm",
-        "pinKey": "rycxytIZQ"
-      }
-    },
-    {
-      "id": "S13hznPWm",
-      "input": {
-        "nodeId": "rkYoMnDbX",
-        "pinKey": "HkeKDhI-7"
-      },
-      "output": {
-        "nodeId": "HJtfh3LWm",
-        "pinKey": "rycxytIZQ"
-      }
-    },
-    {
       "id": "S1KvfhvbX",
       "input": {
         "nodeId": "SyBDM2PZQ",
@@ -218,17 +229,6 @@
       "output": {
         "nodeId": "rkVwG2PZm",
         "pinKey": "Hkeetvn8-Q"
-      }
-    },
-    {
-      "id": "S1L3M3P-X",
-      "input": {
-        "nodeId": "HkrsG3wZQ",
-        "pinKey": "HkeKDhI-7"
-      },
-      "output": {
-        "nodeId": "HJtfh3LWm",
-        "pinKey": "rycxytIZQ"
       }
     },
     {
@@ -243,17 +243,6 @@
       }
     },
     {
-      "id": "S1kSpsPZQ",
-      "input": {
-        "nodeId": "HyjNTjv-7",
-        "pinKey": "BkHrP2I-m"
-      },
-      "output": {
-        "nodeId": "HJtfh3LWm",
-        "pinKey": "rycxytIZQ"
-      }
-    },
-    {
       "id": "S1ooG2DZm",
       "input": {
         "nodeId": "HkrsG3wZQ",
@@ -262,6 +251,17 @@
       "output": {
         "nodeId": "SyBDM2PZQ",
         "pinKey": "Hkeetvn8-Q"
+      }
+    },
+    {
+      "id": "S1xgLlsvUuQ",
+      "input": {
+        "nodeId": "HkrsG3wZQ",
+        "pinKey": "HkeKDhI-7"
+      },
+      "output": {
+        "nodeId": "SJ1xIlsDIOm",
+        "pinKey": "__out__"
       }
     },
     {
@@ -309,17 +309,6 @@
       }
     },
     {
-      "id": "SkL8hhLbQ",
-      "input": {
-        "nodeId": "ByML3nU-m",
-        "pinKey": "HkeKDhI-7"
-      },
-      "output": {
-        "nodeId": "HJtfh3LWm",
-        "pinKey": "rycxytIZQ"
-      }
-    },
-    {
       "id": "SkQEaoP-Q",
       "input": {
         "nodeId": "H1GNToPWX",
@@ -331,17 +320,6 @@
       }
     },
     {
-      "id": "Skcnz3wZQ",
-      "input": {
-        "nodeId": "HJdiznwW7",
-        "pinKey": "HkeKDhI-7"
-      },
-      "output": {
-        "nodeId": "HJtfh3LWm",
-        "pinKey": "rycxytIZQ"
-      }
-    },
-    {
       "id": "SyAXGhP-7",
       "input": {
         "nodeId": "rJQFZ2wbm",
@@ -350,6 +328,17 @@
       "output": {
         "nodeId": "B1KXG3vZm",
         "pinKey": "HJhXDIY9-"
+      }
+    },
+    {
+      "id": "SyLIeiP8dQ",
+      "input": {
+        "nodeId": "By8z-3Dbm",
+        "pinKey": "BkiJZ2wWQ"
+      },
+      "output": {
+        "nodeId": "BkrUesPLd7",
+        "pinKey": "__out__"
       }
     },
     {
@@ -375,6 +364,17 @@
       }
     },
     {
+      "id": "r10b1dL_7",
+      "input": {
+        "nodeId": "S1M7powbm",
+        "pinKey": "Hyz0PhIbm"
+      },
+      "output": {
+        "nodeId": "HJtfh3LWm",
+        "pinKey": "HJoHCvU_Q"
+      }
+    },
+    {
       "id": "r1NoZnDW7",
       "input": {
         "nodeId": "ryLHh2UWQ",
@@ -386,28 +386,6 @@
       }
     },
     {
-      "id": "r1NtGnvWX",
-      "input": {
-        "nodeId": "rkVwG2PZm",
-        "pinKey": "HkeKDhI-7"
-      },
-      "output": {
-        "nodeId": "HJtfh3LWm",
-        "pinKey": "rycxytIZQ"
-      }
-    },
-    {
-      "id": "r1VmTiDZ7",
-      "input": {
-        "nodeId": "S1M7powbm",
-        "pinKey": "BkHrP2I-m"
-      },
-      "output": {
-        "nodeId": "HJtfh3LWm",
-        "pinKey": "rycxytIZQ"
-      }
-    },
-    {
       "id": "r1bvjz3vZm",
       "input": {
         "nodeId": "rJxDsMhvZ7",
@@ -416,6 +394,17 @@
       "output": {
         "nodeId": "r1vsfnvZX",
         "pinKey": "Skw_dnU-Q"
+      }
+    },
+    {
+      "id": "r1l8esPIu7",
+      "input": {
+        "nodeId": "B1Ueiv8uX",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "HJtfh3LWm",
+        "pinKey": "rycxytIZQ"
       }
     },
     {
@@ -441,17 +430,6 @@
       }
     },
     {
-      "id": "rJHPn3U-X",
-      "input": {
-        "nodeId": "ry7D2nU-X",
-        "pinKey": "Sk9EvnL-7"
-      },
-      "output": {
-        "nodeId": "HJtfh3LWm",
-        "pinKey": "rycxytIZQ"
-      }
-    },
-    {
       "id": "rJRjzhvb7",
       "input": {
         "nodeId": "HJdiznwW7",
@@ -463,14 +441,14 @@
       }
     },
     {
-      "id": "rJVUaswb7",
+      "id": "rJRxIlovL_m",
       "input": {
         "nodeId": "H1tBTivb7",
         "pinKey": "BkHrP2I-m"
       },
       "output": {
-        "nodeId": "HJtfh3LWm",
-        "pinKey": "rycxytIZQ"
+        "nodeId": "B1ae8xsvU_7",
+        "pinKey": "__out__"
       }
     },
     {
@@ -485,14 +463,36 @@
       }
     },
     {
-      "id": "rkBmajw-m",
+      "id": "rkGM1uLuQ",
       "input": {
-        "nodeId": "S1M7powbm",
-        "pinKey": "Hyz0PhIbm"
+        "nodeId": "HJtfh3LWm",
+        "pinKey": "S1gjHAPL_7"
       },
       "output": {
-        "nodeId": "B14z2h8-7",
-        "pinKey": "B1SyPhUWm"
+        "nodeId": "SkG9l2DbQ",
+        "pinKey": "Bk4gU0drwJ-"
+      }
+    },
+    {
+      "id": "ry8lUxoDI_X",
+      "input": {
+        "nodeId": "HJdiznwW7",
+        "pinKey": "HkeKDhI-7"
+      },
+      "output": {
+        "nodeId": "HkBxLljPUuQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "ry9IgiPL_m",
+      "input": {
+        "nodeId": "H1GNToPWX",
+        "pinKey": "BkHrP2I-m"
+      },
+      "output": {
+        "nodeId": "SkYIgjDIuX",
+        "pinKey": "__out__"
       }
     },
     {
@@ -507,39 +507,49 @@
       }
     },
     {
-      "id": "ryFSh2Lb7",
+      "id": "ryElIejP8d7",
       "input": {
-        "nodeId": "ryLHh2UWQ",
+        "nodeId": "ByML3nU-m",
         "pinKey": "HkeKDhI-7"
       },
       "output": {
-        "nodeId": "HJtfh3LWm",
-        "pinKey": "rycxytIZQ"
+        "nodeId": "BJQgUeiwLu7",
+        "pinKey": "__out__"
       }
     }
   ],
   "nodes": [
     {
-      "id": "B14z2h8-7",
-      "position": {
-        "x": 102,
-        "y": 102
-      },
-      "type": "@/begin"
-    },
-    {
       "id": "B1KXG3vZm",
       "position": {
         "x": 986,
-        "y": 510
+        "y": 714
       },
       "type": "xod/core/defer"
+    },
+    {
+      "id": "B1Ueiv8uX",
+      "label": "UART",
+      "position": {
+        "x": 34,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/to-bus"
+    },
+    {
+      "id": "B1ae8xsvU_7",
+      "label": "UART",
+      "position": {
+        "x": 306,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/from-bus"
     },
     {
       "id": "B1lrjfnDWX",
       "position": {
         "x": 510,
-        "y": 510
+        "y": 714
       },
       "type": "xod/core/watch"
     },
@@ -547,23 +557,59 @@
       "id": "BJ1df3v-Q",
       "position": {
         "x": 408,
-        "y": 510
+        "y": 714
       },
       "type": "xod/core/watch"
+    },
+    {
+      "id": "BJQgUeiwLu7",
+      "label": "UART",
+      "position": {
+        "x": 102,
+        "y": 510
+      },
+      "type": "xod/patch-nodes/from-bus"
     },
     {
       "id": "BJeDGhvbX",
       "position": {
         "x": 204,
-        "y": 510
+        "y": 714
       },
       "type": "xod/core/watch"
+    },
+    {
+      "id": "Bk6IgjvUOQ",
+      "label": "UART",
+      "position": {
+        "x": 816,
+        "y": 510
+      },
+      "type": "xod/patch-nodes/from-bus"
+    },
+    {
+      "id": "BkWgIgswUum",
+      "label": "UART",
+      "position": {
+        "x": 204,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/from-bus"
+    },
+    {
+      "id": "BkrUesPLd7",
+      "label": "UART",
+      "position": {
+        "x": 408,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/from-bus"
     },
     {
       "id": "By8z-3Dbm",
       "position": {
         "x": 408,
-        "y": 204
+        "y": 306
       },
       "type": "@/flush"
     },
@@ -571,7 +617,7 @@
       "id": "ByML3nU-m",
       "position": {
         "x": 102,
-        "y": 408
+        "y": 612
       },
       "type": "@/read-byte"
     },
@@ -579,9 +625,18 @@
       "id": "Byltif2wbm",
       "position": {
         "x": 816,
-        "y": 510
+        "y": 714
       },
       "type": "xod/core/watch"
+    },
+    {
+      "id": "BywLesv8dm",
+      "label": "UART",
+      "position": {
+        "x": 204,
+        "y": 510
+      },
+      "type": "xod/patch-nodes/from-bus"
     },
     {
       "boundLiterals": {
@@ -590,7 +645,7 @@
       "id": "H1GNToPWX",
       "position": {
         "x": 102,
-        "y": 204
+        "y": 306
       },
       "type": "@/write-byte"
     },
@@ -601,7 +656,7 @@
       "id": "H1tBTivb7",
       "position": {
         "x": 306,
-        "y": 204
+        "y": 306
       },
       "type": "@/write-byte"
     },
@@ -609,7 +664,7 @@
       "id": "HJFIh3U-Q",
       "position": {
         "x": 0,
-        "y": 510
+        "y": 714
       },
       "type": "xod/core/watch"
     },
@@ -617,7 +672,7 @@
       "id": "HJdiznwW7",
       "position": {
         "x": 714,
-        "y": 408
+        "y": 612
       },
       "type": "@/read-byte"
     },
@@ -628,16 +683,34 @@
       },
       "id": "HJtfh3LWm",
       "position": {
-        "x": 918,
-        "y": 102
+        "x": 34,
+        "y": 0
       },
       "type": "@/soft-uart"
+    },
+    {
+      "id": "Hk1-UloD8d7",
+      "label": "UART",
+      "position": {
+        "x": 0,
+        "y": 510
+      },
+      "type": "xod/patch-nodes/from-bus"
+    },
+    {
+      "id": "HkBxLljPUuQ",
+      "label": "UART",
+      "position": {
+        "x": 714,
+        "y": 510
+      },
+      "type": "xod/patch-nodes/from-bus"
     },
     {
       "id": "HkovG3Pb7",
       "position": {
         "x": 306,
-        "y": 510
+        "y": 714
       },
       "type": "xod/core/watch"
     },
@@ -645,7 +718,7 @@
       "id": "HkrsG3wZQ",
       "position": {
         "x": 510,
-        "y": 408
+        "y": 612
       },
       "type": "@/read-byte"
     },
@@ -656,7 +729,7 @@
       "id": "HydubhvbQ",
       "position": {
         "x": 102,
-        "y": 306
+        "y": 408
       },
       "type": "xod/core/gate"
     },
@@ -667,7 +740,7 @@
       "id": "HyjNTjv-7",
       "position": {
         "x": 204,
-        "y": 204
+        "y": 306
       },
       "type": "@/write-byte"
     },
@@ -678,15 +751,24 @@
       "id": "S1M7powbm",
       "position": {
         "x": 0,
-        "y": 204
+        "y": 306
       },
       "type": "@/write-byte"
+    },
+    {
+      "id": "SJ1xIlsDIOm",
+      "label": "UART",
+      "position": {
+        "x": 510,
+        "y": 510
+      },
+      "type": "xod/patch-nodes/from-bus"
     },
     {
       "id": "SJZn-3w-Q",
       "position": {
         "x": 918,
-        "y": 510
+        "y": 714
       },
       "type": "xod/core/any"
     },
@@ -694,9 +776,27 @@
       "id": "SJn83hIZX",
       "position": {
         "x": 102,
-        "y": 510
+        "y": 714
       },
       "type": "xod/core/watch"
+    },
+    {
+      "id": "SJsl8esPIOQ",
+      "label": "UART",
+      "position": {
+        "x": 952,
+        "y": 510
+      },
+      "type": "xod/patch-nodes/from-bus"
+    },
+    {
+      "id": "SkDe8xsPIuQ",
+      "label": "UART",
+      "position": {
+        "x": 306,
+        "y": 510
+      },
+      "type": "xod/patch-nodes/from-bus"
     },
     {
       "boundLiterals": {
@@ -706,16 +806,34 @@
       "description": "Hack to make watch nodes works on Leonardo",
       "id": "SkG9l2DbQ",
       "position": {
-        "x": 0,
-        "y": 102
+        "x": -102,
+        "y": 0
       },
       "type": "xod/core/delay"
+    },
+    {
+      "id": "SkXIgjDIuQ",
+      "label": "UART",
+      "position": {
+        "x": 408,
+        "y": 510
+      },
+      "type": "xod/patch-nodes/from-bus"
+    },
+    {
+      "id": "SkYIgjDIuX",
+      "label": "UART",
+      "position": {
+        "x": 102,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/from-bus"
     },
     {
       "id": "SyBDM2PZQ",
       "position": {
         "x": 408,
-        "y": 408
+        "y": 612
       },
       "type": "@/read-byte"
     },
@@ -723,7 +841,7 @@
       "id": "r1vsfnvZX",
       "position": {
         "x": 612,
-        "y": 408
+        "y": 612
       },
       "type": "@/read-byte"
     },
@@ -731,15 +849,24 @@
       "id": "rJQFZ2wbm",
       "position": {
         "x": 0,
-        "y": 306
+        "y": 408
       },
       "type": "xod/core/flip-flop"
+    },
+    {
+      "id": "rJYeUeivUdm",
+      "label": "UART",
+      "position": {
+        "x": 0,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/from-bus"
     },
     {
       "id": "rJxDsMhvZ7",
       "position": {
         "x": 612,
-        "y": 510
+        "y": 714
       },
       "type": "xod/core/watch"
     },
@@ -747,7 +874,7 @@
       "id": "rkVwG2PZm",
       "position": {
         "x": 306,
-        "y": 408
+        "y": 612
       },
       "type": "@/read-byte"
     },
@@ -755,7 +882,7 @@
       "id": "rkYoMnDbX",
       "position": {
         "x": 816,
-        "y": 408
+        "y": 612
       },
       "type": "@/read-byte"
     },
@@ -763,7 +890,7 @@
       "id": "rkldofnDb7",
       "position": {
         "x": 714,
-        "y": 510
+        "y": 714
       },
       "type": "xod/core/watch"
     },
@@ -771,7 +898,7 @@
       "id": "ry78znP-Q",
       "position": {
         "x": 204,
-        "y": 408
+        "y": 612
       },
       "type": "@/read-byte"
     },
@@ -779,7 +906,7 @@
       "id": "ry7D2nU-X",
       "position": {
         "x": 952,
-        "y": 408
+        "y": 612
       },
       "type": "@/end"
     },
@@ -787,9 +914,18 @@
       "id": "ryLHh2UWQ",
       "position": {
         "x": 0,
-        "y": 408
+        "y": 612
       },
       "type": "@/read-byte"
+    },
+    {
+      "id": "ryoUgjwI_7",
+      "label": "UART",
+      "position": {
+        "x": 612,
+        "y": 510
+      },
+      "type": "xod/patch-nodes/from-bus"
     }
   ]
 }

--- a/workspace/__lib__/xod/uart/soft-uart/patch.cpp
+++ b/workspace/__lib__/xod/uart/soft-uart/patch.cpp
@@ -74,9 +74,17 @@ struct State {
 
 void evaluate(Context ctx) {
     auto state = getState(ctx);
-    uint8_t rx = getValue<input_RX>(ctx);
-    uint8_t tx = getValue<input_TX>(ctx);
-    long baud = (long)getValue<input_BAUD>(ctx);
-    state->uart = new (state->mem) SoftwareUart(rx, tx, baud);
-    emitValue<output_UART>(ctx, state->uart);
+
+    if (isSettingUp()) {
+        uint8_t rx = getValue<input_RX>(ctx);
+        uint8_t tx = getValue<input_TX>(ctx);
+        long baud = (long)getValue<input_BAUD>(ctx);
+        state->uart = new (state->mem) SoftwareUart(rx, tx, baud);
+        emitValue<output_UART>(ctx, state->uart);
+    }
+
+    if (isInputDirty<input_INIT>(ctx)) {
+        state->uart->begin();
+        emitValue<output_DONE>(ctx, 1);
+    }
 }

--- a/workspace/__lib__/xod/uart/soft-uart/patch.xodp
+++ b/workspace/__lib__/xod/uart/soft-uart/patch.xodp
@@ -2,6 +2,29 @@
   "description": "Constructor of SoftwareUart, provides serial communication on any digital pins.",
   "nodes": [
     {
+      "description": "Pulses when UART communication began",
+      "id": "HJoHCvU_Q",
+      "label": "DONE",
+      "position": {
+        "x": 136,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "On Boot"
+      },
+      "description": "Begin UART communication",
+      "id": "S1gjHAPL_7",
+      "label": "INIT",
+      "position": {
+        "x": 136,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
       "boundLiterals": {
         "__out__": "9600"
       },

--- a/workspace/__lib__/xod/uart/uart-0/patch.cpp
+++ b/workspace/__lib__/xod/uart/uart-0/patch.cpp
@@ -9,6 +9,14 @@ struct State {
 
 void evaluate(Context ctx) {
     auto state = getState(ctx);
-    state->uart = new (state->mem) HardwareUart(Serial, (uint32_t)getValue<input_BAUD>(ctx));
-    emitValue<output_UART>(ctx, state->uart);
+
+    if (isSettingUp()) {
+        state->uart = new (state->mem) HardwareUart(Serial, (uint32_t)getValue<input_BAUD>(ctx));
+        emitValue<output_UART>(ctx, state->uart);
+    }
+
+    if (isInputDirty<input_INIT>(ctx)) {
+        state->uart->begin();
+        emitValue<output_DONE>(ctx, 1);
+    }
 }

--- a/workspace/__lib__/xod/uart/uart-0/patch.xodp
+++ b/workspace/__lib__/xod/uart/uart-0/patch.xodp
@@ -15,12 +15,35 @@
       "type": "xod/patch-nodes/input-number"
     },
     {
+      "boundLiterals": {
+        "__out__": "On Boot"
+      },
+      "description": "Begin UART communication",
+      "id": "HklRJFDLOX",
+      "label": "INIT",
+      "position": {
+        "x": 102,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
       "id": "SJQ39d8bm",
       "position": {
         "x": 34,
         "y": 102
       },
       "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "description": "Pulses when UART communication began",
+      "id": "Sk0ktvLO7",
+      "label": "DONE",
+      "position": {
+        "x": 102,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
     },
     {
       "description": "An UART object",

--- a/workspace/__lib__/xod/uart/uart-1/patch.cpp
+++ b/workspace/__lib__/xod/uart/uart-1/patch.cpp
@@ -9,6 +9,14 @@ struct State {
 
 void evaluate(Context ctx) {
     auto state = getState(ctx);
-    state->uart = new (state->mem) HardwareUart(Serial1, (uint32_t)getValue<input_BAUD>(ctx));
-    emitValue<output_UART>(ctx, state->uart);
+
+    if (isSettingUp()) {
+        state->uart = new (state->mem) HardwareUart(Serial1, (uint32_t)getValue<input_BAUD>(ctx));
+        emitValue<output_UART>(ctx, state->uart);
+    }
+
+    if (isInputDirty<input_INIT>(ctx)) {
+        state->uart->begin();
+        emitValue<output_DONE>(ctx, 1);
+    }
 }

--- a/workspace/__lib__/xod/uart/uart-1/patch.xodp
+++ b/workspace/__lib__/xod/uart/uart-1/patch.xodp
@@ -2,6 +2,16 @@
   "description": "Constructor of HardwareUart, provides serial communication through Serial1.",
   "nodes": [
     {
+      "description": "Pulses when UART communication began",
+      "id": "BkmeFD8OQ",
+      "label": "DONE",
+      "position": {
+        "x": 102,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
       "boundLiterals": {
         "__out__": "115200"
       },
@@ -13,6 +23,19 @@
         "y": 0
       },
       "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "On Boot"
+      },
+      "description": "Begin UART communication",
+      "id": "S1l7gFPUum",
+      "label": "INIT",
+      "position": {
+        "x": 102,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
     },
     {
       "id": "SJQ39d8bm",

--- a/workspace/__lib__/xod/uart/uart-2/patch.cpp
+++ b/workspace/__lib__/xod/uart/uart-2/patch.cpp
@@ -9,6 +9,14 @@ struct State {
 
 void evaluate(Context ctx) {
     auto state = getState(ctx);
-    state->uart = new (state->mem) HardwareUart(Serial2, (uint32_t)getValue<input_BAUD>(ctx));
-    emitValue<output_UART>(ctx, state->uart);
+
+    if (isSettingUp()) {
+        state->uart = new (state->mem) HardwareUart(Serial2, (uint32_t)getValue<input_BAUD>(ctx));
+        emitValue<output_UART>(ctx, state->uart);
+    }
+
+    if (isInputDirty<input_INIT>(ctx)) {
+        state->uart->begin();
+        emitValue<output_DONE>(ctx, 1);
+    }
 }

--- a/workspace/__lib__/xod/uart/uart-2/patch.xodp
+++ b/workspace/__lib__/xod/uart/uart-2/patch.xodp
@@ -31,6 +31,29 @@
         "y": 204
       },
       "type": "@/output-uart"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "On Boot"
+      },
+      "description": "Begin UART communication",
+      "id": "SkedxFD8dQ",
+      "label": "INIT",
+      "position": {
+        "x": 102,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "description": "Pulses when UART communication began",
+      "id": "ryulYwIOQ",
+      "label": "DONE",
+      "position": {
+        "x": 102,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
     }
   ]
 }

--- a/workspace/__lib__/xod/uart/uart-3/patch.cpp
+++ b/workspace/__lib__/xod/uart/uart-3/patch.cpp
@@ -9,6 +9,14 @@ struct State {
 
 void evaluate(Context ctx) {
     auto state = getState(ctx);
-    state->uart = new (state->mem) HardwareUart(Serial3, (uint32_t)getValue<input_BAUD>(ctx));
-    emitValue<output_UART>(ctx, state->uart);
+
+    if (isSettingUp()) {
+        state->uart = new (state->mem) HardwareUart(Serial3, (uint32_t)getValue<input_BAUD>(ctx));
+        emitValue<output_UART>(ctx, state->uart);
+    }
+
+    if (isInputDirty<input_INIT>(ctx)) {
+        state->uart->begin();
+        emitValue<output_DONE>(ctx, 1);
+    }
 }

--- a/workspace/__lib__/xod/uart/uart-3/patch.xodp
+++ b/workspace/__lib__/xod/uart/uart-3/patch.xodp
@@ -3,6 +3,19 @@
   "nodes": [
     {
       "boundLiterals": {
+        "__out__": "On Boot"
+      },
+      "description": "Begin UART communication",
+      "id": "BJengKwLuX",
+      "label": "INIT",
+      "position": {
+        "x": 102,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "boundLiterals": {
         "__out__": "115200"
       },
       "description": "Speed of data transmission in bits per second (baud rate).",
@@ -13,6 +26,16 @@
         "y": 0
       },
       "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "description": "Pulses when UART communication began",
+      "id": "H12gFvUOQ",
+      "label": "DONE",
+      "position": {
+        "x": 102,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
     },
     {
       "id": "SJQ39d8bm",

--- a/workspace/__lib__/xod/uart/uart-usb/patch.cpp
+++ b/workspace/__lib__/xod/uart/uart-usb/patch.cpp
@@ -75,6 +75,14 @@ struct State {
 
 void evaluate(Context ctx) {
     auto state = getState(ctx);
-    state->uart = new (state->mem) ChooseUartWrapper<typeof SerialUSB>::UartT(SerialUSB, (uint32_t)getValue<input_BAUD>(ctx));
-    emitValue<output_UART>(ctx, state->uart);
+
+    if (isSettingUp()) {
+        state->uart = new (state->mem) ChooseUartWrapper<typeof SerialUSB>::UartT(SerialUSB, (uint32_t)getValue<input_BAUD>(ctx));
+        emitValue<output_UART>(ctx, state->uart);
+    }
+
+    if (isInputDirty<input_INIT>(ctx)) {
+        state->uart->begin();
+        emitValue<output_DONE>(ctx, 1);
+    }
 }

--- a/workspace/__lib__/xod/uart/uart-usb/patch.xodp
+++ b/workspace/__lib__/xod/uart/uart-usb/patch.xodp
@@ -31,6 +31,29 @@
         "y": 204
       },
       "type": "@/output-uart"
+    },
+    {
+      "description": "Pulses when UART communication began",
+      "id": "Sy7H0DUuQ",
+      "label": "DONE",
+      "position": {
+        "x": 102,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "On Boot"
+      },
+      "description": "Begin UART communication",
+      "id": "ryx7rCvIuQ",
+      "label": "INIT",
+      "position": {
+        "x": 102,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
     }
   ]
 }

--- a/workspace/__lib__/xod/uart/uart/patch.cpp
+++ b/workspace/__lib__/xod/uart/uart/patch.cpp
@@ -10,12 +10,20 @@ struct State {
 
 void evaluate(Context ctx) {
     auto state = getState(ctx);
-    auto baud = (uint32_t)getValue<input_BAUD>(ctx);
+
+    if (isSettingUp()) {
+        auto baud = (uint32_t)getValue<input_BAUD>(ctx);
 #ifdef SERIAL_PORT_HARDWARE_OPEN
-    auto serial = SERIAL_PORT_HARDWARE_OPEN;
+        auto serial = SERIAL_PORT_HARDWARE_OPEN;
 #else
-    auto serial = SERIAL_PORT_HARDWARE;
+        auto serial = SERIAL_PORT_HARDWARE;
 #endif
-    state->uart = new (state->mem) HardwareUart(serial, baud);
-    emitValue<output_UART>(ctx, state->uart);
+        state->uart = new (state->mem) HardwareUart(serial, baud);
+        emitValue<output_UART>(ctx, state->uart);
+    }
+
+    if (isInputDirty<input_INIT>(ctx)) {
+        state->uart->begin();
+        emitValue<output_DONE>(ctx, 1);
+    }
 }

--- a/workspace/__lib__/xod/uart/uart/patch.xodp
+++ b/workspace/__lib__/xod/uart/uart/patch.xodp
@@ -31,6 +31,29 @@
         "y": 204
       },
       "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "On Boot"
+      },
+      "description": "Begin UART communication",
+      "id": "SJCqmwIO7",
+      "label": "INIT",
+      "position": {
+        "x": 102,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "description": "Pulses when UART communication began",
+      "id": "rJAd7vLOQ",
+      "label": "DONE",
+      "position": {
+        "x": 102,
+        "y": 306
+      },
+      "type": "xod/patch-nodes/output-pulse"
     }
   ]
 }


### PR DESCRIPTION
Example patches are also updated.