### PR TITLE
Clean watchNodeValues when simulation is stopped

### DIFF
--- a/packages/xod-client/src/debugger/reducer.js
+++ b/packages/xod-client/src/debugger/reducer.js
@@ -487,6 +487,7 @@ export default (state = initialState, action) => {
       return R.compose(
         addPlainTextToDebuggerLog(MSG.SIMULATION_ABORTED),
         R.assoc('activeSession', SESSION_TYPE.NONE),
+        R.assoc('watchNodeValues', {}),
         R.assoc('isPreparingSimulation', false),
         hideProgressBar
       )(state);


### PR DESCRIPTION
Otherwise, when rerunning a simulation of the same patch, stale values from the previous simulation are displayed.

[stale-values-on-simulation-rerun-example.xodball.zip](https://github.com/xodio/xod/files/2995801/stale-values-on-simulation-rerun-example.xodball.zip)