### PR TITLE
Fix exception on close of IDE

### DIFF
--- a/packages/xod-client-electron/src/app/subscribeIpc.js
+++ b/packages/xod-client-electron/src/app/subscribeIpc.js
@@ -6,7 +6,17 @@ import { errorToPlainObject } from './utils';
 export default (fn, eventName) => {
   const STATES = getAllStatesForEvent(eventName);
   ipcMain.on(STATES.BEGIN, (event, payload) => {
-    const onProgress = data => event.sender.send(STATES.PROCESS, data);
+    // Prevent sending data to the closed window
+    // because it produces an exception
+    if (event.sender.isDestroyed()) return;
+
+    const onProgress = data => {
+      // Prevent sending data to the closed window
+      // because it produces an exception
+      if (event.sender.isDestroyed()) return;
+
+      event.sender.send(STATES.PROCESS, data);
+    };
 
     fn(event, payload, onProgress)
       .then(res => event.sender.send(STATES.COMPLETE, res))


### PR DESCRIPTION
While some process that communicates through IPC using `promifisyIpc` and `subscribeIpc` modules is running it tries to send process/success/failure messages to the renderer from the main process. For example, installing arduino C++ libraries, arduino packages, upload to the board and etc.
So when User closes IDE while a process is running it causes exception, cause the main process can't send data to the renderer, that was destroyed.

Fortunately, electron developers added a method `event.sender.isDestroyed()`, so we can avoid sending data to the destroyed process. That I did in this PR and it fixes the bug.

**How to reproduce the bug**
1. Open previous IDE version.
2. Start installation of some arduino package.
3. Close the window before it's done.
4. You'll see an exception in the OS dialog window.

Then you can checkout this branch and repeat these steps to be sure it works fine :)