### PR TITLE
Prepare arduino-cli wrapper for publishing

### DIFF
--- a/packages/arduino-cli/package.json
+++ b/packages/arduino-cli/package.json
@@ -3,6 +3,7 @@
   "version": "0.26.0",
   "description": "JS-wrapper over arduino-cli",
   "main": "dist/index.js",
+  "files": ["dist/**", "src/**"],
   "scripts": {
     "build": "babel src/ -d dist/ --source-maps",
     "clean:dist": "rimraf ./bin ./__lib__",


### PR DESCRIPTION
Dry run output:
```
npm notice 📦  arduino-cli@0.26.0
npm notice === Tarball Contents === 
npm notice 819B   package.json                   
npm notice 9.1kB  README.md                      
npm notice 2.4kB  dist/config.js                 
npm notice 3.2kB  dist/config.js.map             
npm notice 5.0kB  dist/cpuParser.js              
npm notice 8.5kB  dist/cpuParser.js.map          
npm notice 6.0kB  dist/index.js                  
npm notice 11.2kB dist/index.js.map              
npm notice 3.3kB  dist/listAvailableBoards.js    
npm notice 5.1kB  dist/listAvailableBoards.js.map
npm notice 6.2kB  dist/optionParser.js           
npm notice 10.0kB dist/optionParser.js.map       
npm notice 1.3kB  dist/parseProgressLog.js       
npm notice 2.3kB  dist/parseProgressLog.js.map   
npm notice 918B   dist/parseTable.js             
npm notice 1.4kB  dist/parseTable.js.map         
npm notice 1.5kB  src/config.js                  
npm notice 5.5kB  src/index.js                   
npm notice 2.8kB  src/listAvailableBoards.js     
npm notice 5.3kB  src/optionParser.js            
npm notice 1.0kB  src/parseProgressLog.js        
npm notice === Tarball Details === 
npm notice name:          arduino-cli                             
npm notice version:       0.26.0                                  
npm notice package size:  24.2 kB                                 
npm notice unpacked size: 92.8 kB                                 
npm notice shasum:        b5332fcd2f5e43bc6361bff9f8d0b2adce866ac5
npm notice integrity:     sha512-lvWBeUfHoL4V2[...]9zQ3A/zETpexA==
npm notice total files:   21  
```