### PR TITLE
Handle package indexes update fails

### DIFF
--- a/packages/arduino-cli/README.md
+++ b/packages/arduino-cli/README.md
@@ -73,17 +73,8 @@ Returns a list of all boards that found in all `package_*_index.json` files.
 
 - Returns `Promise<Array<AvailableBoard>>`
 
-### addPackageIndexUrl(url)
-Adds an additional package index URL to the config file.
-Later you can download and install the package with `arduino-cli` (call `core.updateIndex()`).
-
-Accepts:
-- `url` `<String>` — a URL of the third-party `package_*_index.json` file
-
-- Returns `Promise<String>` with the just added URL
-
-### addPackageIndexUrls(urls)
-Adds a list of additional package index urls into the config file.
+### setPackageIndexUrls(urls)
+Sets a list of additional package index urls into the config file.
 Later you can download and install packages with `arduino-cli` (call `core.updateIndex()`).
 
 Accepts:

--- a/packages/arduino-cli/src/config.js
+++ b/packages/arduino-cli/src/config.js
@@ -4,10 +4,14 @@ import { resolve } from 'path';
 import * as fse from 'fs-extra';
 import YAML from 'yamljs';
 
+export const ADDITIONAL_URLS_PATH = ['board_manager', 'additional_urls'];
+
 const getDefaultConfig = configDir => ({
   sketchbook_path: resolve(configDir, 'sketchbook'),
   arduino_data: resolve(configDir, 'data'),
 });
+
+const stringifyConfig = cfg => YAML.stringify(cfg, 10, 2);
 
 // :: Path -> Object -> { config: Object, path: Path }
 export const saveConfig = (configPath, config) => {
@@ -35,25 +39,11 @@ export const configure = inputConfig => {
 };
 
 // :: Path -> [URL] -> Promise [URL] Error
-export const addPackageIndexUrls = (configPath, urls) =>
+export const setPackageIndexUrls = (configPath, urls) =>
   fse
     .readFile(configPath, { encoding: 'utf8' })
     .then(YAML.parse)
-    .then(
-      R.over(
-        R.lensPath(['board_manager', 'additional_urls']),
-        R.pipe(
-          R.defaultTo([]),
-          R.concat(R.__, urls),
-          R.reject(R.isEmpty),
-          R.uniq
-        )
-      )
-    )
-    .then(cfg => YAML.stringify(cfg, 10, 2))
+    .then(R.assocPath(ADDITIONAL_URLS_PATH, urls))
+    .then(stringifyConfig)
     .then(data => fse.writeFile(configPath, data))
     .then(R.always(urls));
-
-// :: Path -> URL -> Promise URL Error
-export const addPackageIndexUrl = (configPath, url) =>
-  addPackageIndexUrls(configPath, [url]).then(R.always(url));

--- a/packages/arduino-cli/src/index.js
+++ b/packages/arduino-cli/src/index.js
@@ -5,12 +5,7 @@ import { exec, spawn } from 'child-process-promise';
 import YAML from 'yamljs';
 import { remove } from 'fs-extra';
 
-import {
-  saveConfig,
-  configure,
-  addPackageIndexUrl,
-  addPackageIndexUrls,
-} from './config';
+import { saveConfig, configure, setPackageIndexUrls } from './config';
 import { patchBoardsWithOptions } from './optionParser';
 import listAvailableBoards from './listAvailableBoards';
 import parseProgressLog from './parseProgressLog';
@@ -113,7 +108,7 @@ const ArduinoCli = (pathToBin, config = null) => {
     },
     listConnectedBoards: () => listBoardsWith('list', R.prop('serialBoards')),
     listInstalledBoards: () => listBoardsWith('listall', R.prop('boards')),
-    listAvailableBoards: () => listAvailableBoards(cfg.arduino_data),
+    listAvailableBoards: () => listAvailableBoards(getConfig, cfg.arduino_data),
     compile: (onProgress, fqbn, sketchName, verbose = false) =>
       runWithProgress(
         onProgress,
@@ -164,8 +159,7 @@ const ArduinoCli = (pathToBin, config = null) => {
       run(`sketch new ${sketchName}`).then(
         R.always(resolve(cfg.sketchbook_path, sketchName, `${sketchName}.ino`))
       ),
-    addPackageIndexUrl: url => addPackageIndexUrl(configPath, url),
-    addPackageIndexUrls: urls => addPackageIndexUrls(configPath, urls),
+    setPackageIndexUrls: urls => setPackageIndexUrls(configPath, urls),
   };
 };
 

--- a/packages/arduino-cli/test-func/index.spec.js
+++ b/packages/arduino-cli/test-func/index.spec.js
@@ -72,14 +72,14 @@ describe('Arduino Cli', () => {
     it('adds URL into .cli-config.yml', () => {
       const cli = arduinoCli(PATH_TO_CLI, cfg);
       return cli
-        .addPackageIndexUrl(url)
+        .setPackageIndexUrls([url])
         .then(() => cli.dumpConfig())
         .then(res => assert.include(res.board_manager.additional_urls, url));
     });
     it('downloads additional package index', () => {
       const cli = arduinoCli(PATH_TO_CLI, cfg);
       return cli
-        .addPackageIndexUrl(url)
+        .setPackageIndexUrls([url])
         .then(() => cli.core.updateIndex())
         .then(() =>
           fse.pathExists(

--- a/packages/arduino-cli/test-func/listAvailableBoards.spec.js
+++ b/packages/arduino-cli/test-func/listAvailableBoards.spec.js
@@ -195,7 +195,12 @@ describe('listAvailableBoards()', () => {
   ];
 
   it('Lists boards parsed from two package index files', () =>
-    listAvailableBoards(fixturesDir).then(res =>
-      assert.sameDeepMembers(res, boards)
-    ));
+    listAvailableBoards(
+      () => ({
+        board_manager: {
+          additional_urls: ['http://test.com/package_esp8266com_index.json'],
+        },
+      }),
+      fixturesDir
+    ).then(res => assert.sameDeepMembers(res, boards)));
 });

--- a/packages/xod-client-electron/src/app/arduinoDependencies.js
+++ b/packages/xod-client-electron/src/app/arduinoDependencies.js
@@ -14,7 +14,6 @@ import {
   checkLibrariesInstalledByUrls,
   installLibrariesByUrls,
 } from 'xod-deploy';
-import { createError } from 'xod-func-tools';
 
 import {
   CHECK_ARDUINO_DEPENDENCIES_INSTALLED,
@@ -42,15 +41,10 @@ const checkArduinoPackageInstalled = async (cli, packages) => {
 };
 
 // :: (ProgressData -> _) -> ArduinoCli -> [{ package, packageName }] -> Promise [{ package, packageName, installed }] Error
-const installArduinoPackages = async (onProgress, cli, packages) =>
-  Promise.all(R.map(pkg => cli.core.install(onProgress, pkg.package))(packages))
-    .then(() => R.map(R.assoc('installed', true))(packages))
-    .catch(async () => {
-      throw createError('CANT_INSTALL_ARDUINO_PACKAGE', {
-        workspacePath: await loadWorkspacePath(),
-        packageNames: R.pluck('packageName', packages),
-      });
-    });
+const installArduinoPackages = (onProgress, cli, packages) =>
+  Promise.all(
+    R.map(pkg => cli.core.install(onProgress, pkg.package))(packages)
+  ).then(() => R.map(R.assoc('installed', true))(packages));
 
 export const subscribeOnCheckArduinoDependencies = arduinoCli =>
   subscribeIpc(

--- a/packages/xod-client-electron/src/arduinoDependencies/middleware.js
+++ b/packages/xod-client-electron/src/arduinoDependencies/middleware.js
@@ -8,6 +8,8 @@ import { ARDUPACKAGES_UPGRADE_PROCEED } from './actionTypes';
 import MSG from './messages';
 import getLibraryNames from './getLibraryNames';
 
+import { formatErrorMessage, formatLogError } from '../view/formatError';
+
 const progressToProcess = R.curry((processFn, progressData) => {
   processFn(progressData.message, progressData.percentage);
 });
@@ -43,7 +45,12 @@ export default store => next => action => {
             );
             proc.success();
           })
-          .catch(err => proc.fail(err.message, 0));
+          .catch(err => {
+            const snackbarError = formatErrorMessage(err);
+            const logErr = formatLogError(err);
+            store.dispatch(client.addError(snackbarError));
+            proc.fail(logErr, 0);
+          });
       },
       maybeData
     );
@@ -61,7 +68,12 @@ export default store => next => action => {
         );
         proc.success();
       })
-      .catch(err => proc.fail(err.message, 0));
+      .catch(err => {
+        const snackbarError = formatErrorMessage(err);
+        const logErr = formatLogError(err);
+        store.dispatch(client.addError(snackbarError));
+        proc.fail(logErr, 0);
+      });
   }
 
   return next(action);

--- a/packages/xod-client-electron/src/upload/components/PopupUploadConfig.jsx
+++ b/packages/xod-client-electron/src/upload/components/PopupUploadConfig.jsx
@@ -124,7 +124,8 @@ class PopupUploadConfig extends React.Component {
         if (!isBoardSelected || !doesSelectedBoardExist) {
           this.changeBoard(defaultBoardIndex);
         }
-      });
+      })
+      .catch(this.props.onError);
   }
 
   getPorts() {
@@ -177,7 +178,10 @@ class PopupUploadConfig extends React.Component {
     this.setState({ boards: null });
     updateIndexFiles()
       .then(() => this.getBoards())
-      .catch(() => this.setState({ boards: oldBoards }));
+      .catch(err => {
+        this.props.onError(err);
+        this.setState({ boards: oldBoards });
+      });
   }
 
   changeBoard(boardIndex) {
@@ -423,6 +427,7 @@ PopupUploadConfig.propTypes = {
   onPortChanged: PropTypes.func,
   onUpload: PropTypes.func,
   onClose: PropTypes.func,
+  onError: PropTypes.func,
 };
 
 PopupUploadConfig.defaultProps = {

--- a/packages/xod-client-electron/src/upload/messages.js
+++ b/packages/xod-client-electron/src/upload/messages.js
@@ -29,9 +29,4 @@ export default {
     note: error,
     solution: `Check your internet connection and correctness of URLs in "${pkgPath}/extra.txt", then try again`,
   }),
-  CANT_INSTALL_ARDUINO_PACKAGE: ({ workspacePath, packageNames }) => ({
-    title: 'Cannot install arduino packages',
-    note: `Tried to install "${packageNames}", but arduino-cli exited with an error`,
-    solution: `Check that "${workspacePath}/__packages__/extra.txt" contains an url to the index file of core, that you want to install and try again`,
-  }),
 };

--- a/packages/xod-client-electron/src/upload/messages.js
+++ b/packages/xod-client-electron/src/upload/messages.js
@@ -19,4 +19,19 @@ export default {
   UPLOADED_SUCCESSFULLY: () => ({
     title: 'Uploaded successfully',
   }),
+  UPDATE_INDEXES_ERROR_BROKEN_FILE: ({ pkgPath, error }) => ({
+    title: 'Package index broken',
+    note: `Error: ${error}`,
+    solution: `Check correctness of the corresponding URL in "${pkgPath}/extra.txt" and try to update indexes again`,
+  }),
+  UPDATE_INDEXES_ERROR_NO_CONNECTION: ({ pkgPath, error }) => ({
+    title: 'Cannot update indexes',
+    note: error,
+    solution: `Check your internet connection and correctness of URLs in "${pkgPath}/extra.txt", then try again`,
+  }),
+  CANT_INSTALL_ARDUINO_PACKAGE: ({ workspacePath, packageNames }) => ({
+    title: 'Cannot install arduino packages',
+    note: `Tried to install "${packageNames}", but arduino-cli exited with an error`,
+    solution: `Check that "${workspacePath}/__packages__/extra.txt" contains an url to the index file of core, that you want to install and try again`,
+  }),
 };

--- a/packages/xod-client-electron/src/view/formatError.js
+++ b/packages/xod-client-electron/src/view/formatError.js
@@ -1,0 +1,23 @@
+import { composeErrorFormatters } from 'xod-func-tools';
+import { messages as xpMessages } from 'xod-project';
+import { messages as xdMessages } from 'xod-deploy';
+
+import { default as arduinoDepMessages } from '../arduinoDependencies/messages';
+import uploadMessages from '../upload/messages';
+
+export const formatErrorMessage = composeErrorFormatters([
+  xpMessages,
+  xdMessages,
+  arduinoDepMessages,
+  uploadMessages,
+]);
+
+export const formatLogError = error => {
+  const stanza = formatErrorMessage(error);
+  return [
+    ...(stanza.title ? [stanza.title] : []),
+    ...(stanza.path ? [stanza.path.join(' -> ')] : []),
+    ...(stanza.note ? [stanza.note] : []),
+    ...(stanza.solution ? [stanza.solution] : []),
+  ].join('\n');
+};


### PR DESCRIPTION
Now it will show an error message and remove new URLs from `.cli-config.yml` that could cause errors (but left downloaded files in the `__packages__` directory to make possible to inspect what is really went wrong).
So IDE will be usable after the error.

It fixes #1506 