### PR TITLE
Enlarge timeout for selector that mostly fails function tests

### DIFF
--- a/packages/xod-client-browser/test-func/pageObjects/PromptPopup.js
+++ b/packages/xod-client-browser/test-func/pageObjects/PromptPopup.js
@@ -15,7 +15,7 @@ PromptPopup.findOnPage = async page => {
 };
 
 PromptPopup.waitOnPage = async page => {
-  await page.waitFor('.PopupPrompt', { timeout: 2000 });
+  await page.waitFor('.PopupPrompt', { timeout: 5000 });
   return PromptPopup.findOnPage(page);
 };
 


### PR DESCRIPTION
There is no issue.
But very often we get failed errors with this selector. I hope it helps to avoid reruns...
Will rerun tests a few times to be sure it helped :)