### PR TITLE
Prevent autoupdate on not supported platforms

### DIFF
--- a/packages/xod-client-electron/src/app/main.js
+++ b/packages/xod-client-electron/src/app/main.js
@@ -291,7 +291,11 @@ const onReady = () => {
       win.setTitle(newTitle);
     });
 
-    autoUpdater.checkForUpdates();
+    // On Linux XOD auto updates are not supported.
+    // Use of OS package manager is encouraged there.
+    if (process.platform === 'win32' || process.platform === 'darwin') {
+      autoUpdater.checkForUpdates();
+    }
   });
 };
 


### PR DESCRIPTION
Proposed change: do not check for update on not supported platforms. This prevents exception and useless stack traces in the console.