### PR TITLE
Remove debug nodes from nested patches

### DIFF
--- a/packages/xod-arduino/src/transpiler.js
+++ b/packages/xod-arduino/src/transpiler.js
@@ -479,11 +479,11 @@ const transformProjectWithImpls = def(
       R.chain(XP.flatten(R.__, path)),
       R.map(XP.expandVariadicNodes(path)),
       R.chain(XP.autoresolveTypes(path)),
+      R.map(XP.jumperizePatchRecursively(path)),
       R.unless(
         () => liveness !== LIVENESS.NONE,
-        R.chain(XP.updatePatch(path, XP.removeDebugNodes))
+        R.map(XP.removeDebugNodes(path))
       ),
-      R.map(XP.jumperizePatchRecursively(path)),
       XP.validatePatchReqursively(path)
       // begin preparing project for transpilation
     )(project)

--- a/packages/xod-project/src/constants.js
+++ b/packages/xod-project/src/constants.js
@@ -109,6 +109,8 @@ export const PULSE_CONST_NODETYPES = {
 // to debug xod programm, it should be omitted
 // from Project before transpilation without
 // turned on debug mode
+// tweak-* nodes should not be omitted,
+// they will just act as slightly less efficient constants
 export const DEBUG_NODETYPES = [
   'xod/core/watch',
   'xod/core/console-log',

--- a/packages/xod-project/src/index.js
+++ b/packages/xod-project/src/index.js
@@ -54,7 +54,6 @@ export {
   assocComment,
   dissocComment,
   upsertComments,
-  removeDebugNodes,
   getTopologyMap,
   applyNodeIdMap,
   resolveNodeTypesInPatch,

--- a/packages/xod-project/src/patch.js
+++ b/packages/xod-project/src/patch.js
@@ -984,21 +984,6 @@ export const toposortNodes = def(
 );
 
 /**
- * Function removes debug nodes and links to these nodes
- * from the patch. It could be used in transpilation without
- * debug mode to omit unuseful debug nodes from compiled program.
- */
-export const removeDebugNodes = def(
-  'removeDebugNodes :: Patch -> Patch',
-  patch =>
-    R.compose(
-      R.reduce((acc, node) => dissocNode(node, acc), patch),
-      R.filter(R.compose(isAmong(CONST.DEBUG_NODETYPES), Node.getNodeType)),
-      listNodes
-    )(patch)
-);
-
-/**
  * Returns a map of pins for Node, that points to a patch that exists.
  * So Pins are fully valid, contains proper types and etc.
  */

--- a/packages/xod-project/test/patch.spec.js
+++ b/packages/xod-project/test/patch.spec.js
@@ -1410,64 +1410,6 @@ describe('Patch', () => {
       });
     });
 
-    describe('remove debug nodes', () => {
-      it('should return patch without debug nodes and links', () => {
-        const origPatch = Helper.defaultizePatch({
-          nodes: {
-            a: {
-              id: 'a',
-              type: 'xod/core/watch',
-            },
-            b: {
-              id: 'b',
-              type: 'xod/core/add',
-            },
-          },
-          links: {
-            b2a: {
-              id: 'b2a',
-              input: { nodeId: 'a', pinKey: 'IN' },
-              output: { nodeId: 'a', pinKey: 'OUT' },
-            },
-          },
-        });
-        const expectedPatch = Helper.defaultizePatch({
-          nodes: {
-            b: {
-              id: 'b',
-              type: 'xod/core/add',
-            },
-          },
-          links: {},
-        });
-
-        assert.deepEqual(Patch.removeDebugNodes(origPatch), expectedPatch);
-      });
-      it('should not affect patch without debug nodes', () => {
-        const origPatch = Helper.defaultizePatch({
-          nodes: {
-            a: {
-              id: 'a',
-              type: 'xod/core/multiply',
-            },
-            b: {
-              id: 'b',
-              type: 'xod/core/add',
-            },
-          },
-          links: {
-            b2a: {
-              id: 'b2a',
-              input: { nodeId: 'a', pinKey: 'IN_0' },
-              output: { nodeId: 'a', pinKey: 'OUT' },
-            },
-          },
-        });
-
-        assert.strictEqual(Patch.removeDebugNodes(origPatch), origPatch);
-      });
-    });
-
     describe('sameNodesList', () => {
       it('returns false if Node added', () => {
         const prevPatch = Helper.defaultizePatch({ nodes: { a: {}, b: {} } });

--- a/packages/xod-project/test/project.spec.js
+++ b/packages/xod-project/test/project.spec.js
@@ -1647,4 +1647,70 @@ describe('Project', () => {
       );
     });
   });
+
+  describe('remove debug nodes', () => {
+    it('should return patch without debug nodes and links', () => {
+      const projectWithDebugNodes = Helper.defaultizeProject({
+        patches: {
+          '@/main': {
+            nodes: {
+              foo: {
+                id: 'foo',
+                type: '@/foo',
+              },
+            },
+          },
+          '@/foo': {
+            nodes: {
+              watch: {
+                id: 'watch',
+                type: 'xod/core/watch',
+              },
+              add: {
+                id: 'add',
+                type: 'xod/core/add',
+              },
+            },
+            links: {
+              l1: {
+                id: 'l1',
+                input: { nodeId: 'watch', pinKey: 'whatever' },
+                output: { nodeId: 'add', pinKey: 'whatever' },
+              },
+            },
+          },
+          'xod/core/watch': {},
+          'xod/core/add': {},
+        },
+      });
+
+      const projectWithoutDebugNodes = Helper.defaultizeProject({
+        patches: {
+          '@/main': {
+            nodes: {
+              foo: {
+                id: 'foo',
+                type: '@/foo',
+              },
+            },
+          },
+          '@/foo': {
+            nodes: {
+              add: {
+                id: 'add',
+                type: 'xod/core/add',
+              },
+            },
+          },
+          'xod/core/watch': {},
+          'xod/core/add': {},
+        },
+      });
+
+      assert.deepEqual(
+        Project.removeDebugNodes('@/main', projectWithDebugNodes),
+        projectWithoutDebugNodes
+      );
+    });
+  });
 });


### PR DESCRIPTION
Before debug-nodes were removed only from the top level.
It could cause compilation error when uploading without debug.