### PR TITLE
Add missing xod/core node descriptions

### DIFF
--- a/workspace/__lib__/xod/core/constant-boolean/patch.xodp
+++ b/workspace/__lib__/xod/core/constant-boolean/patch.xodp
@@ -1,5 +1,5 @@
 {
-  "description": "Constant value",
+  "description": "A predefined `true` or `false` value that never changes in runtime",
   "nodes": [
     {
       "description": "Constant value",

--- a/workspace/__lib__/xod/core/constant-byte/patch.xodp
+++ b/workspace/__lib__/xod/core/constant-byte/patch.xodp
@@ -1,4 +1,5 @@
 {
+  "description": "A predefined single byte datum that never changes in runtime",
   "nodes": [
     {
       "id": "B23RV3eJq",

--- a/workspace/__lib__/xod/core/constant-number/patch.xodp
+++ b/workspace/__lib__/xod/core/constant-number/patch.xodp
@@ -1,4 +1,5 @@
 {
+  "description": "A predefined numeric value that never changes in runtime",
   "nodes": [
     {
       "id": "B1x2RV3eZ",

--- a/workspace/__lib__/xod/core/constant-port/patch.xodp
+++ b/workspace/__lib__/xod/core/constant-port/patch.xodp
@@ -1,4 +1,5 @@
 {
+  "description": "A hardware port value",
   "nodes": [
     {
       "id": "B1x2RV3eZ",

--- a/workspace/__lib__/xod/core/constant-string/patch.xodp
+++ b/workspace/__lib__/xod/core/constant-string/patch.xodp
@@ -1,4 +1,5 @@
 {
+  "description": "A predefined text string that never changes in runtime. Non-ASCII characters are encoded in UTF-8.",
   "nodes": [
     {
       "id": "B1x2RV3eZ",

--- a/workspace/__lib__/xod/core/length(string)/patch.xodp
+++ b/workspace/__lib__/xod/core/length(string)/patch.xodp
@@ -1,4 +1,5 @@
 {
+  "description": "Calculates string size in bytes. Will be inequal to the number of glyphs if the input string is UTF-8 encoded and contains non-ASCII characters.",
   "nodes": [
     {
       "id": "H1kQ1XtbQ",

--- a/workspace/__lib__/xod/core/sine-wave/patch.xodp
+++ b/workspace/__lib__/xod/core/sine-wave/patch.xodp
@@ -1,4 +1,5 @@
 {
+  "description": "Generates sine wave (sinusoid) signal",
   "links": [
     {
       "id": "B1uXK2FyM",

--- a/workspace/__lib__/xod/core/square-wave/patch.xodp
+++ b/workspace/__lib__/xod/core/square-wave/patch.xodp
@@ -1,4 +1,5 @@
 {
+  "description": "Generates square wave signal",
   "nodes": [
     {
       "boundLiterals": {


### PR DESCRIPTION
We have some holes in `xod/core` which are apparent when looking at https://xod.io/libs/xod/core/