### PR TITLE
Provide default name for xodball saved from browser IDE

### DIFF
--- a/packages/xod-client-browser/src/containers/App.jsx
+++ b/packages/xod-client-browser/src/containers/App.jsx
@@ -107,7 +107,7 @@ class App extends client.App {
     const { project } = this.props;
 
     const xodballJSON = XP.toXodball(project);
-    const xodballName = XP.getProjectName(project);
+    const xodballName = XP.getProjectName(project) || 'my-project';
     const link = document ? document.createElement('a') : null;
     const url = `data:application/xod;charset=utf8,${encodeURIComponent(
       xodballJSON


### PR DESCRIPTION
A very small tweak.

The previous behavior caused some pain when creating quick projects in browser IDE, because it would save it as just `.xodball`, which was not correctly  associated with XOD IDE.