### PR TITLE
Select all patch entities or input contents from menu item

### DIFF
--- a/packages/xod-client-browser/src/containers/App.jsx
+++ b/packages/xod-client-browser/src/containers/App.jsx
@@ -54,6 +54,17 @@ class App extends client.App {
 
     props.actions.openProject(props.tutorialProject);
     props.actions.fetchGrant();
+
+    document.addEventListener('keydown', event => {
+      // Prevent selecting all contents with "Ctrl+a" or "Command+a"
+      // Ctrl+a or Command+a
+      const key = event.keyCode || event.which;
+      const mod = event.metaKey || event.ctrlKey;
+      if (mod && key === 65 && !client.isInputTarget(event)) {
+        event.preventDefault();
+        this.props.actions.selectAll();
+      }
+    });
   }
 
   onDocumentClick(e) {
@@ -249,6 +260,8 @@ class App extends client.App {
         onClick(items.undo, this.props.actions.undoCurrentPatch),
         onClick(items.redo, this.props.actions.redoCurrentPatch),
         items.separator,
+        onClick(items.selectall, this.props.actions.selectAll),
+        items.separator,
         onClick(items.insertNode, () => this.props.actions.showSuggester(null)),
         onClick(items.insertComment, this.props.actions.addComment),
         items.separator,
@@ -325,7 +338,11 @@ class App extends client.App {
 
   render() {
     return (
-      <HotKeys id="App" keyMap={client.HOTKEY} handlers={this.hotkeyHandlers}>
+      <HotKeys
+        id="App"
+        keyMap={client.menu.getOsSpecificHotkeys()}
+        handlers={this.hotkeyHandlers}
+      >
         <EventListener
           target={window}
           onResize={this.onResize}

--- a/packages/xod-client-browser/src/containers/App.jsx
+++ b/packages/xod-client-browser/src/containers/App.jsx
@@ -54,17 +54,6 @@ class App extends client.App {
 
     props.actions.openProject(props.tutorialProject);
     props.actions.fetchGrant();
-
-    document.addEventListener('keydown', event => {
-      // Prevent selecting all contents with "Ctrl+a" or "Command+a"
-      // Ctrl+a or Command+a
-      const key = event.keyCode || event.which;
-      const mod = event.metaKey || event.ctrlKey;
-      if (mod && key === 65 && !client.isInputTarget(event)) {
-        event.preventDefault();
-        this.props.actions.selectAll();
-      }
-    });
   }
 
   onDocumentClick(e) {

--- a/packages/xod-client-electron/src/view/containers/App.jsx
+++ b/packages/xod-client-electron/src/view/containers/App.jsx
@@ -99,6 +99,7 @@ class App extends client.App {
     this.onResize = this.onResize.bind(this);
 
     this.suggestProjectFilePath = this.suggestProjectFilePath.bind(this);
+    this.selectAll = this.selectAll.bind(this);
 
     this.onUploadToArduinoClicked = this.onUploadToArduinoClicked.bind(this);
     this.onUploadToArduinoAndDebugClicked = this.onUploadToArduinoAndDebugClicked.bind(
@@ -575,7 +576,19 @@ class App extends client.App {
         items.cut,
         items.copy,
         items.paste,
-        items.selectall,
+        onClick(items.selectall, () => {
+          // We can't use `role: 'selectall'` here, cause it ignores `onClick`.
+          // So we have to handle all cases manually:
+
+          // - select all in inputs
+          if (client.isInput(document.activeElement)) {
+            document.activeElement.select();
+            return;
+          }
+
+          // - select entities on Patch
+          this.props.actions.selectAll();
+        }),
         items.separator,
         onClick(items.insertNode, () => this.props.actions.showSuggester(null)),
         onClick(items.insertComment, this.props.actions.addComment),

--- a/packages/xod-client-electron/src/view/containers/App.jsx
+++ b/packages/xod-client-electron/src/view/containers/App.jsx
@@ -576,19 +576,7 @@ class App extends client.App {
         items.cut,
         items.copy,
         items.paste,
-        onClick(items.selectall, () => {
-          // We can't use `role: 'selectall'` here, cause it ignores `onClick`.
-          // So we have to handle all cases manually:
-
-          // - select all in inputs
-          if (client.isInput(document.activeElement)) {
-            document.activeElement.select();
-            return;
-          }
-
-          // - select entities on Patch
-          this.props.actions.selectAll();
-        }),
+        onClick(items.selectall, this.selectAll),
         items.separator,
         onClick(items.insertNode, () => this.props.actions.showSuggester(null)),
         onClick(items.insertComment, this.props.actions.addComment),
@@ -765,6 +753,21 @@ class App extends client.App {
 
   hideAllPopups() {
     this.props.actions.hideAllPopups();
+  }
+
+  selectAll() {
+    // Handler for menu item "Select All"
+    // We can't use `role: 'selectall'` here, because it ignores `onClick`.
+    // So we have to handle all cases manually:
+
+    // - select all in inputs
+    if (client.isInput(document.activeElement)) {
+      document.activeElement.select();
+      return;
+    }
+
+    // - select entities on Patch
+    this.props.actions.selectAll();
   }
 
   static listPorts() {

--- a/packages/xod-client/src/core/containers/App.jsx
+++ b/packages/xod-client/src/core/containers/App.jsx
@@ -20,6 +20,7 @@ import PopupProjectPreferences from '../../project/components/PopupProjectPrefer
 import PopupPublishProject from '../../project/components/PopupPublishProject';
 
 import * as actions from '../actions';
+import { selectAll } from '../../editor/actions';
 import { NO_PATCH_TO_TRANSPILE } from '../../editor/messages';
 
 import formatErrorMessage from '../formatErrorMessage';
@@ -177,6 +178,7 @@ App.propTypes = {
 };
 
 App.actions = {
+  selectAll,
   updateCompileLimit: actions.updateCompileLimit,
   createProject: actions.createProject,
   requestPublishProject: actions.requestPublishProject,

--- a/packages/xod-client/src/core/containers/App.jsx
+++ b/packages/xod-client/src/core/containers/App.jsx
@@ -11,6 +11,7 @@ import {
   transpile,
 } from 'xod-arduino';
 
+import { isInputTarget } from '../../utils/browser';
 import { lowercaseKebabMask } from '../../utils/inputFormatting';
 import sanctuaryPropType from '../../utils/sanctuaryPropType';
 
@@ -32,6 +33,25 @@ export default class App extends React.Component {
     this.transformProjectForTranspiler = this.transformProjectForTranspiler.bind(
       this
     );
+
+    /**
+     * We have to handle some hotkeys, because:
+     * - Browser IDE should prevent default event handling
+     * - Electron IDE cannot handle some hotkeys correctly
+     *   "...some keybindings cannot be overridden on Windows/Linux because they are hard-coded in Chrome."
+     *   See details: https://github.com/electron/electron/issues/7165 and related issues
+     */
+    document.addEventListener('keydown', event => {
+      // Prevent selecting all contents with "Ctrl+a" or "Command+a"
+      const key = event.keyCode || event.which;
+      const mod = event.metaKey || event.ctrlKey;
+
+      // CmdOrCtrl+A
+      if (mod && key === 65 && !isInputTarget(event)) {
+        event.preventDefault();
+        this.props.actions.selectAll();
+      }
+    });
   }
   componentDidMount() {
     document.addEventListener('cut', this.props.actions.cutEntities);
@@ -138,6 +158,7 @@ App.propTypes = {
   popups: PropTypes.objectOf(PropTypes.bool),
   popupsData: PropTypes.objectOf(PropTypes.object),
   actions: PropTypes.shape({
+    selectAll: PropTypes.func.isRequired,
     updateCompileLimit: PropTypes.func.isRequired,
     createProject: PropTypes.func.isRequired,
     updateProjectMeta: PropTypes.func.isRequired,

--- a/packages/xod-client/src/editor/actions.js
+++ b/packages/xod-client/src/editor/actions.js
@@ -113,6 +113,16 @@ export const setEditorSelection = entities => ({
   payload: { entities },
 });
 
+export const selectAll = () => (dispatch, getState) => {
+  const state = getState();
+  const selection = {
+    nodes: R.values(ProjectSelectors.getCurrentPatchNodes(state)),
+    links: R.values(ProjectSelectors.getCurrentPatchLinks(state)),
+    comments: R.values(ProjectSelectors.getCurrentPatchComments(state)),
+  };
+  return dispatch(setEditorSelection(selection));
+};
+
 export const addAndSelectNode = (
   typeId,
   position,

--- a/packages/xod-client/src/editor/containers/Patch/index.jsx
+++ b/packages/xod-client/src/editor/containers/Patch/index.jsx
@@ -334,6 +334,7 @@ const mapDispatchToProps = dispatch => ({
       resizeNode: ProjectActions.resizeNode,
       deselectAll: EditorActions.deselectAll,
       deleteSelection: EditorActions.deleteSelection,
+      selectAll: EditorActions.selectAll,
       selectLink: EditorActions.selectLink,
       selectNode: EditorActions.selectNode,
       selectComment: EditorActions.selectComment,

--- a/packages/xod-client/src/editor/containers/Patch/modes/selecting.jsx
+++ b/packages/xod-client/src/editor/containers/Patch/modes/selecting.jsx
@@ -198,12 +198,8 @@ const selectingMode = {
   },
   onSelectAll({ props }, event) {
     if (isInputTarget(event)) return;
-
     event.preventDefault();
-
-    props.actions.setSelection(
-      R.compose(R.map(R.values), R.pick(['nodes', 'links', 'comments']))(props)
-    );
+    props.actions.selectAll();
   },
   onBackgroundClick(api, event) {
     // to prevent misclicks when selecting multiple entities

--- a/packages/xod-client/src/utils/browser.js
+++ b/packages/xod-client/src/utils/browser.js
@@ -46,3 +46,5 @@ export const isInputTarget = event => isInput(event.target || event.srcElement);
 
 export const isEdge = () =>
   R.compose(R.test(/Edge/), R.pathOr('', ['navigator', 'userAgent']))(window);
+
+export const isMacOS = () => window.navigator.appVersion.indexOf('Mac') !== -1;

--- a/packages/xod-client/src/utils/constants.js
+++ b/packages/xod-client/src/utils/constants.js
@@ -38,7 +38,7 @@ export const HOTKEY = {
   [COMMAND.DELETE_SELECTION]: ['del', 'backspace'],
 
   [COMMAND.DESELECT]: 'escape',
-  [COMMAND.SELECT_ALL]: ['ctrl+a', 'command+a'],
+  [COMMAND.SELECT_ALL]: 'CmdOrCtrl+a',
 
   [COMMAND.UNDO]: 'ctrl+z',
   [COMMAND.REDO]: ['ctrl+y', 'ctrl+shift+z'],
@@ -61,7 +61,7 @@ export const HOTKEY = {
   [COMMAND.MAKE_BUS]: ['b'],
 
   [COMMAND.PAN_TO_ORIGIN]: ['home'],
-  [COMMAND.PAN_TO_CENTER]: ['ctrl+home', 'command+home'],
+  [COMMAND.PAN_TO_CENTER]: 'CmdOrCtrl+home',
 };
 
 export const ELECTRON_ACCELERATOR = {

--- a/packages/xod-client/src/utils/menu.js
+++ b/packages/xod-client/src/utils/menu.js
@@ -1,5 +1,6 @@
 import * as R from 'ramda';
 import { HOTKEY, ELECTRON_ACCELERATOR, COMMAND } from './constants';
+import { isMacOS } from './browser';
 
 const rawItems = {
   file: {
@@ -152,11 +153,45 @@ const rawItems = {
   },
 };
 
+const containsCmd = R.contains('command');
+
+// :: String -> String
+const unfoldCmdOrCtrl = R.ifElse(
+  () => isMacOS(),
+  R.replace(/CmdOrCtrl/gi, 'command'),
+  R.replace(/CmdOrCtrl/gi, 'ctrl')
+);
+
+/**
+ * Filters OS-specific hotkeys.
+ *
+ * E.G.,
+ * `['ctrl+a', 'command+a']`
+ * will become ['ctrl+a'] on Windows / Linux
+ * and ['command+a'] on MacOS
+ *
+ * But in case there are only 'ctrl+a' hotkey defined
+ * it will be left untouched on MacOS.
+ *
+ * :: String|[String] -> [String]
+ */
+export const filterOsHotkeys = R.compose(
+  R.map(unfoldCmdOrCtrl),
+  R.ifElse(
+    () => isMacOS(),
+    R.when(R.any(containsCmd), R.filter(containsCmd)),
+    R.reject(containsCmd)
+  ),
+  R.unless(R.is(Array), R.of)
+);
+
 const assignHotkeys = menuItem =>
   R.when(
     R.prop('command'),
     R.merge({
-      hotkey: HOTKEY[menuItem.command],
+      hotkey: R.compose(filterOsHotkeys, R.propOr([], menuItem.command))(
+        HOTKEY
+      ),
       accelerator: ELECTRON_ACCELERATOR[menuItem.command],
     }),
     menuItem
@@ -174,3 +209,6 @@ export const onClick = R.flip(R.assoc('click'));
 
 /** add children items to menu item */
 export const submenu = R.flip(R.assoc('submenu'));
+
+/** returns hotkeys key map with filtered OS specific key mapping */
+export const getOsSpecificHotkeys = () => R.map(filterOsHotkeys, HOTKEY);

--- a/packages/xod-client/src/utils/menu.js
+++ b/packages/xod-client/src/utils/menu.js
@@ -80,7 +80,6 @@ const rawItems = {
   selectall: {
     label: 'Select All',
     command: COMMAND.SELECT_ALL,
-    role: 'selectall',
   },
   projectPreferences: {
     label: 'Project Preferences',


### PR DESCRIPTION
It fixes #1497.

Also, I've added "Select All" menu item into browser version of the IDE, that selects all entities on the Patch.