### PR TITLE
Fix publisherName to match certificate's "Issued to" field

### DIFF
--- a/packages/xod-client-electron/package.json
+++ b/packages/xod-client-electron/package.json
@@ -97,7 +97,7 @@
       "category": "public.app-category.developer-tools"
     },
     "win": {
-      "publisherName": "AMPERKA, OOO",
+      "publisherName": "Amperka, OOO",
       "target": [
         "nsis"
       ]


### PR DESCRIPTION
This caused problems with auto-update on Windows.
See https://github.com/electron-userland/electron-builder/issues/1187#issuecomment-278972073
