### PR TITLE
Fix bug in `createProcess` action and block new deployments jobs while upgrading packages

### DIFF
--- a/packages/xod-client-electron/src/arduinoDependencies/actions.js
+++ b/packages/xod-client-electron/src/arduinoDependencies/actions.js
@@ -21,5 +21,4 @@ export const proceedPackageUpgrade = () => ({
   type: AT.ARDUPACKAGES_UPGRADE_PROCEED,
 });
 
-export const updatePackages = () =>
-  client.createProcess(UPGRADE_ARDUINO_DEPENDECIES);
+export const updatePackages = client.createProcess(UPGRADE_ARDUINO_DEPENDECIES);

--- a/packages/xod-client-electron/src/upload/reducer.js
+++ b/packages/xod-client-electron/src/upload/reducer.js
@@ -1,11 +1,13 @@
 import * as R from 'ramda';
 import client from 'xod-client';
 import { SELECT_SERIAL_PORT, UPLOAD } from '../upload/actionTypes';
+import { UPGRADE_ARDUINO_DEPENDECIES } from '../shared/events';
 
 const initialState = {
   selectedSerialPort: null,
   isUploading: false,
   isInstallingArduinoDependencies: false,
+  isUpgradingArduinoPackages: false,
 };
 
 const switchProcess = (propName, action, state) => {
@@ -31,6 +33,9 @@ export default (state = initialState, action) => {
 
     case client.INSTALL_ARDUINO_DEPENDENCIES:
       return switchProcess('isInstallingArduinoDependencies', action, state);
+
+    case UPGRADE_ARDUINO_DEPENDECIES:
+      return switchProcess('isUpgradingArduinoPackages', action, state);
 
     default:
       return state;

--- a/packages/xod-client-electron/src/upload/selectors.js
+++ b/packages/xod-client-electron/src/upload/selectors.js
@@ -30,9 +30,10 @@ export const getSelectedSerialPort = R.compose(
 );
 
 export const isDeploymentInProgress = R.compose(
-  R.converge(R.or, [
+  R.anyPass([
     R.prop('isUploading'),
     R.prop('isInstallingArduinoDependencies'),
+    R.prop('isUpgradingArduinoPackages'),
   ]),
   getUploadState
 );

--- a/packages/xod-client/src/processes/actions.js
+++ b/packages/xod-client/src/processes/actions.js
@@ -42,7 +42,7 @@ export const deleteProcess = (id, type) => ({
   meta: { status: STATUS.DELETED },
 });
 
-export const createProcess = type => dispatch => {
+export const createProcess = type => () => dispatch => {
   const processId = dispatch(addProcess(type));
 
   const deleteThisProcess = () => dispatch(deleteProcess(processId, type));


### PR DESCRIPTION
It fixes the bug introduced in the #1467 and adds a little tweak.