### PR TITLE
Fixes hotkey label position in the main menu

### DIFF
--- a/packages/xod-client/src/utils/components/Menubar.jsx
+++ b/packages/xod-client/src/utils/components/Menubar.jsx
@@ -137,8 +137,8 @@ class Menubar extends React.Component {
         {/* because rc-menu does not support attaching callbacks directly to menu items */}
         {/* eslint-disable jsx-a11y/no-static-element-interactions */}
         <div onClick={click} className="Menubar-clickable-item">
-          {children || label}
           {hotkey && <div className="hotkey">{formatHotkey(hotkey)}</div>}
+          {children || label}
         </div>
         {/* eslint-enable jsx-a11y/no-static-element-interactions */}
       </MenuItem>


### PR DESCRIPTION
It fixes #1515.

The bug was caused by `float: right` of hotkey label element, which was placed after the block contents.