### PR TITLE
Make `xod/math/abs` correctly handle values between -1 and 0 on esp8266

### DIFF
--- a/workspace/__lib__/xod/math/abs/patch.cpp
+++ b/workspace/__lib__/xod/math/abs/patch.cpp
@@ -8,5 +8,5 @@ struct State {
 
 void evaluate(Context ctx) {
     auto x = getValue<input_IN>(ctx);
-    emitValue<output_OUT>(ctx, abs(x));
+    emitValue<output_OUT>(ctx, x > 0 ? x : -x);
 }


### PR DESCRIPTION
`abs` casts input value to `int` :(