### PR TITLE
Improve tabtest of `xod/core/modulo`

### DIFF
--- a/workspace/__lib__/xod/core/modulo/patch.test.tsv
+++ b/workspace/__lib__/xod/core/modulo/patch.test.tsv
@@ -3,3 +3,11 @@ IN1	IN2	OUT
 4	10	4
 -6	10	-6
 -26	10	-6
+-26	-10	-6
+26	-10	6
+735.25	2.33	1.29~
+NaN	10	NaN
+26	NaN	NaN
+Inf	Inf	NaN
+-Inf	Inf	NaN
+Inf	-Inf	NaN


### PR DESCRIPTION
I'm writing an article about writing tabular tests and use `modulo` as an example.