### PR TITLE
Fix bus link splitting and nodes/comment resizing

### DIFF
--- a/packages/xod-client/src/editor/containers/Patch/modes/resizingComment.jsx
+++ b/packages/xod-client/src/editor/containers/Patch/modes/resizingComment.jsx
@@ -13,7 +13,7 @@ import {
   pointToSize,
   sizeToPoint,
   snapNodeSizeToSlots,
-  pixelSizeToSlots,
+  slotSizeToPixels,
   NODE_HEIGHT,
   SLOT_SIZE,
 } from '../../../../project/nodeLayout';
@@ -73,7 +73,6 @@ const resizingCommentMode = {
     const deltaPosition = getDeltaPosition(api);
 
     const newSize = R.compose(
-      pixelSizeToSlots,
       snapNodeSizeToSlots,
       addDeltaToSize(deltaPosition),
       getPxSize,
@@ -97,7 +96,10 @@ const resizingCommentMode = {
     const snappedPreviews = R.compose(
       R.map(
         R.compose(
-          R.over(R.lensProp('pxSize'), snapNodeSizeToSlots),
+          R.over(
+            R.lensProp('pxSize'),
+            R.pipe(snapNodeSizeToSlots, slotSizeToPixels)
+          ),
           R.pick(['pxSize', 'pxPosition'])
         )
       ),

--- a/packages/xod-client/src/project/nodeLayout.js
+++ b/packages/xod-client/src/project/nodeLayout.js
@@ -261,10 +261,8 @@ export const getBusNodePositionForPin = (node, pin) => {
   const pinOrder = XP.getPinOrder(pin);
 
   return {
-    x: nodePosition.x + pinOrder * SLOT_SIZE.WIDTH,
-    y:
-      nodePosition.y +
-      SLOT_SIZE.HEIGHT * (pinDirection === XP.PIN_DIRECTION.INPUT ? -1 : 1),
+    x: nodePosition.x + pinOrder,
+    y: nodePosition.y + (pinDirection === XP.PIN_DIRECTION.INPUT ? -1 : 1),
   };
 };
 

--- a/packages/xod-client/src/project/nodeLayout.js
+++ b/packages/xod-client/src/project/nodeLayout.js
@@ -68,7 +68,7 @@ export const pixelSizeToSlots = R.evolve({
 // :: Size -> Size
 export const slotSizeToPixels = R.evolve({
   width: slots => slots * SLOT_SIZE.WIDTH,
-  height: slots => R.dec(slots) * SLOT_SIZE.HEIGHT + NODE_HEIGHT,
+  height: slots => slots * SLOT_SIZE.HEIGHT - SLOT_SIZE.GAP,
 });
 
 // :: Position -> Position
@@ -210,11 +210,13 @@ export const snapNodePositionToSlots = R.compose(
 );
 
 export const snapNodeSizeToSlots = R.compose(
-  slotSizeToPixels,
   pointToSize,
-  nodePositionInPixelsToSlots,
-  addPoints({ x: SLOT_SIZE.WIDTH * 0.75, y: SLOT_SIZE.HEIGHT * 1.1 }),
-  sizeToPoint
+  R.evolve({
+    x: x => Math.ceil(x),
+    y: y => Math.ceil(y),
+  }),
+  sizeToPoint,
+  pixelSizeToSlots
 );
 
 // :: ([Number] -> Number) -> ([Number] -> Number) -> [Position] -> Maybe Position


### PR DESCRIPTION
Fix few bugs introduced in PR #1695:
- split links with buses
- resizing nodes and comments