### PR TITLE
Change arduino-cli config on switch workspace

### DIFF
--- a/packages/arduino-cli/README.md
+++ b/packages/arduino-cli/README.md
@@ -36,6 +36,14 @@ Wraps `arduino-cli config dump`.
 
 - Returns `Promise<Object>`
 
+### updateConfig(newConfig)
+Replaces old config with the new one.
+
+Accepts:
+- `newConfig` `<Object>` — Plain JS object representation of `.cli-config.yml`
+
+- Returns `<Object>` with the new config
+
 ### listConnectedBoards()
 A wrapper with a custom extension over `arduino-cli board list`.
 

--- a/packages/arduino-cli/src/config.js
+++ b/packages/arduino-cli/src/config.js
@@ -9,10 +9,8 @@ const getDefaultConfig = configDir => ({
   arduino_data: resolve(configDir, 'data'),
 });
 
-export const configure = inputConfig => {
-  const configDir = fse.mkdtempSync(resolve(tmpdir(), 'arduino-cli'));
-  const configPath = resolve(configDir, '.cli-config.yml');
-  const config = inputConfig || getDefaultConfig(configDir);
+// :: Path -> Object -> { config: Object, path: Path }
+export const saveConfig = (configPath, config) => {
   const yamlString = YAML.stringify(config, 2);
 
   // Write config
@@ -26,6 +24,14 @@ export const configure = inputConfig => {
     config,
     path: configPath,
   };
+};
+
+// :: Object -> { config: Object, path: Path }
+export const configure = inputConfig => {
+  const configDir = fse.mkdtempSync(resolve(tmpdir(), 'arduino-cli'));
+  const configPath = resolve(configDir, '.cli-config.yml');
+  const config = inputConfig || getDefaultConfig(configDir);
+  return saveConfig(configPath, config);
 };
 
 // :: Path -> [URL] -> Promise [URL] Error

--- a/packages/arduino-cli/src/index.js
+++ b/packages/arduino-cli/src/index.js
@@ -5,7 +5,12 @@ import { exec, spawn } from 'child-process-promise';
 import YAML from 'yamljs';
 import { remove } from 'fs-extra';
 
-import { configure, addPackageIndexUrl, addPackageIndexUrls } from './config';
+import {
+  saveConfig,
+  configure,
+  addPackageIndexUrl,
+  addPackageIndexUrls,
+} from './config';
 import { patchBoardsWithOptions } from './optionParser';
 import listAvailableBoards from './listAvailableBoards';
 import parseProgressLog from './parseProgressLog';
@@ -19,7 +24,7 @@ const escapeSpacesNonWin = R.unless(() => IS_WIN, R.replace(/\s/g, '\\ '));
  * @param {Object} config Plain-object representation of `.cli-config.yml`
  */
 const ArduinoCli = (pathToBin, config = null) => {
-  const { path: configPath, config: cfg } = configure(config);
+  let { path: configPath, config: cfg } = configure(config);
 
   const escapedConfigPath = escapeSpacesNonWin(configPath);
   const run = args =>
@@ -68,6 +73,12 @@ const ArduinoCli = (pathToBin, config = null) => {
 
   return {
     dumpConfig: getConfig,
+    updateConfig: newConfig => {
+      const newCfg = saveConfig(configPath, newConfig);
+      configPath = newCfg.path;
+      cfg = newCfg.config;
+      return cfg;
+    },
     listConnectedBoards: () => listBoardsWith('list', R.prop('serialBoards')),
     listInstalledBoards: () => listBoardsWith('listall', R.prop('boards')),
     listAvailableBoards: () => listAvailableBoards(cfg.arduino_data),

--- a/packages/arduino-cli/test-func/index.spec.js
+++ b/packages/arduino-cli/test-func/index.spec.js
@@ -1,3 +1,4 @@
+import * as R from 'ramda';
 import { resolve } from 'path';
 import * as fse from 'fs-extra';
 import { assert } from 'chai';
@@ -40,6 +41,27 @@ describe('Arduino Cli', () => {
           assert.strictEqual(res.sketchbook_path, cfg.sketchbook_path);
           assert.strictEqual(res.arduino_data, cfg.arduino_data);
         }));
+  });
+
+  describe('Update arduino-cli config', () => {
+    afterEach(() => fse.remove(tmpDir));
+    it('updates config', async () => {
+      const cli = arduinoCli(PATH_TO_CLI, cfg);
+      const curConf = await cli.dumpConfig();
+
+      assert.strictEqual(curConf.sketchbook_path, cfg.sketchbook_path);
+      assert.strictEqual(curConf.arduino_data, cfg.arduino_data);
+
+      const newDataDir = resolve(tmpDir, 'newData');
+      const newConf = R.assoc('arduino_data', newDataDir, curConf);
+      cli.updateConfig(newConf);
+      const updatedConf = await cli.dumpConfig();
+
+      assert.strictEqual(updatedConf.sketchbook_path, cfg.sketchbook_path);
+      assert.strictEqual(updatedConf.arduino_data, newDataDir);
+
+      return cli;
+    });
   });
 
   describe('Installs additional package index', () => {

--- a/packages/xod-client-electron/src/app/main.js
+++ b/packages/xod-client-electron/src/app/main.js
@@ -241,12 +241,16 @@ const onReady = () => {
       .prepareSketchDir()
       .then(aCli.create)
       .then(arduinoCli => {
-        // TODO: Refactor (WS)
         aCli.subscribeListBoards(arduinoCli);
         aCli.subscribeUpload(arduinoCli);
         aCli.subscribeUpdateIndexes(arduinoCli);
         aCli.subscibeCheckUpdates(arduinoCli);
         aCli.subscribeUpgradeArduinoPackages(arduinoCli);
+
+        // On switching workspace -> update arduino-cli config
+        ipcMain.on(EVENTS.SWITCH_WORKSPACE, (event, newWsPath) =>
+          aCli.switchWorkspace(arduinoCli, newWsPath)
+        );
 
         subscribeOnCheckArduinoDependencies(arduinoCli);
         subscribeOnInstallArduinoDependencies(arduinoCli);

--- a/packages/xod-client-electron/src/app/migrateArduinoPackages.js
+++ b/packages/xod-client-electron/src/app/migrateArduinoPackages.js
@@ -12,7 +12,6 @@ import * as R from 'ramda';
 import * as fse from 'fs-extra';
 import { app } from 'electron';
 
-import { loadWorkspacePath } from './workspaceActions';
 import { ARDUINO_PACKAGES_DIRNAME } from './constants';
 
 const OLD_PACKAGE_VERSIONS = {
@@ -32,9 +31,9 @@ const moveWithoutEexistError = (from, to) =>
 /**
  * Moves old packages into Users' workspace.
  *
- * :: _ -> Promise 0 Error
+ * :: Path -> Promise 0 Error
  */
-export default async () => {
+export default async wsPath => {
   const appData = app.getPath('userData');
   const oldPackagesDir = path.join(appData, 'packages');
   if (!await fse.pathExists(oldPackagesDir)) return 0;
@@ -42,7 +41,6 @@ export default async () => {
   const oldHardwareDir = path.join(oldPackagesDir, 'arduino', 'hardware');
   const archs = await fse.readdir(oldHardwareDir);
 
-  const wsPath = await loadWorkspacePath();
   const wsPackagesDir = path.join(wsPath, ARDUINO_PACKAGES_DIRNAME, 'packages');
   const wsHardwareDir = path.join(wsPackagesDir, 'arduino', 'hardware');
 


### PR DESCRIPTION
Previously, when the user switched workspace and then tried to upload something onto the board or install package — arduino-cli works with the old workspace instead of newly selected one.

This PR make arduino-cli works always with the current user's workspace.
When he switches it — it changes arduino-cli `.cli-config.yml`.