### PR TITLE
Add patchFlags map into hinting state to fix #1547

### DIFF
--- a/packages/xod-client/src/hinting/actions.js
+++ b/packages/xod-client/src/hinting/actions.js
@@ -1,6 +1,6 @@
 import UPDATE_HINTING from './actionType';
 
-export default (deducedTypes, errors, patchSearchData) => ({
+export default (deducedTypes, errors, patchSearchData, patchMarkers) => ({
   type: UPDATE_HINTING,
-  payload: { deducedTypes, errors, patchSearchData },
+  payload: { deducedTypes, errors, patchSearchData, patchMarkers },
 });

--- a/packages/xod-client/src/hinting/middleware.js
+++ b/packages/xod-client/src/hinting/middleware.js
@@ -2,7 +2,12 @@ import { notEquals } from 'xod-func-tools';
 
 import { getProject } from '../project/selectors';
 
-import { getDeducedTypes, getErrors, getPatchSearchData } from './selectors';
+import {
+  getDeducedTypes,
+  getErrors,
+  getPatchSearchData,
+  getPatchMarkers,
+} from './selectors';
 import updateHinting from './actions';
 import { shallDeduceTypes, deduceTypes } from './typeDeduction';
 import { shallValidate, validateProject } from './validation';
@@ -10,6 +15,7 @@ import {
   shallUpdatePatchSearchData,
   getNewPatchSearchData,
 } from './patchSearchData';
+import { shallUpdatePatchMarkers, getNewPatchMarkers } from './patchMarkers';
 
 // =============================================================================
 //
@@ -46,13 +52,21 @@ export default store => next => action => {
     : prevSearchIndex;
   const willUpdateSearchIndex = notEquals(prevSearchIndex, nextSearchIndex);
 
+  // Patch Flags
+  const prevPatchMarkers = getPatchMarkers(newState);
+  const nextPatchMarkers = shallUpdatePatchMarkers(action)
+    ? getNewPatchMarkers(prevPatchMarkers, newProject, action)
+    : prevPatchMarkers;
+  const willUpdatePatchMarkers = notEquals(prevPatchMarkers, nextPatchMarkers);
+
   // Dispatch changes, if needed
   if (willUpdateDeducedTypes || willUpdateErrors || willUpdateSearchIndex) {
     store.dispatch(
       updateHinting(
         willUpdateDeducedTypes ? nextDeducedTypes : null,
         willUpdateErrors ? nextErrors : null,
-        willUpdateSearchIndex ? nextSearchIndex : null
+        willUpdateSearchIndex ? nextSearchIndex : null,
+        willUpdatePatchMarkers ? nextPatchMarkers : null
       )
     );
   }

--- a/packages/xod-client/src/hinting/patchMarkers.js
+++ b/packages/xod-client/src/hinting/patchMarkers.js
@@ -1,0 +1,95 @@
+import * as R from 'ramda';
+import * as XP from 'xod-project';
+import { foldMaybe, isAmong } from 'xod-func-tools';
+import * as PAT from '../project/actionTypes';
+import * as EAT from '../editor/actionTypes';
+
+// :: Action -> Boolean
+const isLoadingProjectAction = R.propSatisfies(
+  isAmong([PAT.PROJECT_IMPORT, PAT.PROJECT_OPEN]),
+  'type'
+);
+
+// :: String -> Boolean
+const oneOfInfoMarkers = isAmong([
+  XP.DEPRECATED_MARKER_PATH,
+  XP.UTILITY_MARKER_PATH,
+]);
+
+// :: Action -> Boolean
+const doesMarkerNodeAdded = R.allPass([
+  R.propEq('type', PAT.NODE_ADD),
+  R.pathSatisfies(oneOfInfoMarkers, ['payload', 'typeId']),
+]);
+
+const doesMarkerNodePasted = R.allPass([
+  R.propEq('type', EAT.PASTE_ENTITIES),
+  R.pathSatisfies(R.any(R.pipe(XP.getNodeType, oneOfInfoMarkers)), [
+    'payload',
+    'entities',
+    'nodes',
+  ]),
+]);
+
+// :: Action -> Boolean
+const doesAnyNodeDeleted = R.allPass([
+  R.propEq('type', PAT.BULK_DELETE_ENTITIES),
+  R.pathSatisfies(nodeList => nodeList.length > 0, ['payload', 'nodeIds']),
+]);
+
+// :: Action -> Boolean
+export const shallUpdatePatchMarkers = R.anyPass([
+  // Update on loading a project
+  isLoadingProjectAction,
+  // Update on adding a marker Node
+  doesMarkerNodeAdded,
+  // Update on pasting a marker Node
+  doesMarkerNodePasted,
+  // Update on deleting any Node
+  // Without checking for deleting only marker nodes,
+  // because it worst by performance
+  doesAnyNodeDeleted,
+]);
+
+// :: Patch -> PatchMarkers
+const getPatchMarkersForPatch = patch => ({
+  utility: XP.isUtilityPatch(patch),
+  deprecated: XP.isDeprecatedPatch(patch),
+});
+
+// :: StrMap PatchPath PatchMarkers -> Project -> StrMap PatchPath PatchMarkers
+const getPatchMarkersForEntireProject = R.curry((oldPatchMarkers, newProject) =>
+  R.compose(
+    R.map(getPatchMarkersForPatch),
+    R.indexBy(XP.getPatchPath),
+    XP.listPatches
+  )(newProject)
+);
+
+// :: StrMap PatchPath PatchMarkers -> PatchPath -> Project -> StrMap PatchPath PatchMarkers
+const updatePatchMarkersForChangedPatch = R.curry(
+  (oldPatchMarkers, patchPath, newProject) =>
+    R.compose(
+      foldMaybe(
+        R.omit([patchPath], oldPatchMarkers),
+        R.compose(
+          R.assoc(patchPath, R.__, oldPatchMarkers),
+          getPatchMarkersForPatch
+        )
+      ),
+      XP.getPatchByPath
+    )(patchPath, newProject)
+);
+
+// :: StrMap PatchPath PatchMarkers -> Project -> Action -> StrMap PatchPath PatchMarkers
+export const getNewPatchMarkers = R.curry(
+  (oldPatchMarkers, newProject, action) =>
+    R.ifElse(
+      isLoadingProjectAction,
+      () => getPatchMarkersForEntireProject(oldPatchMarkers, newProject),
+      R.compose(
+        updatePatchMarkersForChangedPatch(oldPatchMarkers, R.__, newProject),
+        R.path(['payload', 'patchPath'])
+      )
+    )(action)
+);

--- a/packages/xod-client/src/hinting/reducer.js
+++ b/packages/xod-client/src/hinting/reducer.js
@@ -10,6 +10,7 @@ const errorsLens = R.lensProp('errors');
 const getDeducedTypesFromAction = R.path(['payload', 'deducedTypes']);
 const getErrorsFromAction = R.path(['payload', 'errors']);
 const getPatchSearchDataFromAction = R.path(['payload', 'patchSearchData']);
+const getPatchMarkersFromAction = R.path(['payload', 'patchMarkers']);
 // =============================================================================
 const updateDeducedTypes = R.curry((action, state) =>
   R.ifElse(
@@ -19,22 +20,25 @@ const updateDeducedTypes = R.curry((action, state) =>
   )(action)
 );
 const updateErrors = R.curry((action, state) =>
-  R.ifElse(
-    R.pipe(getErrorsFromAction, notNil),
-    R.pipe(getErrorsFromAction, errs =>
-      R.over(errorsLens, mergeErrors(R.__, errs), state)
+  R.compose(
+    R.ifElse(
+      notNil,
+      errs => R.over(errorsLens, mergeErrors(R.__, errs), state),
+      R.always(state)
     ),
-    R.always(state)
+    getErrorsFromAction
   )(action)
 );
 const updatePatchSearchData = R.curry((action, state) =>
-  R.ifElse(
-    R.pipe(getPatchSearchDataFromAction, notNil),
-    R.pipe(
-      getPatchSearchDataFromAction,
-      R.assoc('patchSearchData', R.__, state)
-    ),
-    R.always(state)
+  R.compose(
+    R.ifElse(notNil, R.assoc('patchSearchData', R.__, state), R.always(state)),
+    getPatchSearchDataFromAction
+  )(action)
+);
+const updatePatchMarkers = R.curry((action, state) =>
+  R.compose(
+    R.ifElse(notNil, R.assoc('patchMarkers', R.__, state), R.always(state)),
+    getPatchMarkersFromAction
   )(action)
 );
 // =============================================================================
@@ -45,7 +49,8 @@ export default (state = initialState, action) => {
       return R.compose(
         updateDeducedTypes(action),
         updateErrors(action),
-        updatePatchSearchData(action)
+        updatePatchSearchData(action),
+        updatePatchMarkers(action)
       )(state);
     default:
       return state;

--- a/packages/xod-client/src/hinting/selectors.js
+++ b/packages/xod-client/src/hinting/selectors.js
@@ -51,3 +51,8 @@ export const getPinErrors = R.curry((patchPath, nodeId, pinKey, errors) =>
     maybePath([patchPath, 'nodes', nodeId, 'pins', pinKey])
   )(errors)
 );
+
+export const getPatchMarkers = R.compose(
+  R.prop('patchMarkers'),
+  getHintingState
+);

--- a/packages/xod-client/src/hinting/state.js
+++ b/packages/xod-client/src/hinting/state.js
@@ -43,4 +43,12 @@ export default {
      * },
      */
   ],
+  patchMarkers: {
+    /**
+     * [PatchPath]: PatchMarkers :: {
+     *   utility: Boolean,
+     *   deprecated: Boolean,
+     * }
+     */
+  },
 };

--- a/packages/xod-client/src/projectBrowser/selectors.js
+++ b/packages/xod-client/src/projectBrowser/selectors.js
@@ -37,13 +37,23 @@ const markDeadPatches = R.curry((errors, patch) =>
   )
 );
 
-// :: Patch -> Patch
-const markDeprecatedPatches = patch =>
-  R.assoc('isDeprecated', XP.isDeprecatedPatch(patch), patch);
+// :: StrMap PatchPath PathFlags -> Patch -> Patch
+const markDeprecatedPatches = R.curry((patchMarkers, patch) =>
+  R.compose(
+    R.assoc('isDeprecated', R.__, patch),
+    patchPath => R.pathOr(false, [patchPath, 'deprecated'], patchMarkers),
+    XP.getPatchPath
+  )(patch)
+);
 
-// :: Patch -> Patch
-const markUtilityPatches = patch =>
-  R.assoc('isUtility', XP.isUtilityPatch(patch), patch);
+// :: StrMap PatchPath PathFlags -> Patch -> Patch
+const markUtilityPatches = R.curry((patchMarkers, patch) =>
+  R.compose(
+    R.assoc('isUtility', R.__, patch),
+    patchPath => R.pathOr(false, [patchPath, 'utility'], patchMarkers),
+    XP.getPatchPath
+  )(patch)
+);
 
 const getPatchPaths = R.pipe(R.indexBy(XP.getPatchPath), R.keys);
 // :: [Patch] -> [Patch] -> Boolean
@@ -55,15 +65,19 @@ const getLocalPatchesList = createSelector(
 );
 
 export const getLocalPatches = createMemoizedSelector(
-  [HintingSelectors.getErrors, getLocalPatchesList],
-  [R.equals, samePatchPaths],
-  (errors, patches) =>
+  [
+    HintingSelectors.getErrors,
+    HintingSelectors.getPatchMarkers,
+    getLocalPatchesList,
+  ],
+  [R.equals, R.equals, samePatchPaths],
+  (errors, patchMarkers, patches) =>
     R.compose(
       R.sortBy(XP.getPatchPath),
       R.map(
         R.compose(
-          markUtilityPatches,
-          markDeprecatedPatches,
+          markUtilityPatches(patchMarkers),
+          markDeprecatedPatches(patchMarkers),
           markDeadPatches(errors)
         )
       )
@@ -87,17 +101,21 @@ const getLibraryPatchesList = createSelector(
 );
 
 export const getLibs = createMemoizedSelector(
-  [HintingSelectors.getErrors, getLibraryPatchesList],
-  [R.equals, samePatchPaths],
-  (errors, patches) =>
+  [
+    HintingSelectors.getErrors,
+    HintingSelectors.getPatchMarkers,
+    getLibraryPatchesList,
+  ],
+  [R.equals, R.equals, samePatchPaths],
+  (errors, patchMarkers, patches) =>
     R.compose(
       R.map(R.sort(R.ascend(XP.getPatchPath))),
       R.groupBy(R.pipe(XP.getPatchPath, XP.getLibraryName)),
       R.reject(isPatchDeadTerminal),
       R.map(
         R.compose(
-          markUtilityPatches,
-          markDeprecatedPatches,
+          markUtilityPatches(patchMarkers),
+          markDeprecatedPatches(patchMarkers),
           markDeadPatches(errors)
         )
       )


### PR DESCRIPTION
It fixes #1547 

It adds `patchFlags` map into `hinting` state.
Fulfilling this map on loading project takes about 35ms on my machine and takes less 1ms on any change, including adding/pasting/deleting marker nodes.