### PR TITLE
Fix lib name for `xod/mutex`

### DIFF
--- a/workspace/__lib__/xod/mutex/project.xod
+++ b/workspace/__lib__/xod/mutex/project.xod
@@ -1,4 +1,4 @@
 {
   "license": "AGPL-3.0",
-  "name": "servo"
+  "name": "mutex"
 }


### PR DESCRIPTION
Introduced in #1748