### PR TITLE
Fix coloring of jumper node when it’s connected to generic pins

### DIFF
--- a/packages/xod-client/src/core/styles/components/Node.scss
+++ b/packages/xod-client/src/core/styles/components/Node.scss
@@ -110,7 +110,7 @@
     &.error {
       stroke: $color-datatype-dead;
     }
-    &.generic {
+    &.t1 {
       stroke: $color-node-outline;
     }
   }

--- a/packages/xod-client/src/project/components/nodeParts/JumperNodeBody.jsx
+++ b/packages/xod-client/src/project/components/nodeParts/JumperNodeBody.jsx
@@ -14,8 +14,9 @@ const JumperNodeBody = ({ pins }) => {
 
   const type = R.cond([
     [() => inConnected, R.pipe(R.prop(INPUT_PINKEY), getRenderablePinType)],
-    [() => outConnected, R.pipe(R.prop(OUTPUT_PINKEY), getRenderablePinType)],
-    [R.T, R.always('generic')],
+    // if output pin is not connected as well,
+    // it will fall back to good old `t1`
+    [R.T, R.pipe(R.prop(OUTPUT_PINKEY), getRenderablePinType)],
   ])(pins);
 
   const isConnected =


### PR DESCRIPTION
Before:
![screen shot 2019-02-27 at 17 46 31](https://user-images.githubusercontent.com/2527093/53500799-13aedb80-3abc-11e9-9805-42e35c668b6e.png)

After:
![screen shot 2019-02-27 at 17 48 49](https://user-images.githubusercontent.com/2527093/53500819-1c071680-3abc-11e9-9a55-2510f297900a.png)
