### PR TITLE
Add missing descriptions to `xod-dev/servo`, `xod-mutex`, `xod-net` and `xod/stream` libraries

### DIFF
--- a/workspace/__lib__/xod-dev/servo/project.xod
+++ b/workspace/__lib__/xod-dev/servo/project.xod
@@ -1,4 +1,8 @@
 {
+  "authors": [
+    "XOD"
+  ],
+  "description": "Nodes to control RC hobby servos",
   "license": "AGPL-3.0",
   "name": "servo",
   "version": "0.29.0"

--- a/workspace/__lib__/xod/mutex/project.xod
+++ b/workspace/__lib__/xod/mutex/project.xod
@@ -1,4 +1,8 @@
 {
+  "authors": [
+    "XOD"
+  ],
+  "description": "Library to work with mutually exclusive resources. Useful to avoid conflicts between nodes controlling long-running processes.",
   "license": "AGPL-3.0",
   "name": "mutex",
   "version": "0.29.0"

--- a/workspace/__lib__/xod/net/project.xod
+++ b/workspace/__lib__/xod/net/project.xod
@@ -2,6 +2,7 @@
   "authors": [
     "XOD"
   ],
+  "description": "General types and operations to manage network connections",
   "license": "AGPL-3.0",
   "name": "net",
   "version": "0.29.0"

--- a/workspace/__lib__/xod/stream/project.xod
+++ b/workspace/__lib__/xod/stream/project.xod
@@ -2,6 +2,7 @@
   "authors": [
     "XOD"
   ],
+  "description": "Nodes to process sequences of bytes one by one",
   "license": "AGPL-3.0",
   "name": "stream",
   "version": "0.29.0"


### PR DESCRIPTION
Closes #1758
