### PR TITLE
Fix joining urls in extra.txt with os-specific EOL instead of `\n`

### DIFF
--- a/packages/xod-client-electron/src/app/arduinoCli.js
+++ b/packages/xod-client-electron/src/app/arduinoCli.js
@@ -109,7 +109,7 @@ const ensureExtraTxt = async wsPath => {
   const extraTxtFilePath = getExtraTxtPath(wsPath);
   const doesExist = await fse.pathExists(extraTxtFilePath);
   if (!doesExist) {
-    const bundledUrls = R.join('\n', BUNDLED_ADDITIONAL_URLS);
+    const bundledUrls = R.join(os.EOL, BUNDLED_ADDITIONAL_URLS);
     await fse.writeFile(extraTxtFilePath, bundledUrls, { flag: 'wx' });
   } else {
     // TODO: For Users on 0.25.0 or 0.25.1 we have to add bundled esp8266
@@ -119,7 +119,7 @@ const ensureExtraTxt = async wsPath => {
     });
     const extraUrls = parseExtraTxtContent(extraTxtContents);
     const newContents = R.compose(
-      R.join('\n'),
+      R.join(os.EOL),
       R.concat(R.__, extraUrls),
       R.difference(BUNDLED_ADDITIONAL_URLS)
     )(extraUrls);


### PR DESCRIPTION
No issue.
This should be done in the #1509 

This fix does not affect on getting URLs from `extra.txt`, but when we do `ensureExtraTxt` it writes bundled URLs if they do not exist in the file.

This PR make contents of `extra.txt` looks correctly in the text editor on any platforms.