### PR TITLE
Fix docs screenshoter to avoid hovering effects

### DIFF
--- a/tools/screenshot-xodball
+++ b/tools/screenshot-xodball
@@ -103,6 +103,9 @@ const height =
   await menubar.clickTopLevelItem('View');
   await menubar.clickMenuItem('Pan to Center');
 
+  // move mouse out from the view area to avoid hover effects
+  await page.mouse.move(10000, 10000);
+
   await page.screenshot({
     path: screenshotDestPath,
     clip: Object.assign({}, patchboardTopLeft, desiredScreenshotSize),


### PR DESCRIPTION
There is no issue. But here is the example of the bug:
![a](https://raw.githubusercontent.com/xodio/xod-docs/a604068d274b8a6186d46b181803984c916d6787/docs/guide/creating-variadics/assignments.patch.png)