### PR TITLE
Visualize errors in the IDE

### DIFF
--- a/packages/xod-arduino/src/index.js
+++ b/packages/xod-arduino/src/index.js
@@ -2,6 +2,7 @@ export {
   transpile,
   transformProject,
   getNodeIdsMap,
+  getPinsAffectedByErrorRaisers,
   getRequireUrls,
 } from './transpiler';
 

--- a/packages/xod-client/src/core/styles/components/Link.scss
+++ b/packages/xod-client/src/core/styles/components/Link.scss
@@ -53,6 +53,10 @@
     @include link-parts-coloring($color-canvas-selected);
   }
 
+  &.is-error-affected {
+    @include link-parts-coloring($error);
+  }
+
   &.is-dead {
     @include link-parts-coloring($error);
     stroke-dasharray: 2,2;

--- a/packages/xod-client/src/core/styles/components/Node.scss
+++ b/packages/xod-client/src/core/styles/components/Node.scss
@@ -4,6 +4,8 @@
   text-shadow: 0 1px 1px $color-node-fill;
 }
 
+$error-disappear-time: 250ms;
+
 .Node {
   .body {
     width: 100%;
@@ -16,6 +18,7 @@
     fill: transparent;
     stroke: $color-node-outline;
     stroke-width: 1px;
+    transition: stroke $error-disappear-time;
 
     // For terminals:
     &.string { stroke: $color-datatype-string; }
@@ -42,6 +45,32 @@
       stroke: $error;
     }
   }
+
+  &.is-error-raised, &.is-error-affected {
+    .nodeLabel {
+      color: $error-text !important;
+      transition: color 0s;
+    }
+    .bus-node .outline {
+      stroke: $error !important;
+    }
+    .jumper-line {
+      stroke: $error !important;
+    }
+  }
+  &.is-error-raised {
+    .outline {
+      stroke: $error;
+      transition: stroke 0s;
+    }
+    .VariadicHandle--grip {
+      fill: $error;
+    }
+    .NodeResizeHandle {
+      fill: $error;
+    }
+  }
+  &.is-error-affected {}
 
   &.is-variadic {}
 
@@ -144,6 +173,8 @@
     text-overflow: ellipsis;
     cursor: default;
     user-select: none;
+
+    transition: color $error-disappear-time;
   }
 
   &.is-hovered {

--- a/packages/xod-client/src/core/styles/components/Pin.scss
+++ b/packages/xod-client/src/core/styles/components/Pin.scss
@@ -64,7 +64,7 @@
       @include symbol-coloring($color-datatype-errcode);
     }
 
-    &.dead, &.is-invalid, &.conflicting {
+    &.dead, &.is-invalid, &.conflicting, &.is-error-affected {
       @include symbol-coloring($color-datatype-dead);
     }
   }

--- a/packages/xod-client/src/debugger/actions.js
+++ b/packages/xod-client/src/debugger/actions.js
@@ -33,12 +33,14 @@ export const selectDebuggerTab = tab => ({
 export const startDebuggerSession = (
   message,
   nodeIdsMap,
+  pinsAffectedByErrorRaisers,
   currentPatchPath
 ) => ({
   type: AT.DEBUG_SESSION_STARTED,
   payload: {
     message,
     nodeIdsMap,
+    pinsAffectedByErrorRaisers,
     patchPath: currentPatchPath,
   },
 });

--- a/packages/xod-client/src/debugger/debugProtocol.js
+++ b/packages/xod-client/src/debugger/debugProtocol.js
@@ -24,6 +24,8 @@ export const DEBUGGER_MESSAGE_TYPES = {
   ERROR: 'error',
 };
 
+const XOD_ERROR_PREFIX = '+XOD_ERR';
+
 //------------------------------------------------------------------------------
 //
 // Utils
@@ -46,6 +48,9 @@ const xodMessageRegExp = /^(\+\w+):(\d+):(\d+):(.+)/;
 
 // :: String -> Boolean
 export const isXodMessage = R.test(xodMessageRegExp);
+
+// :: XodMessage -> Boolean
+export const isXodErrorMessage = R.propEq('prefix', XOD_ERROR_PREFIX);
 
 // :: String -> XodMessage
 export const createXodMessage = input =>

--- a/packages/xod-client/src/debugger/state.js
+++ b/packages/xod-client/src/debugger/state.js
@@ -34,4 +34,6 @@ export default {
   nodeIdsMap: {},
   watchNodeValues: {},
   uploadProgress: null,
+  interactiveNodeErrorCodes: {},
+  pinsAffectedByErrorRaisers: {},
 };

--- a/packages/xod-client/src/editor/actions.js
+++ b/packages/xod-client/src/editor/actions.js
@@ -814,10 +814,12 @@ export const abortSimulation = () => (dispatch, getState) => {
   });
 };
 
-export const runSimulation = (simulationPatchPath, nodeIdsMap, code) => (
-  dispatch,
-  getState
-) => {
+export const runSimulation = (
+  simulationPatchPath,
+  nodeIdsMap,
+  code,
+  pinsAffectedByErrorRaisers
+) => (dispatch, getState) => {
   dispatch({ type: ActionType.SIMULATION_GENERATED_CPP });
 
   const ABORT_ERROR_TYPE = 'ABORT_BY_USER';
@@ -846,6 +848,7 @@ export const runSimulation = (simulationPatchPath, nodeIdsMap, code) => (
             payload: {
               worker,
               nodeIdsMap,
+              pinsAffectedByErrorRaisers,
               patchPath: simulationPatchPath,
             },
           });

--- a/packages/xod-client/src/editor/containers/Patch/modes/changingArityLevel.jsx
+++ b/packages/xod-client/src/editor/containers/Patch/modes/changingArityLevel.jsx
@@ -93,7 +93,16 @@ const changingArityLevel = {
           R.values,
           R.prop('pins')
         )(renderableNode),
-      getRenderableNode(R.__, currentPatch, connectedPins, {}, project, {}),
+      getRenderableNode(
+        R.__,
+        currentPatch,
+        connectedPins,
+        {},
+        project,
+        {},
+        {},
+        {}
+      ),
       XP.setNodeArityLevel(api.state.desiredArityLevel),
       XP.getNodeByIdUnsafe(api.state.nodeId)
     )(currentPatch);

--- a/packages/xod-client/src/project/components/Link.jsx
+++ b/packages/xod-client/src/project/components/Link.jsx
@@ -64,6 +64,7 @@ class Link extends React.Component {
       'is-ghost': this.props.isGhost,
       'is-dead': this.props.dead,
       'is-dragged': this.props.isDragged,
+      'is-error-affected': this.props.isAffectedByErrorRaiser,
     });
 
     const clickable = this.isClickable();
@@ -127,6 +128,7 @@ Link.propTypes = {
   isOverlay: PropTypes.bool,
   isDragged: PropTypes.bool,
   onClick: PropTypes.func,
+  isAffectedByErrorRaiser: PropTypes.bool,
 };
 
 Link.defaultProps = {
@@ -136,6 +138,7 @@ Link.defaultProps = {
   isGhost: false,
   isOverlay: false,
   isDragged: false,
+  isAffectedByErrorRaiser: false,
   onClick: noop,
 };
 

--- a/packages/xod-client/src/project/components/Pin.jsx
+++ b/packages/xod-client/src/project/components/Pin.jsx
@@ -32,6 +32,7 @@ const Pin = props => {
     hasConflictingBoundValue,
     'is-connected': props.isConnected,
     'is-invalid': props.isInvalid,
+    'is-error-affected': props.isAffectedByErrorRaiser,
   });
 
   const pinCircleCenter = {
@@ -96,6 +97,7 @@ Pin.propTypes = {
   isInvalid: PropTypes.bool,
   isAcceptingLinks: PropTypes.bool,
   isLastVariadicGroup: PropTypes.bool,
+  isAffectedByErrorRaiser: PropTypes.bool,
 };
 
 export default Pin;

--- a/packages/xod-client/src/project/components/layers/LinksLayer.jsx
+++ b/packages/xod-client/src/project/components/layers/LinksLayer.jsx
@@ -19,6 +19,7 @@ const LinksLayer = ({ links, selection, isDragged = false }) => (
           to={link.to}
           type={link.type}
           dead={link.dead}
+          isAffectedByErrorRaiser={link.isAffectedByErrorRaiser}
           isDragged={isDragged}
           isSelected={isLinkSelected(selection, link.id)}
         />

--- a/packages/xod-client/src/project/components/layers/NodesLayer.jsx
+++ b/packages/xod-client/src/project/components/layers/NodesLayer.jsx
@@ -38,6 +38,8 @@ const NodesLayer = ({
             position={node.pxPosition}
             pxPosition={node.pxPosition}
             errors={node.errors}
+            raisedErrorCode={node.raisedErrorCode}
+            isAffectedByErrorRaiser={node.isAffectedByErrorRaiser}
             isDeprecated={node.isDeprecated}
             hidden={node.hidden}
             size={node.pxSize}
@@ -70,6 +72,8 @@ const NodesLayer = ({
 NodesLayer.defaultProps = {
   areDragged: false,
   nodeValues: {},
+  interactiveNodeErrorCodes: {},
+  nodesAffectedByErrorRaisers: {},
 };
 
 NodesLayer.propTypes = {

--- a/packages/xod-project/src/Node.re
+++ b/packages/xod-project/src/Node.re
@@ -11,6 +11,8 @@ let create = patchPath => _create(Position.origin, patchPath);
 
 [@bs.module ".."] external getId : t => id = "getNodeId";
 
+[@bs.module ".."] external setId : (id, t) => t = "setNodeId";
+
 [@bs.module ".."] external getType : t => PatchPath.t = "getNodeType";
 
 [@bs.module ".."] external setType : (PatchPath.t, t) => t = "setNodeType";

--- a/packages/xod-project/src/Node.rei
+++ b/packages/xod-project/src/Node.rei
@@ -8,6 +8,8 @@ let create: PatchPath.t => t;
 
 let getId: t => id;
 
+let setId: (id, t) => t;
+
 let getType: t => PatchPath.t;
 
 let setType: (PatchPath.t, t) => t;

--- a/packages/xod-project/src/Patch.re
+++ b/packages/xod-project/src/Patch.re
@@ -109,3 +109,15 @@ let getTabtestContent = t =>
   |. Option.map(Attachment.getContent);
 
 let hasTabtest = t => getAttachments(t) |. List.some(Attachment.isTabtest);
+
+[@bs.module ".."]
+external isNotImplementedInXod : t => bool = "isPatchNotImplementedInXod";
+
+[@bs.module ".."]
+external isAbstract : t => bool = "isAbstractPatch";
+
+let isTerminal = patch => patch |. getPath |. PatchPath.isTerminal;
+let isJumper = patch => patch |. getPath |. PatchPath.isJumper;
+let isBus = patch => patch |. getPath |. PatchPath.isBus;
+let isFromBus = patch => patch |. getPath |. PatchPath.isFromBus;
+let isToBus = patch => patch |. getPath |. PatchPath.isToBus;

--- a/packages/xod-project/src/Patch.rei
+++ b/packages/xod-project/src/Patch.rei
@@ -43,3 +43,12 @@ let getAttachments: t => list(Attachment.t);
 let getTabtestContent: t => option(string);
 
 let hasTabtest: t => bool;
+
+let isNotImplementedInXod: t => bool;
+
+let isAbstract: t => bool;
+let isTerminal: t => bool;
+let isJumper: t => bool;
+let isBus: t => bool;
+let isFromBus: t => bool;
+let isToBus: t => bool;

--- a/packages/xod-project/src/PatchPath.re
+++ b/packages/xod-project/src/PatchPath.re
@@ -1,3 +1,11 @@
 type t = string;
 
 [@bs.module ".."] external getBaseName : t => string = "";
+
+[@bs.module ".."] external isTerminal : t => bool = "isTerminalPatchPath";
+
+[@bs.module ".."] external isJumper : t => bool = "isJumperPatchPath";
+
+[@bs.module ".."] external isBus : t => bool = "isBusPatchPath";
+[@bs.module ".."] external isFromBus : t => bool = "isFromBusPatchPath";
+[@bs.module ".."] external isToBus : t => bool = "isToBusPatchPath";

--- a/packages/xod-project/src/PatchPath.rei
+++ b/packages/xod-project/src/PatchPath.rei
@@ -1,3 +1,10 @@
 type t = string;
 
 let getBaseName: t => string;
+
+let isTerminal: t => bool;
+
+let isJumper: t => bool;
+let isBus: t => bool;
+let isFromBus: t => bool;
+let isToBus: t => bool;

--- a/packages/xod-project/src/Pin.re
+++ b/packages/xod-project/src/Pin.re
@@ -40,6 +40,10 @@ let getDirection = (pin: t) : direction => {
   };
 };
 
+let isOutput = (pin: t) : bool => pin |. getDirection |. dir => (dir === Output);
+
+let isInput = (pin: t) : bool => pin |. getDirection |. dir => (dir === Input);
+
 [@bs.module ".."]
 external _normalizeLabels : array(t) => array(t) = "normalizeEmptyPinLabels";
 

--- a/packages/xod-project/src/Pin.rei
+++ b/packages/xod-project/src/Pin.rei
@@ -25,6 +25,10 @@ type dataType = string;
 
 let getDirection: t => direction;
 
+let isOutput: t => bool;
+
+let isInput: t => bool;
+
 let normalizeLabels: list(t) => list(t);
 
 let getPrimitiveTypeExn: t => primitiveDataType;

--- a/packages/xod-project/src/Traversing.re
+++ b/packages/xod-project/src/Traversing.re
@@ -1,0 +1,198 @@
+open Belt;
+
+type pinWithOwnerNode = (Pin.t, Node.t);
+
+/*
+ ==============================================================================================================
+   Utility functions
+ ==============================================================================================================
+ */
+
+let isCompositionPatch = patch =>
+  !Patch.isNotImplementedInXod(patch) && !Patch.isTerminal(patch);
+
+let getUpstreamPinWithOwnerNodeFromInputPin:
+  (Pin.t, Node.t, Patch.t, Project.t) => option(pinWithOwnerNode) =
+  (pin, node, currentPatch, project) => {
+    /* Traverse up if there is a link */
+    let pinKey = Pin.getKey(pin);
+    let nodeId = Node.getId(node);
+
+    currentPatch
+    ->Patch.listLinks
+    ->(
+        List.keep(link =>
+          Link.getInputPinKey(link) === pinKey
+          && Link.getInputNodeId(link) === nodeId
+        )
+      )
+    ->List.head
+    ->(
+        Option.flatMap(link => {
+          let upstreamPinKey = link->Link.getOutputPinKey;
+          let upstreamNode =
+            link->Link.getOutputNodeId |> Patch.getNodeById(currentPatch);
+          let upstreamPin =
+            upstreamNode
+            ->(Option.flatMap(Project.getPatchByNode(project)))
+            ->(
+                Option.flatMap(patch =>
+                  patch->(Patch.getPinByKey(upstreamPinKey))
+                )
+              );
+          switch (upstreamPin, upstreamNode) {
+          | (Some(pin), Some(node)) => Some((pin, node))
+          | _ => None
+          };
+        })
+      );
+  };
+
+let getUpstreamBusInputPinWithOwnerNode:
+  (Node.t, Patch.t, Project.t) => option(pinWithOwnerNode) =
+  (node, currentPatch, project) => {
+    let busLabel = node->Node.getLabel;
+    currentPatch
+    ->Patch.listNodes
+    ->(
+        List.keep(node =>
+          Node.getLabel(node) === busLabel
+          && PatchPath.isToBus(Node.getType(node))
+        )
+      )
+    ->List.head
+    ->(
+        Option.flatMap(toBusNode =>
+          (toBusNode |> Project.getPatchByNode(project))
+          ->(Option.flatMap(patch => patch->Patch.listInputPins->List.head))
+          ->(Option.map(toBusInputPin => (toBusInputPin, toBusNode)))
+        )
+      );
+  };
+
+let drillDownAndGetTerminalsInputPin:
+  (Pin.t, Patch.t, Project.t) => option(pinWithOwnerNode) =
+  (pin, patchToDrillDown, project) => {
+    let pinKey = Pin.getKey(pin);
+    let _terminalNode = patchToDrillDown->(Patch.getNodeById(pinKey));
+    _terminalNode
+    ->(
+        Option.flatMap(terminalNode =>
+          (terminalNode->Node.getType |> Project.getPatchByPath(project))
+          ->(
+              Option.flatMap(terminalPatch =>
+                terminalPatch->Patch.listInputPins->List.head
+              )
+            )
+          ->(Option.map(terminalInputPin => (terminalInputPin, terminalNode)))
+        )
+      );
+  };
+
+let listOf: 'a => list('a) = a => [a];
+
+let isTerminalNode: Node.t => bool =
+  node => node->Node.getType->PatchPath.isTerminal;
+
+/** Updates Node Id by adding the parent Node Id in the beggining with "~" separator. */
+let patchNodeIdWithParentNodeId:
+  (Node.id, pinWithOwnerNode) => pinWithOwnerNode =
+  (parentNodeId, (pin, node)) => {
+    let originalNodeId = Node.getId(node);
+    let newNodeId = String.concat("~", [parentNodeId, originalNodeId]);
+    let patchedNode = Node.setId(newNodeId, node);
+    (pin, patchedNode);
+  };
+
+/*
+ ==============================================================================================================
+   Traversing functions
+ ==============================================================================================================
+ */
+
+let rec listUpstreamPinsToNiix:
+  (list(pinWithOwnerNode), Patch.t, Project.t) => list(pinWithOwnerNode) =
+  (pinPairs, currentPatch, project) =>
+    pinPairs
+    ->List.head
+    ->(
+        Option.flatMap(((pin, node)) =>
+          switch (
+            Pin.getDirection(pin),
+            Project.getPatchByNode(project, node),
+          ) {
+          | (Pin.Input, _) =>
+            pin
+            ->(
+                getUpstreamPinWithOwnerNodeFromInputPin(
+                  node,
+                  currentPatch,
+                  project,
+                )
+              )
+            ->(Option.map(listOf))
+          | (Pin.Output, Some(patch)) when Patch.isFromBus(patch) =>
+            node
+            ->(getUpstreamBusInputPinWithOwnerNode(currentPatch, project))
+            ->(Option.map(listOf))
+          | (Pin.Output, Some(patch)) when Patch.isAbstract(patch) => None
+          | (Pin.Output, Some(patch)) when isCompositionPatch(patch) =>
+            /*
+             Node is implemented in XOD.
+             So, drill down and traverse from the output terminal up.
+             If traversing ended with the input terminal (some kind of "identity" inside) —
+             go back to the parent level and continue traversing from the input pin.
+             Otherwise, return an output pin of this node.
+             */
+            drillDownAndGetTerminalsInputPin(pin, patch, project)
+            ->(
+                Option.flatMap(terminalPair =>
+                  [terminalPair]
+                  ->(listUpstreamPinsToNiix(patch, project))
+                  ->(
+                      insidePairs =>
+                        switch (insidePairs) {
+                        | [(_, insideLatestNode), ..._]
+                            when isTerminalNode(insideLatestNode) =>
+                          let inputTerminalPinKey =
+                            Node.getId(insideLatestNode);
+                          let parentNodeId = Node.getId(node);
+                          (inputTerminalPinKey |> Patch.getPinByKey(patch))
+                          ->(
+                              Option.map(inputNodePin =>
+                                insidePairs
+                                ->(
+                                    List.map(
+                                      patchNodeIdWithParentNodeId(
+                                        parentNodeId,
+                                      ),
+                                    )
+                                  )
+                                ->(List.add((inputNodePin, node)))
+                              )
+                            );
+                        | [_, ..._] =>
+                          let parentNodeId = Node.getId(node);
+                          insidePairs
+                          ->(
+                              List.map(
+                                patchNodeIdWithParentNodeId(parentNodeId),
+                              )
+                            )
+                          ->(x => Some(x));
+                        | _ => None
+                        }
+                    )
+                )
+              )
+          | (Pin.Output, _) => None
+          }
+        )
+      )
+    ->(
+        Option.map(newPairs =>
+          List.concat(newPairs, pinPairs)
+          ->(listUpstreamPinsToNiix(currentPatch, project))
+        )
+      )
+    ->(Option.getWithDefault(pinPairs));

--- a/packages/xod-project/src/Traversing.rei
+++ b/packages/xod-project/src/Traversing.rei
@@ -1,0 +1,8 @@
+/** A pair represents a Pin of the exact Node, so contains Pin object and Node object. */
+type pinWithOwnerNode = (Pin.t, Node.t);
+
+/** Returns a list of upstream pins starting from the first one of the list.
+    Function traversing by links, drilling down inside composite nodes,
+    passing through jumpers and resolving pairs of bus nodes. */
+let listUpstreamPinsToNiix:
+  (list(pinWithOwnerNode), Patch.t, Project.t) => list(pinWithOwnerNode);

--- a/packages/xod-project/src/Traversing_Js.re
+++ b/packages/xod-project/src/Traversing_Js.re
@@ -1,0 +1,8 @@
+let listUpstreamPinsToNiixU:
+  (array(Traversing.pinWithOwnerNode), Patch.t, Project.t) =>
+  array(Traversing.pinWithOwnerNode) =
+  (pinPairs, currentPatch, project) =>
+    pinPairs
+    ->Belt.List.fromArray
+    ->(Traversing.listUpstreamPinsToNiix(currentPatch, project))
+    ->Belt.List.toArray;

--- a/packages/xod-project/src/index.js
+++ b/packages/xod-project/src/index.js
@@ -2,6 +2,7 @@ import { curry } from 'ramda';
 
 // because functions exported from Reason are uncurried
 import { jumperizePatchRecursivelyU, splitLinksToBusesU } from './Buses_Js.bs';
+import { listUpstreamPinsToNiixU } from './Traversing_Js.bs';
 
 export * from './project';
 export {
@@ -143,3 +144,4 @@ export { BUILT_IN_TERMINAL_PATCH_PATHS } from './builtinTerminalPatches';
 
 export const jumperizePatchRecursively = curry(jumperizePatchRecursivelyU);
 export const splitLinksToBuses = curry(splitLinksToBusesU);
+export const listUpstreamPinsToNiix = curry(listUpstreamPinsToNiixU);

--- a/packages/xod-project/src/internal/patchPathUtils.js
+++ b/packages/xod-project/src/internal/patchPathUtils.js
@@ -124,10 +124,13 @@ export const isWatchPatchPath = R.test(/^xod\/(core|debug)\/watch$/);
 export const isJumperPatchPath = R.equals(CONST.JUMPER_PATCH_PATH);
 
 // :: String -> Boolean
-export const isBusPatchPath = R.either(
-  R.equals(CONST.FROM_BUS_PATH),
-  R.equals(CONST.TO_BUS_PATH)
-);
+export const isFromBusPatchPath = R.equals(CONST.FROM_BUS_PATH);
+
+// :: String -> Boolean
+export const isToBusPatchPath = R.equals(CONST.TO_BUS_PATH);
+
+// :: String -> Boolean
+export const isBusPatchPath = R.either(isFromBusPatchPath, isToBusPatchPath);
 
 // :: LibName -> Boolean
 export const isBuiltInLibName = R.equals(TERMINALS_LIB_NAME);

--- a/packages/xod-project/src/node.js
+++ b/packages/xod-project/src/node.js
@@ -85,6 +85,18 @@ export const getNodeId = def(
 );
 
 /**
+ * Only for using in `xod-project`
+ * @function setNodeId
+ * @param {NodeId} nodeId
+ * @param {Node} node
+ * @returns {Node}
+ */
+export const setNodeId = def(
+  'setNodeId :: NodeId -> Node -> Node',
+  R.assoc('id')
+);
+
+/**
  * @function getNodeType
  * @param {Node} node
  * @returns {string}

--- a/packages/xod-project/src/patchPathUtils.js
+++ b/packages/xod-project/src/patchPathUtils.js
@@ -24,6 +24,8 @@ export {
   isValidPatchPath,
   isTerminalPatchPath,
   isWatchPatchPath,
+  isFromBusPatchPath,
+  isToBusPatchPath,
   isBusPatchPath,
   isJumperPatchPath,
   isBuiltInLibName,

--- a/packages/xod-project/test/fixtures/traversing.xodball
+++ b/packages/xod-project/test/fixtures/traversing.xodball
@@ -1,0 +1,800 @@
+{
+  "name": "",
+  "patches": {
+    "@/basic": {
+      "links": {
+        "r1Od4qH6V": {
+          "id": "r1Od4qH6V",
+          "input": {
+            "nodeId": "bottomNode",
+            "pinKey": "startPin"
+          },
+          "output": {
+            "nodeId": "topNode",
+            "pinKey": "endPin"
+          }
+        }
+      },
+      "nodes": {
+        "bottomNode": {
+          "id": "bottomNode",
+          "position": {
+            "x": 3,
+            "y": 2,
+            "units": "slots"
+          },
+          "type": "@/bottom"
+        },
+        "topNode": {
+          "id": "topNode",
+          "position": {
+            "x": 3,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "@/top"
+        }
+      },
+      "path": "@/basic"
+    },
+    "@/bottom": {
+      "attachments": [
+        {
+          "content": "\nstruct State {\n};\n\n{{ GENERATED_CODE }}\n\nvoid evaluate(Context ctx) {\n    //auto inValue = getValue<input_IN>(ctx);\n    //emitValue<output_OUT>(ctx, inValue);\n}\n",
+          "encoding": "utf-8",
+          "filename": "patch.cpp"
+        }
+      ],
+      "nodes": {
+        "ByFIITraN": {
+          "id": "ByFIITraN",
+          "position": {
+            "x": 4,
+            "y": 0,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/utility"
+        },
+        "SJuipNKTN": {
+          "id": "SJuipNKTN",
+          "position": {
+            "x": 2,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/not-implemented-in-xod"
+        },
+        "startPin": {
+          "id": "startPin",
+          "label": "START",
+          "position": {
+            "x": 2,
+            "y": 0,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/input-number"
+        }
+      },
+      "path": "@/bottom"
+    },
+    "@/buses": {
+      "links": {
+        "BJT-9FHT4": {
+          "id": "BJT-9FHT4",
+          "input": {
+            "nodeId": "ry9lcYSp4",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "HkIZ5traN",
+            "pinKey": "__out__"
+          }
+        },
+        "Bk7OAKSa4": {
+          "id": "Bk7OAKSa4",
+          "input": {
+            "nodeId": "BJfxcYHTV",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "topNode",
+            "pinKey": "endPin"
+          }
+        },
+        "SkXWqtBT4": {
+          "id": "SkXWqtBT4",
+          "input": {
+            "nodeId": "S14l5KBpN",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "S11bqYH64",
+            "pinKey": "__out__"
+          }
+        },
+        "ryB_0YBpV": {
+          "id": "ryB_0YBpV",
+          "input": {
+            "nodeId": "bottomNode",
+            "pinKey": "startPin"
+          },
+          "output": {
+            "nodeId": "S1vbqYB6N",
+            "pinKey": "__out__"
+          }
+        }
+      },
+      "nodes": {
+        "BJfxcYHTV": {
+          "id": "BJfxcYHTV",
+          "label": "3",
+          "position": {
+            "x": 1,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/to-bus"
+        },
+        "HkIZ5traN": {
+          "id": "HkIZ5traN",
+          "label": "2",
+          "position": {
+            "x": 4,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/from-bus"
+        },
+        "S11bqYH64": {
+          "id": "S11bqYH64",
+          "label": "3",
+          "position": {
+            "x": 2,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/from-bus"
+        },
+        "S14l5KBpN": {
+          "id": "S14l5KBpN",
+          "label": "2",
+          "position": {
+            "x": 2,
+            "y": 2,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/to-bus"
+        },
+        "S1vbqYB6N": {
+          "id": "S1vbqYB6N",
+          "label": "1",
+          "position": {
+            "x": 1,
+            "y": 2,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/from-bus"
+        },
+        "bottomNode": {
+          "id": "bottomNode",
+          "position": {
+            "x": 1,
+            "y": 3,
+            "units": "slots"
+          },
+          "type": "@/bottom"
+        },
+        "ry9lcYSp4": {
+          "id": "ry9lcYSp4",
+          "label": "1",
+          "position": {
+            "x": 4,
+            "y": 2,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/to-bus"
+        },
+        "topNode": {
+          "id": "topNode",
+          "position": {
+            "x": 1,
+            "y": 0,
+            "units": "slots"
+          },
+          "type": "@/top"
+        }
+      },
+      "path": "@/buses"
+    },
+    "@/buses-and-jumpers": {
+      "links": {
+        "BJyVctHT4": {
+          "id": "BJyVctHT4",
+          "input": {
+            "nodeId": "BJA7cKBaN",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "ByBSQ9YHa4",
+            "pinKey": "__out__"
+          }
+        },
+        "BkyScKSTE": {
+          "id": "BkyScKSTE",
+          "input": {
+            "nodeId": "SJcNcFBT4",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "SJLrm9KB6V",
+            "pinKey": "__out__"
+          }
+        },
+        "Sk9PAFS6E": {
+          "id": "Sk9PAFS6E",
+          "input": {
+            "nodeId": "bottomNode",
+            "pinKey": "startPin"
+          },
+          "output": {
+            "nodeId": "SJcNcFBT4",
+            "pinKey": "__out__"
+          }
+        },
+        "rJBE5FS64": {
+          "id": "rJBE5FS64",
+          "input": {
+            "nodeId": "SyXV5FHp4",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "BJA7cKBaN",
+            "pinKey": "__out__"
+          }
+        },
+        "rkvDCFSTV": {
+          "id": "rkvDCFSTV",
+          "input": {
+            "nodeId": "H1WrQ5FBpE",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "topNode",
+            "pinKey": "endPin"
+          }
+        },
+        "rkwHQcFrTN": {
+          "id": "rkwHQcFrTN",
+          "input": {
+            "nodeId": "H1GS79FB6N",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "ByNrQcFSaV",
+            "pinKey": "__out__"
+          }
+        },
+        "ryI45KBp4": {
+          "id": "ryI45KBp4",
+          "input": {
+            "nodeId": "rkXSQqtSp4",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "SyXV5FHp4",
+            "pinKey": "__out__"
+          }
+        }
+      },
+      "nodes": {
+        "BJA7cKBaN": {
+          "id": "BJA7cKBaN",
+          "position": {
+            "x": 3,
+            "y": 2,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/jumper"
+        },
+        "ByBSQ9YHa4": {
+          "id": "ByBSQ9YHa4",
+          "label": "2",
+          "position": {
+            "x": 3,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/from-bus"
+        },
+        "ByNrQcFSaV": {
+          "id": "ByNrQcFSaV",
+          "label": "3",
+          "position": {
+            "x": 1,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/from-bus"
+        },
+        "H1GS79FB6N": {
+          "id": "H1GS79FB6N",
+          "label": "2",
+          "position": {
+            "x": 1,
+            "y": 2,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/to-bus"
+        },
+        "H1WrQ5FBpE": {
+          "id": "H1WrQ5FBpE",
+          "label": "3",
+          "position": {
+            "x": 0,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/to-bus"
+        },
+        "SJLrm9KB6V": {
+          "id": "SJLrm9KB6V",
+          "label": "1",
+          "position": {
+            "x": 0,
+            "y": 2,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/from-bus"
+        },
+        "SJcNcFBT4": {
+          "id": "SJcNcFBT4",
+          "position": {
+            "x": 0,
+            "y": 3,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/jumper"
+        },
+        "SyXV5FHp4": {
+          "id": "SyXV5FHp4",
+          "position": {
+            "x": 5,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/jumper"
+        },
+        "bottomNode": {
+          "id": "bottomNode",
+          "position": {
+            "x": 0,
+            "y": 4,
+            "units": "slots"
+          },
+          "type": "@/bottom"
+        },
+        "rkXSQqtSp4": {
+          "id": "rkXSQqtSp4",
+          "label": "1",
+          "position": {
+            "x": 5,
+            "y": 2,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/to-bus"
+        },
+        "topNode": {
+          "id": "topNode",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "units": "slots"
+          },
+          "type": "@/top"
+        }
+      },
+      "path": "@/buses-and-jumpers"
+    },
+    "@/identity-pin": {
+      "links": {
+        "H1LarprTN": {
+          "id": "H1LarprTN",
+          "input": {
+            "nodeId": "nullNode",
+            "pinKey": "nullNodeInputPin"
+          },
+          "output": {
+            "nodeId": "inputNullPin",
+            "pinKey": "__out__"
+          }
+        },
+        "H1nw5Kr6V": {
+          "id": "H1nw5Kr6V",
+          "input": {
+            "nodeId": "identityPin",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "HJjD9YS6V",
+            "pinKey": "__out__"
+          }
+        },
+        "SJ0P9tr6E": {
+          "id": "SJ0P9tr6E",
+          "input": {
+            "nodeId": "HJjD9YS6V",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "inputNullPin",
+            "pinKey": "__out__"
+          }
+        },
+        "rkwar6Bp4": {
+          "id": "rkwar6Bp4",
+          "input": {
+            "nodeId": "outputNullPin",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "nullNode",
+            "pinKey": "nullNodeOutputPin"
+          }
+        }
+      },
+      "nodes": {
+        "HJjD9YS6V": {
+          "id": "HJjD9YS6V",
+          "position": {
+            "x": 3,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/jumper"
+        },
+        "nullNode": {
+          "id": "nullNode",
+          "position": {
+            "x": 1,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "@/null"
+        },
+        "SkBsrTHTE": {
+          "id": "SkBsrTHTE",
+          "position": {
+            "x": 5,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/utility"
+        },
+        "identityPin": {
+          "id": "identityPin",
+          "label": "IDNT",
+          "position": {
+            "x": 3,
+            "y": 2,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/output-number"
+        },
+        "inputNullPin": {
+          "id": "inputNullPin",
+          "label": "NULL",
+          "position": {
+            "x": 1,
+            "y": 0,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/input-number"
+        },
+        "outputNullPin": {
+          "id": "outputNullPin",
+          "position": {
+            "x": 1,
+            "y": 2,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/output-number"
+        }
+      },
+      "path": "@/identity-pin"
+    },
+    "@/jumpers": {
+      "links": {
+        "HyB6FFHTN": {
+          "id": "HyB6FFHTN",
+          "input": {
+            "nodeId": "rJanFtr64",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "H1s3KtHp4",
+            "pinKey": "__out__"
+          }
+        },
+        "r1E6YKBT4": {
+          "id": "r1E6YKBT4",
+          "input": {
+            "nodeId": "r1C3KFB6V",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "rJanFtr64",
+            "pinKey": "__out__"
+          }
+        },
+        "rkgY0tr6V": {
+          "id": "rkgY0tr6V",
+          "input": {
+            "nodeId": "bottomNode",
+            "pinKey": "startPin"
+          },
+          "output": {
+            "nodeId": "r1C3KFB6V",
+            "pinKey": "__out__"
+          }
+        },
+        "ryUpFFHpE": {
+          "id": "ryUpFFHpE",
+          "input": {
+            "nodeId": "H1s3KtHp4",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "Hy9nKYB6V",
+            "pinKey": "__out__"
+          }
+        },
+        "rypOCKraE": {
+          "id": "rypOCKraE",
+          "input": {
+            "nodeId": "Hy9nKYB6V",
+            "pinKey": "__in__"
+          },
+          "output": {
+            "nodeId": "topNode",
+            "pinKey": "endPin"
+          }
+        }
+      },
+      "nodes": {
+        "H1s3KtHp4": {
+          "id": "H1s3KtHp4",
+          "position": {
+            "x": -4,
+            "y": 0,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/jumper"
+        },
+        "Hy9nKYB6V": {
+          "id": "Hy9nKYB6V",
+          "position": {
+            "x": -5,
+            "y": 0,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/jumper"
+        },
+        "bottomNode": {
+          "id": "bottomNode",
+          "position": {
+            "x": -2,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "@/bottom"
+        },
+        "r1C3KFB6V": {
+          "id": "r1C3KFB6V",
+          "position": {
+            "x": -2,
+            "y": 0,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/jumper"
+        },
+        "rJanFtr64": {
+          "id": "rJanFtr64",
+          "position": {
+            "x": -3,
+            "y": 0,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/jumper"
+        },
+        "topNode": {
+          "id": "topNode",
+          "position": {
+            "x": -5,
+            "y": -1,
+            "units": "slots"
+          },
+          "type": "@/top"
+        }
+      },
+      "path": "@/jumpers"
+    },
+    "@/no-links": {
+      "nodes": {
+        "bottomNode": {
+          "id": "bottomNode",
+          "position": {
+            "x": 0,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "@/bottom"
+        }
+      },
+      "path": "@/no-links"
+    },
+    "@/null": {
+      "attachments": [
+        {
+          "content": "\nstruct State {\n};\n\n{{ GENERATED_CODE }}\n\nvoid evaluate(Context ctx) {\n}\n",
+          "encoding": "utf-8",
+          "filename": "patch.cpp"
+        }
+      ],
+      "nodes": {
+        "H1doVTS6E": {
+          "id": "H1doVTS6E",
+          "position": {
+            "x": 0,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/not-implemented-in-xod"
+        },
+        "nullNodeOutputPin": {
+          "id": "nullNodeOutputPin",
+          "position": {
+            "x": 0,
+            "y": 2,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/output-number"
+        },
+        "r1sqrarpE": {
+          "id": "r1sqrarpE",
+          "position": {
+            "x": 2,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/utility"
+        },
+        "nullNodeInputPin": {
+          "id": "nullNodeInputPin",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/input-number"
+        }
+      },
+      "path": "@/null"
+    },
+    "@/top": {
+      "attachments": [
+        {
+          "content": "\nstruct State {\n};\n\n{{ GENERATED_CODE }}\n\nvoid evaluate(Context ctx) {\n    //auto inValue = getValue<input_IN>(ctx);\n    //emitValue<output_OUT>(ctx, inValue);\n}\n",
+          "encoding": "utf-8",
+          "filename": "patch.cpp"
+        }
+      ],
+      "nodes": {
+        "Hkoj64YaE": {
+          "id": "Hkoj64YaE",
+          "position": {
+            "x": 1,
+            "y": 3,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/not-implemented-in-xod"
+        },
+        "endPin": {
+          "id": "endPin",
+          "label": "END",
+          "position": {
+            "x": 1,
+            "y": 2,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/output-number"
+        },
+        "r1xyPL6Ba4": {
+          "id": "r1xyPL6Ba4",
+          "position": {
+            "x": 3,
+            "y": 2,
+            "units": "slots"
+          },
+          "type": "xod/patch-nodes/utility"
+        }
+      },
+      "path": "@/top"
+    },
+    "@/with-identity-pin": {
+      "links": {
+        "By0X0FHTV": {
+          "id": "By0X0FHTV",
+          "input": {
+            "nodeId": "bottomNodeToIdentity",
+            "pinKey": "startPin"
+          },
+          "output": {
+            "nodeId": "nodeWithIdentityPin",
+            "pinKey": "identityPin"
+          }
+        },
+        "S1Q4AYrpE": {
+          "id": "S1Q4AYrpE",
+          "input": {
+            "nodeId": "bottomNodeToNull",
+            "pinKey": "startPin"
+          },
+          "output": {
+            "nodeId": "nodeWithIdentityPin",
+            "pinKey": "outputNullPin"
+          }
+        },
+        "rywMAtH6N": {
+          "id": "rywMAtH6N",
+          "input": {
+            "nodeId": "nodeWithIdentityPin",
+            "pinKey": "inputNullPin"
+          },
+          "output": {
+            "nodeId": "topNode",
+            "pinKey": "endPin"
+          }
+        }
+      },
+      "nodes": {
+        "nodeWithIdentityPin": {
+          "id": "nodeWithIdentityPin",
+          "position": {
+            "x": 2,
+            "y": 1,
+            "units": "slots"
+          },
+          "type": "@/identity-pin"
+        },
+        "topNode": {
+          "id": "topNode",
+          "position": {
+            "x": 2,
+            "y": 0,
+            "units": "slots"
+          },
+          "type": "@/top"
+        },
+        "bottomNodeToIdentity": {
+          "id": "bottomNodeToIdentity",
+          "position": {
+            "x": 3,
+            "y": 2,
+            "units": "slots"
+          },
+          "type": "@/bottom"
+        },
+        "bottomNodeToNull": {
+          "id": "bottomNodeToNull",
+          "position": {
+            "x": 1,
+            "y": 2,
+            "units": "slots"
+          },
+          "type": "@/bottom"
+        }
+      },
+      "path": "@/with-identity-pin"
+    }
+  }
+}

--- a/packages/xod-project/test/traversing.spec.js
+++ b/packages/xod-project/test/traversing.spec.js
@@ -1,0 +1,109 @@
+import * as R from 'ramda';
+import { assert } from 'chai';
+
+import * as H from './helpers';
+import * as XP from '../src';
+import { setNodeId } from '../src/node';
+
+describe('traversing', () => {
+  const project = H.loadXodball('./fixtures/traversing.xodball');
+  const bottomPatch = XP.getPatchByPathUnsafe('@/bottom', project);
+  const startPin = XP.getPinByKeyUnsafe('startPin', bottomPatch);
+  const topPatch = XP.getPatchByPathUnsafe('@/top', project);
+  const endPin = XP.getPinByKeyUnsafe('endPin', topPatch);
+
+  describe('listUpstreamPinsToNiix', () => {
+    it('traverse from input pin without upstream link returns the same pin pair list', () => {
+      const patch = XP.getPatchByPathUnsafe('@/no-links', project);
+      const startNode = XP.getNodeByIdUnsafe('bottomNode', patch);
+      const inputPinPair = [startPin, startNode];
+
+      const res = XP.listUpstreamPinsToNiix([inputPinPair], patch, project);
+      assert.sameDeepOrderedMembers(res, [inputPinPair]);
+    });
+    it('traverse to closest NIIX node', () => {
+      const patch = XP.getPatchByPathUnsafe('@/basic', project);
+      const startNode = XP.getNodeByIdUnsafe('bottomNode', patch);
+      const endNode = XP.getNodeByIdUnsafe('topNode', patch);
+      const inputPinPair = [startPin, startNode];
+
+      const res = XP.listUpstreamPinsToNiix([inputPinPair], patch, project);
+      assert.sameDeepOrderedMembers(res, [[endPin, endNode], inputPinPair]);
+    });
+    it('traverse through jumpers', () => {
+      const patch = XP.getPatchByPathUnsafe('@/jumpers', project);
+      const startNode = XP.getNodeByIdUnsafe('bottomNode', patch);
+      const inputPinPair = [startPin, startNode];
+
+      const endNode = XP.getNodeByIdUnsafe('topNode', patch);
+
+      const res = XP.listUpstreamPinsToNiix([inputPinPair], patch, project);
+      assert.lengthOf(res, 18);
+      assert.sameDeepOrderedMembers(res[0], [endPin, endNode]);
+      assert.sameDeepOrderedMembers(res[17], inputPinPair);
+    });
+    it('traverse through buses', () => {
+      const patch = XP.getPatchByPathUnsafe('@/buses', project);
+      const startNode = XP.getNodeByIdUnsafe('bottomNode', patch);
+      const inputPinPair = [startPin, startNode];
+
+      const endNode = XP.getNodeByIdUnsafe('topNode', patch);
+
+      const res = XP.listUpstreamPinsToNiix([inputPinPair], patch, project);
+      assert.lengthOf(res, 8);
+      assert.sameDeepOrderedMembers(res[0], [endPin, endNode]);
+      assert.sameDeepOrderedMembers(res[7], inputPinPair);
+    });
+    it('traverse through buses mixed with jumpers', () => {
+      const patch = XP.getPatchByPathUnsafe('@/buses-and-jumpers', project);
+      const startNode = XP.getNodeByIdUnsafe('bottomNode', patch);
+      const inputPinPair = [startPin, startNode];
+
+      const endNode = XP.getNodeByIdUnsafe('topNode', patch);
+
+      const res = XP.listUpstreamPinsToNiix([inputPinPair], patch, project);
+      assert.lengthOf(res, 20);
+      assert.sameDeepOrderedMembers(res[0], [endPin, endNode]);
+      assert.sameDeepOrderedMembers(res[19], inputPinPair);
+    });
+    it('traverse through node (identity)', () => {
+      const patch = XP.getPatchByPathUnsafe('@/with-identity-pin', project);
+      const startNode = XP.getNodeByIdUnsafe('bottomNodeToIdentity', patch);
+      const inputPinPair = [startPin, startNode];
+
+      const endNode = XP.getNodeByIdUnsafe('topNode', patch);
+
+      const res = XP.listUpstreamPinsToNiix([inputPinPair], patch, project);
+      assert.lengthOf(res, 10);
+      assert.sameDeepOrderedMembers(res[0], [endPin, endNode]);
+      assert.sameDeepOrderedMembers(res[9], inputPinPair);
+      // List contains pairs inside the `@/identity-pin` node
+      // So let's check that patched node ids correctly
+      assert.equal(XP.getNodeId(res[3][1]), 'nodeWithIdentityPin~HJjD9YS6V');
+      assert.equal(
+        XP.getNodeId(res[5][1]),
+        'nodeWithIdentityPin~HJjD9YS6V~__out__'
+      );
+    });
+    it('traverse to the NIIX node (inside another node)', () => {
+      const patch = XP.getPatchByPathUnsafe('@/with-identity-pin', project);
+      const startNode = XP.getNodeByIdUnsafe('bottomNodeToNull', patch);
+      const inputPinPair = [startPin, startNode];
+
+      const nullPatch = XP.getPatchByPathUnsafe('@/null', project);
+      const nullPin = XP.getPinByKeyUnsafe('nullNodeOutputPin', nullPatch);
+      const identityPatch = XP.getPatchByPathUnsafe('@/identity-pin', project);
+      // Because we're setting parent node ids into NodeId
+      // we have to change it in the test case
+      const nullNode = R.compose(
+        setNodeId('nodeWithIdentityPin~nullNode'),
+        XP.getNodeByIdUnsafe('nullNode')
+      )(identityPatch);
+
+      const res = XP.listUpstreamPinsToNiix([inputPinPair], patch, project);
+      assert.lengthOf(res, 4);
+      assert.sameDeepOrderedMembers(res[0], [nullPin, nullNode]);
+      assert.sameDeepOrderedMembers(res[3], inputPinPair);
+    });
+  });
+});


### PR DESCRIPTION
It closes #1773 

Here is my example project to test all possible cases (I hope so):
[visualize-errors.xodball.zip](https://github.com/xodio/xod/files/3242103/visualize-errors.xodball.zip)
- `0-test` contains identity nodes, jumpers, buses, nested error raisers and etc
- `1-defers` contains a loop with `defer` node and `if-error` catcher

