### PR TITLE
Fix screenshot tools

### DIFF
--- a/tools/generate-tutorial-docs.js
+++ b/tools/generate-tutorial-docs.js
@@ -160,9 +160,7 @@ const extractCommentsFromProject = projectPath =>
 // =============================================================================
 
 const formatScreenshotCommand = patchName =>
-  `"$SHOT" "$SRC" ${patchName} ${
-    options.output
-  }/${patchName}/${patchName}.patch.png`;
+  `"$SHOT" "$SRC" ${patchName} ./${patchName}/${patchName}.patch.png`;
 
 const generateScreenshotScript = projectPath =>
   getProjectPatchDirs(projectPath)

--- a/tools/screenshot-xodball
+++ b/tools/screenshot-xodball
@@ -42,9 +42,13 @@ const getPatchHeight = (pathToProject, patchName) =>
         comments: XP.listComments(patch),
         links: XP.listLinks(patch),
       };
-      return (
-        slotPositionToPixels(getBBox(patch, proj, entities)).y + SLOT_SIZE.GAP
-      );
+
+      const patchBbox = slotPositionToPixels(getBBox(patch, proj, entities));
+
+      if (patchBbox.y <= 0)
+        return Promise.reject(`Patch "${patchName}" is empty.`);
+
+      return patchBbox.y + SLOT_SIZE.GAP;
     }
   );
 
@@ -79,7 +83,10 @@ const patchboardTopLeft = {
     pathToXodball,
     patchBaseName,
     desiredScreenshotHeight
-  );
+  ).catch(err => {
+    process.stdout.write(`${err}\n`);
+    process.exit(1);
+  });
 
   const desiredScreenshotSize = {
     width: 700,


### PR DESCRIPTION
There is no issue.

1. `generate-tutorial-docs` outputs wrong paths in the `update-screenshots.sh`. Fixed.
2. `screenshot-xodball` hangs when tried to make a screenshot for the empty patch. Fixed.