### PR TITLE
Deprecate `xod/core/word-to-number`

### DIFF
--- a/workspace/__lib__/xod/core/word-to-number/patch.xodp
+++ b/workspace/__lib__/xod/core/word-to-number/patch.xodp
@@ -2,6 +2,16 @@
   "description": "Packs two bytes into an integer number",
   "nodes": [
     {
+      "description": "Use `xod/bits/i16-to-number` instead",
+      "id": "S1AxlFmtV",
+      "position": {
+        "units": "slots",
+        "x": 4,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/deprecated"
+    },
+    {
       "id": "SJ_i04svZ",
       "position": {
         "units": "slots",


### PR DESCRIPTION
It was introduced in v0.13.
Now we have `xod/bits/i16-to-number` that does exactly the same.