### PR TITLE
Stop checking if port is less than zero

### DIFF
--- a/workspace/__lib__/xod/common-hardware/servo/patch.cpp
+++ b/workspace/__lib__/xod/common-hardware/servo/patch.cpp
@@ -16,7 +16,7 @@ void evaluate(Context ctx) {
 
     State* state = getState(ctx);
     auto port = (int)getValue<input_PORT>(ctx);
-    if (port < 0 || port > NUM_DIGITAL_PINS - 1) {
+    if (port > NUM_DIGITAL_PINS - 1) {
         emitValue<output_ERR>(ctx, 1);
         return;
     }

--- a/workspace/__lib__/xod/gpio/digital-read/patch.cpp
+++ b/workspace/__lib__/xod/gpio/digital-read/patch.cpp
@@ -8,7 +8,7 @@ void evaluate(Context ctx) {
         return;
 
     const uint8_t port = getValue<input_PORT>(ctx);
-    bool err = (port < 0 || port > NUM_DIGITAL_PINS - 1);
+    bool err = (port > NUM_DIGITAL_PINS - 1);
     if (err) {
         emitValue<output_ERR>(ctx, 1);
         return;

--- a/workspace/__lib__/xod/gpio/digital-write/patch.cpp
+++ b/workspace/__lib__/xod/gpio/digital-write/patch.cpp
@@ -8,7 +8,7 @@ void evaluate(Context ctx) {
         return;
 
     const uint8_t port = getValue<input_PORT>(ctx);
-    bool err = (port < 0 || port > NUM_DIGITAL_PINS - 1);
+    bool err = (port > NUM_DIGITAL_PINS - 1);
     if (err) {
         emitValue<output_ERR>(ctx, 1);
         return;

--- a/workspace/__lib__/xod/gpio/pwm-write/patch.cpp
+++ b/workspace/__lib__/xod/gpio/pwm-write/patch.cpp
@@ -14,7 +14,7 @@ void evaluate(Context ctx) {
         return;
 
     const uint8_t port = getValue<input_PORT>(ctx);
-    bool err = (port < 0 || port > NUM_DIGITAL_PINS - 1);
+    bool err = (port > NUM_DIGITAL_PINS - 1);
 
     if (err) {
         emitValue<output_ERR>(ctx, 1);

--- a/workspace/blink/__fixtures__/arduino.cpp
+++ b/workspace/blink/__fixtures__/arduino.cpp
@@ -1235,7 +1235,7 @@ void evaluate(Context ctx) {
         return;
 
     const uint8_t port = getValue<input_PORT>(ctx);
-    bool err = (port < 0 || port > NUM_DIGITAL_PINS - 1);
+    bool err = (port > NUM_DIGITAL_PINS - 1);
     if (err) {
         emitValue<output_ERR>(ctx, 1);
         return;


### PR DESCRIPTION
It never is. It's `uint8_t`:
https://github.com/xodio/xod/blob/5934f2b56eaeac8cb0f7b38b80e99d2e9303bc4f/packages/xod-arduino/src/templates.js#L77
