### PR TITLE
Rename daily quotas to cloud limits (cosmetic)

### DIFF
--- a/packages/xod-client/src/core/styles/components/AccountPane.scss
+++ b/packages/xod-client/src/core/styles/components/AccountPane.scss
@@ -13,7 +13,7 @@
     margin-bottom: 1em;
   }
 
-  .dailyQuotas {
+  .cloudLimits {
     font-size: $font-size-m;
     margin-bottom: 2em;
     cursor: default;

--- a/packages/xod-client/src/user/components/AuthForm.jsx
+++ b/packages/xod-client/src/user/components/AuthForm.jsx
@@ -39,7 +39,7 @@ class AuthForm extends React.Component {
     return (
       <form onSubmit={this.onLogin}>
         <div className="whyLogin">
-          Log in to increase quotas and access more features
+          Log in to increase cloud limits and access more features
         </div>
 
         <input

--- a/packages/xod-client/src/user/containers/AccountPane.jsx
+++ b/packages/xod-client/src/user/containers/AccountPane.jsx
@@ -46,8 +46,8 @@ const AccountPane = ({
         )}
       </div>
 
-      <div className="dailyQuotas">
-        <div className="title">Daily quotas</div>
+      <div className="cloudLimits">
+        <div className="title">Cloud limits</div>
         <div>
           Compilations:{' '}
           {compilationsLeft == null ? 'currently offline' : compilationsLeft}


### PR DESCRIPTION
There is no issue.
"Daily quotas" phrase doesn't represent the essence of our time slot based limits. Also, we always say "limits" or "cloud limits" and not "quotas". But actually I'm not againts "quotas", I'm against "daily". So, If you know a more appropriate phrase, propose it :)