### PR TITLE
Fix "Select All" hotkey in Desktop IDE

### DIFF
--- a/packages/xod-client-electron/src/view/containers/App.jsx
+++ b/packages/xod-client-electron/src/view/containers/App.jsx
@@ -623,7 +623,10 @@ class App extends client.App {
       R.values
     )(client.menu.items);
 
-    return R.omit(commandsBoundToNativeMenu, client.HOTKEY);
+    return R.omit(
+      commandsBoundToNativeMenu,
+      client.menu.getOsSpecificHotkeys()
+    );
   }
 
   static getSelectedBoard() {


### PR DESCRIPTION
It fixes #1552 