### PR TITLE
Allow Errcode values up to 255

### DIFF
--- a/packages/xod-client/src/utils/normalizeErrcode.js
+++ b/packages/xod-client/src/utils/normalizeErrcode.js
@@ -5,7 +5,7 @@ export default R.pipe(
   R.when(R.test(/^[eE].*/g), R.tail),
   x => parseInt(x, 10),
   R.defaultTo(0),
-  R.min(127),
+  R.min(255),
   R.max(0),
   n => `E${n}`
 );

--- a/packages/xod-client/test/normalizeErrcode.spec.js
+++ b/packages/xod-client/test/normalizeErrcode.spec.js
@@ -23,7 +23,7 @@ describe('normalizeErrcode', () => {
   });
 
   describe('ensure boundaries', () => {
-    test('E128', 'E127');
+    test('E256', 'E255');
     test('E-1', 'E0');
   });
 
@@ -31,5 +31,6 @@ describe('normalizeErrcode', () => {
     test('E0', 'E0');
     test('E42', 'E42');
     test('E127', 'E127');
+    test('E255', 'E255');
   });
 });

--- a/packages/xod-project/src/utils.js
+++ b/packages/xod-project/src/utils.js
@@ -200,7 +200,7 @@ export const isValidErrcodeLiteral = def(
     R.test(/^E\d{1,3}$/g),
     R.pipe(R.tail, n => {
       const parsed = parseInt(n, 10);
-      const isInBounds = parsed >= 0 && parsed <= 127;
+      const isInBounds = parsed >= 0 && parsed <= 255;
       return parsed.toString(10) === n && isInBounds;
     })
   )

--- a/packages/xod-project/test/utils.spec.js
+++ b/packages/xod-project/test/utils.spec.js
@@ -125,13 +125,13 @@ describe('Utils', () => {
       assertIsValid('E8');
       assertIsValid('E10');
       assertIsValid('E100');
-      assertIsValid('E127');
+      assertIsValid('E255');
     });
 
     it('should treat out of range error codes as invalid', () => {
       assertIsInvalid('E-1');
       assertIsInvalid('E-10');
-      assertIsInvalid('E128');
+      assertIsInvalid('E256');
       assertIsInvalid('E567');
       assertIsInvalid('E1227');
     });
@@ -214,6 +214,7 @@ describe('Utils', () => {
       expectType('E0', PIN_TYPE.ERRCODE);
       expectType('E42', PIN_TYPE.ERRCODE);
       expectType('E127', PIN_TYPE.ERRCODE);
+      expectType('E255', PIN_TYPE.ERRCODE);
     });
   });
 });


### PR DESCRIPTION
They were limited to 127 before because the last was intended to be used as a flag. This is no longer true, so we can use all 8 bits to store the errcode.
