### PR TITLE
Sharp Infrared Range Meters Library

### DIFF
--- a/packages/xod-patch-search/test/index.spec.js
+++ b/packages/xod-patch-search/test/index.spec.js
@@ -60,7 +60,7 @@ describe('xod-patch-search/index', () => {
       const foundPatchPaths = R.map(R.path(['item', 'path']), results);
       assert.equal(
         results[0].item.path,
-        'xod/common-hardware/gp2y0a02-range-meter' // Cause this node has a full match `meter` in the `path`
+        'xod-dev/sharp-irm/gp2y0a02-range-meter' // Cause this node has a full match `meter` in the `path`
       );
       assert.includeMembers(foundPatchPaths, ['xod/units/m-to-ft']); // Don't care about position, but be sure that it's found
     });

--- a/workspace/__lib__/xod-dev/sharp-irm/gp2y0a-linearize/patch.xodp
+++ b/workspace/__lib__/xod-dev/sharp-irm/gp2y0a-linearize/patch.xodp
@@ -1,0 +1,232 @@
+{
+  "links": [
+    {
+      "id": "BJ00BG8oim",
+      "input": {
+        "nodeId": "rJvASzLsjm",
+        "pinKey": "BypX80uSD1Z"
+      },
+      "output": {
+        "nodeId": "ry7ASfUosm",
+        "pinKey": "BkqLCOSw1W"
+      }
+    },
+    {
+      "id": "ByLeCrMLijm",
+      "input": {
+        "nodeId": "Sy9CHMUjjm",
+        "pinKey": "SkdIRuBD1b"
+      },
+      "output": {
+        "nodeId": "rJvASzLsjm",
+        "pinKey": "HyRmUCdBDkZ"
+      }
+    },
+    {
+      "id": "HkdMm6Tj7",
+      "input": {
+        "nodeId": "ryNCSzLji7",
+        "pinKey": "BJlzICOSv1-"
+      },
+      "output": {
+        "nodeId": "Hkt0SGUsiX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HyfgArfLooQ",
+      "input": {
+        "nodeId": "ryNCSzLji7",
+        "pinKey": "rJbGU0_Hv1Z"
+      },
+      "output": {
+        "nodeId": "r1Z0rMUjiX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HynCSfIjj7",
+      "input": {
+        "nodeId": "ryNCSzLji7",
+        "pinKey": "ry1z8CuBDy-"
+      },
+      "output": {
+        "nodeId": "BJeRBfLji7",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "SkpCSM8ssm",
+      "input": {
+        "nodeId": "ry7ASfUosm",
+        "pinKey": "BytUCdHD1-"
+      },
+      "output": {
+        "nodeId": "ryNCSzLji7",
+        "pinKey": "H12bIR_SPyZ"
+      }
+    },
+    {
+      "id": "rJrxCSzLsiX",
+      "input": {
+        "nodeId": "HJdRrGLio7",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "Sy9CHMUjjm",
+        "pinKey": "BkqLCOSw1W"
+      }
+    },
+    {
+      "id": "rk1xASfLijX",
+      "input": {
+        "nodeId": "ryNCSzLji7",
+        "pinKey": "HJCWLAdSwyW"
+      },
+      "output": {
+        "nodeId": "BkUArfLsi7",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "rkQlCBz8jo7",
+      "input": {
+        "nodeId": "ryNCSzLji7",
+        "pinKey": "rkpbU0OrwyZ"
+      },
+      "output": {
+        "nodeId": "SkCrMIjjm",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "rkll0rfLism",
+      "input": {
+        "nodeId": "rJvASzLsjm",
+        "pinKey": "rkJ4URuHDJ-"
+      },
+      "output": {
+        "nodeId": "BkH0BzIsjX",
+        "pinKey": "__out__"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "id": "BJeRBfLji7",
+      "label": "Ymin",
+      "position": {
+        "x": 102,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "BkH0BzIsjX",
+      "label": "SHFT",
+      "position": {
+        "x": 374,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "BkUArfLsi7",
+      "label": "Ymax",
+      "position": {
+        "x": 170,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "Bks0rGUsjX",
+      "position": {
+        "x": 374,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/utility"
+    },
+    {
+      "id": "HJdRrGLio7",
+      "label": "Dm",
+      "position": {
+        "x": 136,
+        "y": 510
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "Hkt0SGUsiX",
+      "label": "V",
+      "position": {
+        "x": 34,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "SkCrMIjjm",
+      "label": "Xmax",
+      "position": {
+        "x": 306,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "boundLiterals": {
+        "BytUCdHD1-": "100"
+      },
+      "description": "Convert centimeters to meters",
+      "id": "Sy9CHMUjjm",
+      "label": "/100",
+      "position": {
+        "x": 136,
+        "y": 408
+      },
+      "type": "xod/core/divide"
+    },
+    {
+      "id": "r1Z0rMUjiX",
+      "label": "Xmin",
+      "position": {
+        "x": 238,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "boundLiterals": {
+        "rkJ4URuHDJ-": "0"
+      },
+      "id": "rJvASzLsjm",
+      "position": {
+        "x": 136,
+        "y": 306
+      },
+      "type": "xod/core/subtract"
+    },
+    {
+      "boundLiterals": {
+        "SkdIRuBD1b": "1"
+      },
+      "description": "Convert 1/(L+SHFT) → L+SHFT",
+      "id": "ry7ASfUosm",
+      "label": "1/Y",
+      "position": {
+        "x": 102,
+        "y": 204
+      },
+      "type": "xod/core/divide"
+    },
+    {
+      "id": "ryNCSzLji7",
+      "position": {
+        "x": 68,
+        "y": 102
+      },
+      "type": "xod/math/map"
+    }
+  ]
+}

--- a/workspace/__lib__/xod-dev/sharp-irm/gp2y0a02-range-meter/patch.xodp
+++ b/workspace/__lib__/xod-dev/sharp-irm/gp2y0a02-range-meter/patch.xodp
@@ -1,0 +1,194 @@
+{
+  "description": "Reads Sharp infrared range meter GP2Y0A02YK0F (the one with 20…150 cm range)",
+  "links": [
+    {
+      "id": "BJp7m6TjQ",
+      "input": {
+        "nodeId": "HkqXQa6iX",
+        "pinKey": "B1GfLR_SPk-"
+      },
+      "output": {
+        "nodeId": "BkUmmMIoiQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HkEVmppi7",
+      "input": {
+        "nodeId": "HkqXQa6iX",
+        "pinKey": "SJ4zUC_BD1-"
+      },
+      "output": {
+        "nodeId": "HJ-QXGIojQ",
+        "pinKey": "SyBtREhlW"
+      }
+    },
+    {
+      "id": "SkGgmQMUjj7",
+      "input": {
+        "nodeId": "HJ-QXGIojQ",
+        "pinKey": "SyKd0E2x-"
+      },
+      "output": {
+        "nodeId": "rkeQ7fUos7",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "SkVeQmGLsjm",
+      "input": {
+        "nodeId": "HJ-QXGIojQ",
+        "pinKey": "SkuhqCqym"
+      },
+      "output": {
+        "nodeId": "HyG7XMUsj7",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "SkmgXXG8ism",
+      "input": {
+        "nodeId": "HkQXGLsjm",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "HJ-QXGIojQ",
+        "pinKey": "BkGpcpcJQ"
+      }
+    },
+    {
+      "id": "SyXYfIisQ",
+      "input": {
+        "nodeId": "HymQQMLojm",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "H1S_MUsjQ",
+        "pinKey": "HJdRrGLio7"
+      }
+    },
+    {
+      "id": "rkfNmaTjm",
+      "input": {
+        "nodeId": "H1S_MUsjQ",
+        "pinKey": "Hkt0SGUsiX"
+      },
+      "output": {
+        "nodeId": "HkqXQa6iX",
+        "pinKey": "BkQzLCurwJZ"
+      }
+    },
+    {
+      "id": "ryrxmmzIjjm",
+      "input": {
+        "nodeId": "H1NQXfLsim",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "HJ-QXGIojQ",
+        "pinKey": "HJgzpqacyX"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "boundLiterals": {
+        "__out__": "5"
+      },
+      "description": "Analog voltage reference, i.e., the voltage level corresponding to the 1.0 value of an analog read. Usually 5 or 3.3 volts matching the board power voltage",
+      "id": "BkUmmMIoiQ",
+      "label": "AVcc",
+      "position": {
+        "x": 204,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "description": "Fires if reading failed. For example, in the case of the wrong port number",
+      "id": "H1NQXfLsim",
+      "label": "ERR",
+      "position": {
+        "x": 272,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "boundLiterals": {
+        "BJeRBfLji7": "0.925",
+        "BkUArfLsi7": "2",
+        "SkCrMIjjm": "0.033",
+        "r1Z0rMUjiX": "0.014"
+      },
+      "id": "H1S_MUsjQ",
+      "position": {
+        "x": 136,
+        "y": 306
+      },
+      "type": "@/gp2y0a-linearize"
+    },
+    {
+      "id": "HJ-QXGIojQ",
+      "position": {
+        "x": 204,
+        "y": 102
+      },
+      "type": "xod/gpio/analog-read"
+    },
+    {
+      "description": "Fires when the reading completes successfully",
+      "id": "HkQXGLsjm",
+      "label": "DONE",
+      "position": {
+        "x": 238,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "id": "HkqXQa6iX",
+      "position": {
+        "x": 136,
+        "y": 204
+      },
+      "type": "xod/core/multiply"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "A0"
+      },
+      "description": "Board port number the sensor is connected to.",
+      "id": "HyG7XMUsj7",
+      "label": "PORT",
+      "position": {
+        "x": 136,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-port"
+    },
+    {
+      "description": "Measured distance in meters. Trustworthy only for distances in [0.3, 1.5] meters range. Returns wrong values if an object is too close to the sensor.",
+      "id": "HymQQMLojm",
+      "label": "Dm",
+      "position": {
+        "x": 136,
+        "y": 408
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "Continuously"
+      },
+      "description": "Triggers an update, that is, rereads values",
+      "id": "rkeQ7fUos7",
+      "label": "UPD",
+      "position": {
+        "x": 272,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    }
+  ]
+}

--- a/workspace/__lib__/xod-dev/sharp-irm/gp2y0a21-range-meter/patch.xodp
+++ b/workspace/__lib__/xod-dev/sharp-irm/gp2y0a21-range-meter/patch.xodp
@@ -1,0 +1,194 @@
+{
+  "description": "Reads Sharp infrared range meter GP2Y0A21YK0F (the one with 10…80 cm range)",
+  "links": [
+    {
+      "id": "B1R_T4TpiQ",
+      "input": {
+        "nodeId": "S1Wu646TjQ",
+        "pinKey": "Hkt0SGUsiX"
+      },
+      "output": {
+        "nodeId": "H1Vu6NT6jQ",
+        "pinKey": "BkQzLCurwJZ"
+      }
+    },
+    {
+      "id": "By9u6NppoQ",
+      "input": {
+        "nodeId": "ByzOTNT6jX",
+        "pinKey": "SyKd0E2x-"
+      },
+      "output": {
+        "nodeId": "ByPu6NaasX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "H1iOp466o7",
+      "input": {
+        "nodeId": "ByzOTNT6jX",
+        "pinKey": "SkuhqCqym"
+      },
+      "output": {
+        "nodeId": "SkBdpVTaim",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HkadpEaasm",
+      "input": {
+        "nodeId": "HyLO6VT6iX",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "S1Wu646TjQ",
+        "pinKey": "HJdRrGLio7"
+      }
+    },
+    {
+      "id": "Hkh_64p6j7",
+      "input": {
+        "nodeId": "Bk7dTEaTo7",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "ByzOTNT6jX",
+        "pinKey": "BkGpcpcJQ"
+      }
+    },
+    {
+      "id": "S1yeu6Vp6sX",
+      "input": {
+        "nodeId": "Byl_64pToQ",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "ByzOTNT6jX",
+        "pinKey": "HJgzpqacyX"
+      }
+    },
+    {
+      "id": "SyFO64T6o7",
+      "input": {
+        "nodeId": "H1Vu6NT6jQ",
+        "pinKey": "SJ4zUC_BD1-"
+      },
+      "output": {
+        "nodeId": "ByzOTNT6jX",
+        "pinKey": "SyBtREhlW"
+      }
+    },
+    {
+      "id": "SyddTV6asX",
+      "input": {
+        "nodeId": "H1Vu6NT6jQ",
+        "pinKey": "B1GfLR_SPk-"
+      },
+      "output": {
+        "nodeId": "rJ_pETpsm",
+        "pinKey": "__out__"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "description": "Fires when the reading completes successfully",
+      "id": "Bk7dTEaTo7",
+      "label": "DONE",
+      "position": {
+        "x": 170,
+        "y": 306
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "Continuously"
+      },
+      "description": "Triggers an update, that is, rereads values",
+      "id": "ByPu6NaasX",
+      "label": "UPD",
+      "position": {
+        "x": 204,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "description": "Fires if reading failed. For example, in the case of the wrong port number",
+      "id": "Byl_64pToQ",
+      "label": "ERR",
+      "position": {
+        "x": 204,
+        "y": 306
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "id": "ByzOTNT6jX",
+      "position": {
+        "x": 136,
+        "y": 204
+      },
+      "type": "xod/gpio/analog-read"
+    },
+    {
+      "id": "H1Vu6NT6jQ",
+      "position": {
+        "x": 68,
+        "y": 306
+      },
+      "type": "xod/core/multiply"
+    },
+    {
+      "description": "Measured distance in meters. Trustworthy only for distances in [0.1, 0.8] meters range. Returns wrong values if an object is too close to the sensor",
+      "id": "HyLO6VT6iX",
+      "label": "Dm",
+      "position": {
+        "x": 68,
+        "y": 510
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "boundLiterals": {
+        "BJeRBfLji7": "0.75",
+        "BkUArfLsi7": "2.325",
+        "SkCrMIjjm": "0.1",
+        "r1Z0rMUjiX": "0.025"
+      },
+      "id": "S1Wu646TjQ",
+      "position": {
+        "x": 68,
+        "y": 408
+      },
+      "type": "@/gp2y0a-linearize"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "A0"
+      },
+      "description": "Board port number the sensor is connected to",
+      "id": "SkBdpVTaim",
+      "label": "PORT",
+      "position": {
+        "x": 68,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/input-port"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "5"
+      },
+      "description": "Analog voltage reference, i.e., the voltage level corresponding to the 1.0 value of an analog read. Usually 5 or 3.3 volts matching the board power voltage",
+      "id": "rJ_pETpsm",
+      "label": "AVcc",
+      "position": {
+        "x": 136,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/input-number"
+    }
+  ]
+}

--- a/workspace/__lib__/xod-dev/sharp-irm/gp2y0a41-range-meter/patch.xodp
+++ b/workspace/__lib__/xod-dev/sharp-irm/gp2y0a41-range-meter/patch.xodp
@@ -1,0 +1,195 @@
+{
+  "description": "Reads Sharp infrared range meter GP2Y0A41SK0F (the one with 4…30 cm range)",
+  "links": [
+    {
+      "id": "B1Ct6p6jX",
+      "input": {
+        "nodeId": "SJ-81rTTs7",
+        "pinKey": "Hkt0SGUsiX"
+      },
+      "output": {
+        "nodeId": "HJteppps7",
+        "pinKey": "BkQzLCurwJZ"
+      }
+    },
+    {
+      "id": "BJoL1Saao7",
+      "input": {
+        "nodeId": "HJfIyrp6j7",
+        "pinKey": "SkuhqCqym"
+      },
+      "output": {
+        "nodeId": "B1SUkH6po7",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "Bk3U1Bp6sm",
+      "input": {
+        "nodeId": "HJmIyHa6o7",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "HJfIyrp6j7",
+        "pinKey": "BkGpcpcJQ"
+      }
+    },
+    {
+      "id": "ByqLkHT6jm",
+      "input": {
+        "nodeId": "HJfIyrp6j7",
+        "pinKey": "SyKd0E2x-"
+      },
+      "output": {
+        "nodeId": "ryvIyH66oX",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "H11gL1BaTiQ",
+      "input": {
+        "nodeId": "rJxI1SpTs7",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "HJfIyrp6j7",
+        "pinKey": "HJgzpqacyX"
+      }
+    },
+    {
+      "id": "HJpUkS6ps7",
+      "input": {
+        "nodeId": "ryI8yHT6iX",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "SJ-81rTTs7",
+        "pinKey": "HJdRrGLio7"
+      }
+    },
+    {
+      "id": "SkyyCpaom",
+      "input": {
+        "nodeId": "HJteppps7",
+        "pinKey": "SJ4zUC_BD1-"
+      },
+      "output": {
+        "nodeId": "HJfIyrp6j7",
+        "pinKey": "SyBtREhlW"
+      }
+    },
+    {
+      "id": "SyVx0a6im",
+      "input": {
+        "nodeId": "HJteppps7",
+        "pinKey": "B1GfLR_SPk-"
+      },
+      "output": {
+        "nodeId": "HJIJSaps7",
+        "pinKey": "__out__"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "boundLiterals": {
+        "__out__": "A0"
+      },
+      "description": "Board port number the sensor is connected to",
+      "id": "B1SUkH6po7",
+      "label": "PORT",
+      "position": {
+        "x": -238,
+        "y": -102
+      },
+      "type": "xod/patch-nodes/input-port"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "5"
+      },
+      "description": "Analog voltage reference, i.e., the voltage level corresponding to the 1.0 value of an analog read. Usually 5 or 3.3 volts matching the board power voltage",
+      "id": "HJIJSaps7",
+      "label": "AVcc",
+      "position": {
+        "x": -170,
+        "y": -102
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "HJfIyrp6j7",
+      "position": {
+        "x": -170,
+        "y": 0
+      },
+      "type": "xod/gpio/analog-read"
+    },
+    {
+      "description": "Fires when the reading completes successfully",
+      "id": "HJmIyHa6o7",
+      "label": "DONE",
+      "position": {
+        "x": -136,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "id": "HJteppps7",
+      "position": {
+        "x": -238,
+        "y": 102
+      },
+      "type": "xod/core/multiply"
+    },
+    {
+      "boundLiterals": {
+        "BJeRBfLji7": "0.3",
+        "BkH0BzIsjX": "0.42",
+        "BkUArfLsi7": "1.4",
+        "SkCrMIjjm": "0.107",
+        "r1Z0rMUjiX": "0.025"
+      },
+      "id": "SJ-81rTTs7",
+      "position": {
+        "x": -238,
+        "y": 204
+      },
+      "type": "@/gp2y0a-linearize"
+    },
+    {
+      "description": "Fires if reading failed. For example, in the case of the wrong port number",
+      "id": "rJxI1SpTs7",
+      "label": "ERR",
+      "position": {
+        "x": -102,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "description": "Measured distance in meters. Trustworthy only for distances in [0.04, 0.3] meters range. Returns wrong values if an object is too close to the sensor",
+      "id": "ryI8yHT6iX",
+      "label": "Dm",
+      "position": {
+        "x": -238,
+        "y": 306
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "Continuously"
+      },
+      "description": "Triggers an update, that is, rereads values",
+      "id": "ryvIyH66oX",
+      "label": "UPD",
+      "position": {
+        "x": -102,
+        "y": -102
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    }
+  ]
+}

--- a/workspace/__lib__/xod-dev/sharp-irm/project.xod
+++ b/workspace/__lib__/xod-dev/sharp-irm/project.xod
@@ -1,0 +1,9 @@
+{
+  "authors": [
+    "XOD"
+  ],
+  "description": "Nodes to read analog infrared range meters by Sharp (GP2Y0A) and convert the signal to distance values.",
+  "license": "AGPL-3.0",
+  "name": "sharp-irm",
+  "version": "0.25.0"
+}

--- a/workspace/__lib__/xod/common-hardware/gp2y0a-linearize/patch.xodp
+++ b/workspace/__lib__/xod/common-hardware/gp2y0a-linearize/patch.xodp
@@ -143,6 +143,15 @@
       "type": "xod/patch-nodes/input-number"
     },
     {
+      "description": "Use `xod-dev/sharp-irm/gp2y0a-linearize` instead",
+      "id": "BkfmHIii7",
+      "position": {
+        "x": 442,
+        "y": 204
+      },
+      "type": "xod/patch-nodes/deprecated"
+    },
+    {
       "id": "BkqJFHDLW",
       "label": "Xmin",
       "position": {

--- a/workspace/__lib__/xod/common-hardware/gp2y0a02-range-meter/patch.xodp
+++ b/workspace/__lib__/xod/common-hardware/gp2y0a02-range-meter/patch.xodp
@@ -2,58 +2,58 @@
   "description": "Reads Sharp infrared range meter GP2Y0A02YK0F (the one with 20…150 cm range).",
   "links": [
     {
-      "id": "B1gmUoSxX",
+      "id": "BkFA_HIooX",
       "input": {
-        "nodeId": "ByTMIiSl7",
-        "pinKey": "SyKd0E2x-"
+        "nodeId": "rJNCdrLsom",
+        "pinKey": "SkuhqCqym"
       },
       "output": {
-        "nodeId": "B1rqmq_8Z",
+        "nodeId": "H1mAuB8sjm",
         "pinKey": "__out__"
       }
     },
     {
-      "id": "S1vXLsrxm",
+      "id": "S1LROSIjjQ",
+      "input": {
+        "nodeId": "rJNCdrLsom",
+        "pinKey": "SyKd0E2x-"
+      },
+      "output": {
+        "nodeId": "BJlCuH8ojQ",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "SJq0ur8jjQ",
+      "input": {
+        "nodeId": "S1rAuSLji7",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "rJNCdrLsom",
+        "pinKey": "BkGpcpcJQ"
+      }
+    },
+    {
+      "id": "r1jCOS8ojm",
+      "input": {
+        "nodeId": "rk-C_BUijQ",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "rJNCdrLsom",
+        "pinKey": "HJgzpqacyX"
+      }
+    },
+    {
+      "id": "rJbqB8ji7",
       "input": {
         "nodeId": "SycjXcO8Z",
         "pinKey": "SyTBDSwIZ"
       },
       "output": {
-        "nodeId": "ByTMIiSl7",
+        "nodeId": "rJNCdrLsom",
         "pinKey": "SyBtREhlW"
-      }
-    },
-    {
-      "id": "r1VDLjreX",
-      "input": {
-        "nodeId": "B1VU8irgX",
-        "pinKey": "__in__"
-      },
-      "output": {
-        "nodeId": "ByTMIiSl7",
-        "pinKey": "BkGpcpcJQ"
-      }
-    },
-    {
-      "id": "r1fXUiBgQ",
-      "input": {
-        "nodeId": "ByTMIiSl7",
-        "pinKey": "SkuhqCqym"
-      },
-      "output": {
-        "nodeId": "ByaY75_Ib",
-        "pinKey": "__out__"
-      }
-    },
-    {
-      "id": "rJGDUsrgX",
-      "input": {
-        "nodeId": "S1vULore7",
-        "pinKey": "__in__"
-      },
-      "output": {
-        "nodeId": "ByTMIiSl7",
-        "pinKey": "HJgzpqacyX"
       }
     },
     {
@@ -70,66 +70,57 @@
   ],
   "nodes": [
     {
-      "description": "Fires when reading is done",
-      "id": "B1VU8irgX",
-      "label": "DONE",
+      "description": "Use `xod-dev/sharp-irm/gp2y0a02-range-meter` instead",
+      "id": "BJl6rLiiX",
       "position": {
-        "x": 204,
-        "y": 306
+        "x": 238,
+        "y": -102
       },
-      "type": "xod/patch-nodes/output-pulse"
+      "type": "xod/patch-nodes/deprecated"
     },
     {
       "boundLiterals": {
         "__out__": "Continuously"
       },
       "description": "Triggers an update, i.e. reading values again.",
-      "id": "B1rqmq_8Z",
+      "id": "BJlCuH8ojQ",
       "label": "UPD",
       "position": {
-        "x": 204,
-        "y": 0
+        "x": 102,
+        "y": -204
       },
       "type": "xod/patch-nodes/input-pulse"
     },
     {
-      "id": "ByTMIiSl7",
+      "description": "Measured distance in meters. Trustworthy only for distances in [0.3, 1.5] meters range. Returns wrong values if an object is too close to the sensor.",
+      "id": "H1JpXq_I-",
+      "label": "Dm",
       "position": {
-        "x": 170,
+        "x": -102,
         "y": 102
       },
-      "type": "xod/gpio/analog-read"
+      "type": "xod/patch-nodes/output-number"
     },
     {
       "boundLiterals": {
         "__out__": "A0"
       },
       "description": "Board port number the sensor is connected to.",
-      "id": "ByaY75_Ib",
+      "id": "H1mAuB8sjm",
       "label": "PORT",
       "position": {
-        "x": 170,
-        "y": 0
+        "x": 68,
+        "y": -204
       },
       "type": "xod/patch-nodes/input-port"
     },
     {
-      "description": "Measured distance in meters. Trustworhy only for distances in [0.3, 1.5] meters range.",
-      "id": "H1JpXq_I-",
-      "label": "Dm",
+      "description": "Fires when reading is done",
+      "id": "S1rAuSLji7",
+      "label": "DONE",
       "position": {
-        "x": 0,
-        "y": 306
-      },
-      "type": "xod/patch-nodes/output-number"
-    },
-    {
-      "description": "Fires if reading failed",
-      "id": "S1vULore7",
-      "label": "ERR",
-      "position": {
-        "x": 238,
-        "y": 306
+        "x": 102,
+        "y": 102
       },
       "type": "xod/patch-nodes/output-pulse"
     },
@@ -142,10 +133,28 @@
       },
       "id": "SycjXcO8Z",
       "position": {
-        "x": 0,
-        "y": 204
+        "x": -102,
+        "y": 0
       },
       "type": "@/gp2y0a-linearize"
+    },
+    {
+      "id": "rJNCdrLsom",
+      "position": {
+        "x": 68,
+        "y": -102
+      },
+      "type": "xod/gpio/analog-read"
+    },
+    {
+      "description": "Fires if reading failed",
+      "id": "rk-C_BUijQ",
+      "label": "ERR",
+      "position": {
+        "x": 136,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/output-pulse"
     }
   ]
 }

--- a/workspace/__lib__/xod/common-hardware/gp2y0a21-range-meter/patch.xodp
+++ b/workspace/__lib__/xod/common-hardware/gp2y0a21-range-meter/patch.xodp
@@ -146,6 +146,15 @@
         "y": 204
       },
       "type": "@/gp2y0a-linearize"
+    },
+    {
+      "description": "Use `xod-dev/sharp-irm/gp2y0a21-range-meter` instead",
+      "id": "rkxRS8osQ",
+      "position": {
+        "x": 340,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/deprecated"
     }
   ]
 }

--- a/workspace/__lib__/xod/common-hardware/gp2y0a41-range-meter/patch.xodp
+++ b/workspace/__lib__/xod/common-hardware/gp2y0a41-range-meter/patch.xodp
@@ -108,6 +108,15 @@
       "type": "xod/patch-nodes/output-pulse"
     },
     {
+      "description": "Use `xod-dev/sharp-irm/gp2y0a41-range-meter` instead",
+      "id": "Hy71UIosm",
+      "position": {
+        "x": 340,
+        "y": 102
+      },
+      "type": "xod/patch-nodes/deprecated"
+    },
+    {
       "description": "Measured distance in meters. Trustworhy only for distances in [0.04, 0.30] meters range.",
       "id": "S10ecHDUW",
       "label": "Dm",


### PR DESCRIPTION
PR refers to the [XEN-L005](https://github.com/xodio/xod-xens/tree/master/XEN-L005)

- Transfers range meter nodes for Sharp devices to the new `xod-dev/sharp-irm` library;
- Deprecates the previous Sharp nodes at the `xod/common-hardware` library.
- For new nodes, adds the analog reference voltage adjustment. 