### PR TITLE
Add second publisherName for electron-builder config

### DIFF
--- a/packages/xod-client-electron/package.json
+++ b/packages/xod-client-electron/package.json
@@ -96,7 +96,7 @@
       "category": "public.app-category.developer-tools"
     },
     "win": {
-      "publisherName": "Amperka, OOO",
+      "publisherName": ["AMPERKA, OOO", "Amperka, OOO"],
       "target": [
         "nsis"
       ]


### PR DESCRIPTION
In #1555 we replaced it with a new one, but having both is a more bulletproof solution.
