### PR TITLE
Fix closing of Switch Workspace Popup and click outside the popup

### DIFF
--- a/packages/xod-client-electron/src/settings/components/PopupSetWorkspace.jsx
+++ b/packages/xod-client-electron/src/settings/components/PopupSetWorkspace.jsx
@@ -18,7 +18,7 @@ class PopupSetWorkspace extends React.Component {
     }
   }
   onClose() {
-    if (!this.props.isClosable) {
+    if (this.props.isClosable) {
       this.props.onClose();
     }
   }
@@ -66,7 +66,7 @@ class PopupSetWorkspace extends React.Component {
         title="Choose your workspace directory"
         isVisible={this.props.isVisible}
         isClosable={this.props.isClosable}
-        onCloseClicked={this.onClose}
+        onClose={this.onClose}
       >
         <div className="ModalContent">{currentWorkspace}</div>
         <div className="ModalFooter">

--- a/packages/xod-client/src/core/styles/components/SkyLight.scss
+++ b/packages/xod-client/src/core/styles/components/SkyLight.scss
@@ -11,7 +11,17 @@
   width: 100%;
   height: 100%;
   z-index: 100;
-  background-color: rgba(0,0,0,0.3);
+
+  .skylight-overlay {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    z-index: 5;
+
+    background-color: rgba(0,0,0,0.3);
+  }
 
   .skylight-dialog {
     width: 50%;


### PR DESCRIPTION
It fixes #1596 
Also, fixed click outside the closable popup (on the shaded overlay) will cause closing too.