### PR TITLE
Fix C++ errors/warnings in new nodes

### DIFF
--- a/workspace/__lib__/xod-dev/servo/servo-device/patch.cpp
+++ b/workspace/__lib__/xod-dev/servo/servo-device/patch.cpp
@@ -33,7 +33,7 @@ class XServo : public Servo {
         this->attach(port, pulseMin, pulseMax);
     }
 
-    Number read01() const {
+    Number read01() {
         int us = this->readMicroseconds();
         return (Number)(us - pulseMin) / (Number)(pulseMax - pulseMin);
     }

--- a/workspace/__lib__/xod/core/animation-unit/patch.cpp
+++ b/workspace/__lib__/xod/core/animation-unit/patch.cpp
@@ -8,7 +8,7 @@ struct State {
 void evaluate(Context ctx) {
     auto now = transactionTime();
     auto state = getState(ctx);
-    auto rate = max(0, getValue<input_RATE>(ctx));
+    auto rate = max((Number)0, getValue<input_RATE>(ctx));
     auto out = getValue<output_OUT>(ctx);
 
     if (isInputDirty<input_FWD>(ctx)) {


### PR DESCRIPTION
Introduced in #1748.
Causes errors when compiling for esp8266 and some other platforms.