### PR TITLE
Make bundled __ardulibs__ reachable again

### DIFF
--- a/packages/xod-client-electron/package.json
+++ b/packages/xod-client-electron/package.json
@@ -71,6 +71,10 @@
       {
         "from": "arduino-builders/${os}",
         "to": "arduino-builder"
+      },
+      {
+        "from": "src-babel/workspace",
+        "to": "workspace"
       }
     ],
     "linux": {

--- a/packages/xod-client-electron/src/app/utils.js
+++ b/packages/xod-client-electron/src/app/utils.js
@@ -58,4 +58,6 @@ export const getFilePathToOpen = app => {
  * Returns Path to the bundled workspace
  */
 export const getPathToBundledWorkspace = () =>
-  path.resolve(__dirname, '../workspace');
+  IS_DEV
+    ? path.resolve(__dirname, '../workspace')
+    : path.resolve(process.resourcesPath, './workspace');


### PR DESCRIPTION
This issue [was reported on our forum](https://forum.xod.io/t/0-24-upgrade-fail/1130).

Because `__ardulib__` directory was packed into `asar`, it was unreachable by build tools.
