### PR TITLE
Fix adding a bus node while linking in the right position

### DIFF
--- a/packages/xod-client/src/editor/containers/Patch/modes/linking.jsx
+++ b/packages/xod-client/src/editor/containers/Patch/modes/linking.jsx
@@ -6,6 +6,11 @@ import { COMMAND } from '../../../../utils/constants';
 import PatchSVG from '../../../../project/components/PatchSVG';
 import * as Layers from '../../../../project/components/layers';
 
+import {
+  snapPositionToSlots,
+  pixelPositionToSlots,
+} from '../../../../project/nodeLayout';
+
 import { getOffsetMatrix, bindApi, getMousePosition } from '../modeUtils';
 
 const abort = api => {
@@ -45,9 +50,13 @@ const linkingMode = {
     const { nodeId, pinKey } = api.props.linkingPin;
     const node = api.props.nodes[nodeId];
 
+    const mouseSlotPosition = pixelPositionToSlots(
+      snapPositionToSlots(api.state.mousePosition)
+    );
+
     api.props.actions.addBusNode(
       api.props.patchPath,
-      api.state.mousePosition,
+      mouseSlotPosition,
       node,
       pinKey
     );

--- a/packages/xod-client/src/project/reducer.js
+++ b/packages/xod-client/src/project/reducer.js
@@ -12,7 +12,6 @@ import {
 import {
   addPoints,
   slotPositionToPixels,
-  snapPositionToSlots,
   snapNodePositionToSlots,
   pixelPositionToSlots,
   getBusNodePositionForPin,
@@ -413,14 +412,13 @@ export default (state = {}, action) => {
         position,
       } = action.payload;
 
-      const busNodePosition = snapPositionToSlots(position);
       const busNodeType =
         pinDirection === XP.PIN_DIRECTION.INPUT
           ? XP.FROM_BUS_PATH
           : XP.TO_BUS_PATH;
 
       const busNode = R.compose(XP.setNodeLabel(label), XP.createNode)(
-        busNodePosition,
+        position,
         busNodeType
       );
 


### PR DESCRIPTION
There is no issue. Reported by @gabbapeople in the chat

To reproduce:
- Start linking
- Press "B" to place a bus node

Expected to see a new bus node at the mouse position.
Actually, it placed somewhere outside the view area.