### PR TITLE
Add pin labels validation in tabtests

### DIFF
--- a/packages/xod-func-tools/src/Errors.re
+++ b/packages/xod-func-tools/src/Errors.re
@@ -1,0 +1,1 @@
+[@bs.module ".."] external createError : (string, 'a) => Js.Exn.t = "";

--- a/packages/xod-func-tools/src/Errors.rei
+++ b/packages/xod-func-tools/src/Errors.rei
@@ -1,0 +1,7 @@
+/**
+ * Returns a JS Error with added `type` and `payload` properties.
+ * Accepts:
+ * - type (string)
+ * - payload (record)
+ */
+let createError: (string, 'a) => Js.Exn.t;

--- a/packages/xod-tabtest/src/SpecialColumns.re
+++ b/packages/xod-tabtest/src/SpecialColumns.re
@@ -1,0 +1,3 @@
+let time = "__time(ms)";
+
+let list = [time];

--- a/packages/xod-tabtest/src/SpecialColumns.re
+++ b/packages/xod-tabtest/src/SpecialColumns.re
@@ -1,3 +1,1 @@
 let time = "__time(ms)";
-
-let list = [time];

--- a/packages/xod-tabtest/src/TabData.re
+++ b/packages/xod-tabtest/src/TabData.re
@@ -102,14 +102,18 @@ let emptyLinesRegEx = [%re {|/^\s+$/gm|}];
 let tabSplit = x =>
   Js.String.split("\t", x) |. List.fromArray |. List.map(Js.String.trim);
 
-let parse = (tsvSource: string) : t =>
+let listDataLines = (tsvSource: string) : list(string) =>
   tsvSource
   |> Js.String.replaceByRe([%re {|/\r/gm|}], "")
   |> Js.String.replaceByRe(commentsRegEx, "")
   |> Js.String.replaceByRe(emptyLinesRegEx, "")
   |> Js.String.split("\n")
   |> List.fromArray
-  |. List.keep(x => x != "")
+  |. List.keep(x => x != "");
+
+let parse = (tsvSource: string) : t =>
+  tsvSource
+  |> listDataLines
   |> (
     lines =>
       switch (List.head(lines)) {

--- a/packages/xod-tabtest/src/TabData.rei
+++ b/packages/xod-tabtest/src/TabData.rei
@@ -38,6 +38,12 @@ let map: (t, Record.t => 'v) => List.t('v);
 /** Maps all records in data with indexes like regular lists do */
 let mapWithIndex: (t, (int, Record.t) => 'v) => List.t('v);
 
+/** Returns a list of strings separated by `\n` without comments and empty lines */
+let listDataLines: string => list(string);
+
+/** Returns a list of strings separated by tabs and with leading/trailing whitespace trimmed */
+let tabSplit: string => list(string);
+
 /** Parses a plain source (as read from file) into tabular data.
 
     Note, the parsing always succeeds leaving `Value.Invalid` for

--- a/packages/xod-tabtest/src/TabData.rei
+++ b/packages/xod-tabtest/src/TabData.rei
@@ -19,7 +19,6 @@ module Value: {
     | String(string)
     | Byte(int)
     | Pulse(bool)
-    | Millis(int)
     | Invalid(string);
 };
 

--- a/packages/xod-tabtest/src/Tabtest.re
+++ b/packages/xod-tabtest/src/Tabtest.re
@@ -211,7 +211,9 @@ module TestCase = {
          });
     let setTimeStatement =
       switch (record |. TabData.Record.get(SpecialColumns.time)) {
-      | Some(Millis(t)) => {j|mockTime($t);|j}
+      | Some(Number(t)) =>
+        let time = int_of_float(t);
+        {j|mockTime($time);|j};
       | Some(_)
       | None => "mockTime(millis() + 1);"
       };

--- a/packages/xod-tabtest/src/Tabtest.re
+++ b/packages/xod-tabtest/src/Tabtest.re
@@ -210,7 +210,7 @@ module TestCase = {
            };
          });
     let setTimeStatement =
-      switch (record |. TabData.Record.get("__time(ms)")) {
+      switch (record |. TabData.Record.get(SpecialColumns.time)) {
       | Some(Millis(t)) => {j|mockTime($t);|j}
       | Some(_)
       | None => "mockTime(millis() + 1);"
@@ -299,31 +299,44 @@ let generatePatchSuite = (project, patchPathToTest) : XResult.t(t) => {
   | (Some(patchUnderTest), Some(tsv)) =>
     let bench = Bench.create(project, patchUnderTest);
     let probes = bench.probes;
-    let benchPatchPath =
-      "tabtest-"
-      ++ patchPathToTest
-      /* to convert "tabtest-@/foo" to "tabtest/local/foo" */
-      |> Js.String.replace("-@", "/local");
-    let safeBasename =
-      PatchPath.getBaseName(patchPathToTest)
-      |> Js.String.replace("(", "__")
-      |> Js.String.replace(",", "__")
-      |> Js.String.replace(")", "");
-    let sketchFilename = safeBasename ++ ".sketch.cpp";
-    let testFilename = safeBasename ++ ".catch.inl";
     let tabData = TabData.parse(tsv);
-    let sketchFooter = {j|\n\n#include "$testFilename"\n|j};
-    Project.assocPatch(project, benchPatchPath, bench.patch)
-    |. XodArduino.Transpiler.transpile(_, benchPatchPath)
-    |. BeltHoles.Result.map(program => {
-         let idMap =
-           BeltHoles.Map.String.innerJoin(bench.probeMap, program.nodeIdMap);
-         let testCase =
-           TestCase.generate(patchPathToTest, tabData, idMap, probes);
-         Map.String.empty
-         |. Map.String.set(sketchFilename, program.code ++ sketchFooter)
-         |. Map.String.set(testFilename, testCase);
-       });
+    let realPinLabels =
+      bench.probeMap |> Map.String.keysToArray |> List.fromArray;
+    let testingPinLabels =
+      tsv |. TabData.listDataLines |. List.getExn(0) |. TabData.tabSplit;
+    let result =
+      switch (Validator.validatePinLabels(realPinLabels, testingPinLabels)) {
+      | Some(e) => Result.Error(e)
+      | None =>
+        let benchPatchPath =
+          "tabtest-"
+          ++ patchPathToTest
+          /* to convert "tabtest-@/foo" to "tabtest/local/foo" */
+          |> Js.String.replace("-@", "/local");
+        let safeBasename =
+          PatchPath.getBaseName(patchPathToTest)
+          |> Js.String.replace("(", "__")
+          |> Js.String.replace(",", "__")
+          |> Js.String.replace(")", "");
+        let sketchFilename = safeBasename ++ ".sketch.cpp";
+        let testFilename = safeBasename ++ ".catch.inl";
+        let sketchFooter = {j|\n\n#include "$testFilename"\n|j};
+        Project.assocPatch(project, benchPatchPath, bench.patch)
+        |. XodArduino.Transpiler.transpile(_, benchPatchPath)
+        |. BeltHoles.Result.map(program => {
+             let idMap =
+               BeltHoles.Map.String.innerJoin(
+                 bench.probeMap,
+                 program.nodeIdMap,
+               );
+             let testCase =
+               TestCase.generate(patchPathToTest, tabData, idMap, probes);
+             Map.String.empty
+             |. Map.String.set(sketchFilename, program.code ++ sketchFooter)
+             |. Map.String.set(testFilename, testCase);
+           });
+      };
+    result;
   };
 };
 

--- a/packages/xod-tabtest/src/Validator.re
+++ b/packages/xod-tabtest/src/Validator.re
@@ -1,0 +1,59 @@
+open Belt;
+
+[@bs.deriving abstract]
+type invalidPinsErrorPayloadType = {
+  missing: array(string),
+  redundant: array(string),
+  duplicated: array(string),
+};
+
+let validatePinLabels =
+    (realPinLabels: list(string), testingPinLabels: list(string))
+    : option(Js.Exn.t) => {
+  /* Create Sets of real and testing pin labels to get difference in optimal way */
+  let testingPinLabelsSet =
+    testingPinLabels |. List.toArray |. Set.String.fromArray;
+  let realPinLabelsSet = realPinLabels |. List.toArray |. Set.String.fromArray;
+  let missingPinLabels =
+    realPinLabelsSet
+    |. Set.String.diff(testingPinLabelsSet)
+    |. Set.String.toList;
+  let redundantPinLabels =
+    testingPinLabelsSet
+    |. Set.String.diff(realPinLabelsSet)
+    |. Set.String.toList
+    |. List.keep((!=)(SpecialColumns.time));
+  let duplicatedPinLabels =
+    testingPinLabels
+    |. List.reduce(
+         Map.String.empty,
+         (acc, pinLabel) => {
+           let pinLabelCount = acc |. Map.String.getWithDefault(pinLabel, 0);
+           acc |. Map.String.set(pinLabel, pinLabelCount + 1);
+         },
+       )
+    |. Map.String.keep((_, v) => v > 1)
+    |. Map.String.keysToArray
+    |. List.fromArray
+    |. List.keep(x => ! List.has(redundantPinLabels, x, (==)));
+  let errorOccured =
+    List.length(missingPinLabels)
+    + List.length(redundantPinLabels)
+    + List.length(duplicatedPinLabels) > 0;
+  if (errorOccured) {
+    let payload =
+      invalidPinsErrorPayloadType(
+        ~missing=missingPinLabels |. List.toArray,
+        ~redundant=redundantPinLabels |. List.toArray,
+        ~duplicated=duplicatedPinLabels |. List.toArray,
+      );
+    Some(
+      XodFuncTools.Errors.createError(
+        "INVALID_PIN_LABELS_IN_TABTEST",
+        payload,
+      ),
+    );
+  } else {
+    None;
+  };
+};

--- a/packages/xod-tabtest/src/Validator.rei
+++ b/packages/xod-tabtest/src/Validator.rei
@@ -1,0 +1,17 @@
+/**
+ * Checks tabtest for correct pin labels and throws an error if tabtest has:
+ * - missing pin labels
+ * - redundant pin labels
+ * - duplicated pin labels
+ *
+ * Otherwise do nothing.
+ *
+ * Accepts two arguments:
+ * - List of real pin labels of tested node
+ * - List of pin labels specified in tabtest, including special columns like `__time(ms)`
+ *
+ * Returns Option:
+ * - None if valid
+ * - Some(Error) if invalid
+ */
+let validatePinLabels: (list(string), list(string)) => option(Js.Exn.t);

--- a/packages/xod-tabtest/test/TabData_jest.re
+++ b/packages/xod-tabtest/test/TabData_jest.re
@@ -125,23 +125,4 @@ describe("TSV parser", () => {
     ];
     expect(TabData.parse(tsv)) |> toEqual(expected);
   });
-  test("recognizes time column", () => {
-    let tsv =
-      "__time(ms)\tNumber\n" ++ "0\t0\n" ++ "500\t0.5\n" ++ "1200\t1.2";
-    let expected: TabData.t = [
-      Map.String.fromArray([|
-        ("__time(ms)", Millis(0)),
-        ("Number", Number(0.0)),
-      |]),
-      Map.String.fromArray([|
-        ("__time(ms)", Millis(500)),
-        ("Number", Number(0.5)),
-      |]),
-      Map.String.fromArray([|
-        ("__time(ms)", Millis(1200)),
-        ("Number", Number(1.2)),
-      |]),
-    ];
-    expect(TabData.parse(tsv)) |> toEqual(expected);
-  });
 });

--- a/packages/xod-tabtest/test/Validator_jest.re
+++ b/packages/xod-tabtest/test/Validator_jest.re
@@ -1,0 +1,96 @@
+open Jest;
+
+open Validator;
+
+let assertNone = (expectation: option('a)) : assertion =>
+  switch (expectation) {
+  | None => pass
+  | Some(_) => fail("Expected to get None, but got Some")
+  };
+
+let assertSomeError =
+    (expectedMsg: string, optError: option(Js.Exn.t))
+    : assertion =>
+  switch (optError) {
+  | Some(err) =>
+    switch (Js.Exn.message(err)) {
+    | Some(message) =>
+      message === expectedMsg ?
+        pass :
+        fail(
+          "Different error messages\n"
+          ++ "Expected: \""
+          ++ expectedMsg
+          ++ "\""
+          ++ "\nActual:   \""
+          ++ message
+          ++ "\"",
+        )
+    | None =>
+      fail(
+        "Expected to throw an error \""
+        ++ expectedMsg
+        ++ "\" but it throws an exception without error message.",
+      )
+    }
+  | None =>
+    fail(
+      "Expected to throw an error \"" ++ expectedMsg ++ "\" but it does not.",
+    )
+  };
+
+describe("Assert pin labels", () => {
+  test("Returns unit for valid pin labels", () => {
+    let realPins = ["IN1", "IN2", "IN3"];
+    let tsvPins = ["IN1", "IN2", "IN3"];
+    assertNone(validatePinLabels(realPins, tsvPins));
+  });
+  test("Throws missing pin labels error", () => {
+    let realPins = ["IN1", "IN2", "IN3"];
+    let tsvPins = ["IN1"];
+    assertSomeError(
+      {|INVALID_PIN_LABELS_IN_TABTEST {"missing":["IN2","IN3"],"redundant":[],"duplicated":[]}|},
+      validatePinLabels(realPins, tsvPins),
+    );
+  });
+  test("Throws redundant pin labels error", () => {
+    let realPins = ["IN1"];
+    let tsvPins = ["IN1", "IN2", "IN3"];
+    assertSomeError(
+      {|INVALID_PIN_LABELS_IN_TABTEST {"missing":[],"redundant":["IN2","IN3"],"duplicated":[]}|},
+      validatePinLabels(realPins, tsvPins),
+    );
+  });
+  test(
+    "Do not throw a redundant pin labels error for special columns like `__time(ms)`",
+    () => {
+      let realPins = ["IN1"];
+      let tsvPins = ["__time(ms)", "IN1"];
+      assertNone(validatePinLabels(realPins, tsvPins));
+    },
+  );
+  test("Throws duplicated pin labels error", () => {
+    let realPins = ["IN1"];
+    let tsvPins = ["IN1", "IN1", "IN1"];
+    assertSomeError(
+      {|INVALID_PIN_LABELS_IN_TABTEST {"missing":[],"redundant":[],"duplicated":["IN1"]}|},
+      validatePinLabels(realPins, tsvPins),
+    );
+  });
+  test("Throws duplicated pin labels error for special columns", () => {
+    let realPins = ["IN1"];
+    let tsvPins = ["__time(ms)", "IN1", "__time(ms)"];
+    assertSomeError(
+      {|INVALID_PIN_LABELS_IN_TABTEST {"missing":[],"redundant":[],"duplicated":["__time(ms)"]}|},
+      validatePinLabels(realPins, tsvPins),
+    );
+  });
+  test("Throws all pin labels error", () => {
+    let realPins = ["IN1", "IN2", "IN3"];
+    let tsvPins = ["IN1", "IN1", "IN4", "IN4"];
+    assertSomeError(
+      {|INVALID_PIN_LABELS_IN_TABTEST {"missing":["IN2","IN3"],"redundant":["IN4"],"duplicated":["IN1"]}|},
+      validatePinLabels(realPins, tsvPins),
+    );
+  });
+});


### PR DESCRIPTION
Now it throws errors if tabtest:
- does not have columns for some pins (missing pin labels)
- have redundant pins, that are missing in tested node
- have duplicated pin labels
And it works fine with "special" columns, like `__time(ms)`.

Also, I've added `List.contains` and `List.difference` into `belt-holes` package.