### PR TITLE
Make node and pin labels a bit brighter

### DIFF
--- a/packages/xod-client/src/core/styles/abstracts/variables.scss
+++ b/packages/xod-client/src/core/styles/abstracts/variables.scss
@@ -14,7 +14,7 @@ $color-success: #579205;
 $color-canvas-background: $dark-deep;
 $color-canvas-background-gridlines: $dark-light;
 $color-canvas-face: #646464;
-$color-canvas-face-light: $chalk-light;
+$color-canvas-face-light: $chalk-bright;
 $color-canvas-face-text: #a7a7a7;
 $color-canvas-selected: #4ed5ed;
 $color-highlight: #eeeeee;
@@ -44,7 +44,7 @@ $color-watch-node-highlight-outline: #bce88e;
 $color-comment-text: #d0ccc0;
 $color-comment-handle: #605f5b;
 
-$color-pinlabel: $grey-bright;
+$color-pinlabel: $light-grey-bright;
 
 $color-toolbar-background: #b3b3b3;
 $color-toolbar-foreground: #000;


### PR DESCRIPTION
This should deal with readability issues that were reported on our forum: https://forum.xod.io/t/xod-0-28-0-more-detailed-patch-board/1961/6?u=evgenykochetkov