### PR TITLE
Make sure generated C++ is compatible with STM32 boards

### DIFF
--- a/packages/xod-arduino/platform/runtime.cpp
+++ b/packages/xod-arduino/platform/runtime.cpp
@@ -46,7 +46,7 @@
 // Compatibilities
 //----------------------------------------------------------------------------
 
-#if !defined(ARDUINO_ARCH_AVR)
+#if !defined(ARDUINO_ARCH_AVR) && !defined(__DTOSTRF_H_)
 /*
  * Provide dtostrf function for non-AVR platforms. Although many platforms
  * provide a stub many others do not. And the stub is based on `sprintf`

--- a/packages/xod-client/src/utils/normalizePort.js
+++ b/packages/xod-client/src/utils/normalizePort.js
@@ -1,12 +1,16 @@
 import * as R from 'ramda';
-import { DEFAULT_VALUE_OF_TYPE, PIN_TYPE } from 'xod-project';
+import {
+  DEFAULT_VALUE_OF_TYPE,
+  PIN_TYPE,
+  isValidPortLiteral,
+} from 'xod-project';
 
 const LEADING_CHAR = 'D';
 
 // :: DataValue -> DataValue
 export default input =>
   R.unless(
-    R.test(/^(A|D)\d+/i),
+    isValidPortLiteral,
     R.pipe(
       x => parseInt(x, 10),
       R.ifElse(

--- a/packages/xod-project/src/utils.js
+++ b/packages/xod-project/src/utils.js
@@ -181,6 +181,8 @@ export const isValidNumberDataValue = R.test(numberDataTypeRegExp);
 // getting type from literal value
 //
 
+export const isValidPortLiteral = R.test(/^(P[A-F]|A|D)\d{0,3}$/g);
+
 export const isLikeCharLiteral = def(
   'isLikeCharLiteral :: String -> Boolean',
   R.test(/^'\\?.'$/)
@@ -217,7 +219,7 @@ export const getTypeFromLiteral = def(
     if (isValidNumberDataValue(literal))
       return Either.of(CONST.PIN_TYPE.NUMBER);
 
-    if (R.test(/^(A|D)\d{0,3}$/gi, literal)) {
+    if (isValidPortLiteral(literal)) {
       return Either.of(CONST.PIN_TYPE.PORT);
     }
 

--- a/packages/xod-project/test/utils.spec.js
+++ b/packages/xod-project/test/utils.spec.js
@@ -169,6 +169,12 @@ describe('Utils', () => {
       expectType('A13', PIN_TYPE.PORT);
       expectType('D0', PIN_TYPE.PORT);
       expectType('D13', PIN_TYPE.PORT);
+      expectType('PA13', PIN_TYPE.PORT);
+      expectType('PB8', PIN_TYPE.PORT);
+      expectType('PC0', PIN_TYPE.PORT);
+      expectType('PD20', PIN_TYPE.PORT);
+      expectType('PE8', PIN_TYPE.PORT);
+      expectType('PF0', PIN_TYPE.PORT);
     });
   });
 });

--- a/workspace/blink/__fixtures__/arduino.cpp
+++ b/workspace/blink/__fixtures__/arduino.cpp
@@ -625,7 +625,7 @@ template<typename T> bool equal(List<T> lhs, List<T> rhs) {
 // Compatibilities
 //----------------------------------------------------------------------------
 
-#if !defined(ARDUINO_ARCH_AVR)
+#if !defined(ARDUINO_ARCH_AVR) && !defined(__DTOSTRF_H_)
 /*
  * Provide dtostrf function for non-AVR platforms. Although many platforms
  * provide a stub many others do not. And the stub is based on `sprintf`

--- a/workspace/count-with-feedback-loops/__fixtures__/arduino.cpp
+++ b/workspace/count-with-feedback-loops/__fixtures__/arduino.cpp
@@ -625,7 +625,7 @@ template<typename T> bool equal(List<T> lhs, List<T> rhs) {
 // Compatibilities
 //----------------------------------------------------------------------------
 
-#if !defined(ARDUINO_ARCH_AVR)
+#if !defined(ARDUINO_ARCH_AVR) && !defined(__DTOSTRF_H_)
 /*
  * Provide dtostrf function for non-AVR platforms. Although many platforms
  * provide a stub many others do not. And the stub is based on `sprintf`

--- a/workspace/lcd-time/__fixtures__/arduino.cpp
+++ b/workspace/lcd-time/__fixtures__/arduino.cpp
@@ -625,7 +625,7 @@ template<typename T> bool equal(List<T> lhs, List<T> rhs) {
 // Compatibilities
 //----------------------------------------------------------------------------
 
-#if !defined(ARDUINO_ARCH_AVR)
+#if !defined(ARDUINO_ARCH_AVR) && !defined(__DTOSTRF_H_)
 /*
  * Provide dtostrf function for non-AVR platforms. Although many platforms
  * provide a stub many others do not. And the stub is based on `sprintf`

--- a/workspace/two-button-switch/__fixtures__/arduino.cpp
+++ b/workspace/two-button-switch/__fixtures__/arduino.cpp
@@ -625,7 +625,7 @@ template<typename T> bool equal(List<T> lhs, List<T> rhs) {
 // Compatibilities
 //----------------------------------------------------------------------------
 
-#if !defined(ARDUINO_ARCH_AVR)
+#if !defined(ARDUINO_ARCH_AVR) && !defined(__DTOSTRF_H_)
 /*
  * Provide dtostrf function for non-AVR platforms. Although many platforms
  * provide a stub many others do not. And the stub is based on `sprintf`


### PR DESCRIPTION
- Add ability to define PORTs as `PA13`, `PB8` etc
- Don't redefine `dtostrf`, [the built-in one](https://github.com/stm32duino/Arduino_Core_STM32/blob/master/cores/arduino/avr/dtostrf.c) is fine
