### PR TITLE
Allow custom name of wasm file

### DIFF
--- a/packages/xod-client/src/workers/wasm.worker.js
+++ b/packages/xod-client/src/workers/wasm.worker.js
@@ -64,10 +64,7 @@ _self.onmessage = e => {
       _self.importScripts(runtimeUrl);
       const opts = Object.assign(suite, {
         // Make possible downloading of wasmFile from dedicated webserver:
-        locateFile: fileName => {
-          if (fileName === 'main.wasm') return wasmUrl;
-          return fileName;
-        },
+        locateFile: () => wasmUrl,
         onAbort: x =>
           _self.postMessage({
             type: 'abort',


### PR DESCRIPTION
There is no issue.
We have hardcoded name of wasm file. But this name baked in the JS runtime on the backend at compilation time. So we need a hack that rewrites this name in JS runtime.
Сontrariwise, it's always only one wasm file. So we can just always return URL of the wasm file. 
This change is backward compatible with the current backend version.