### PR TITLE
Exclude the whole bs-platform from bundling into electron app

### DIFF
--- a/packages/xod-arduino/package.json
+++ b/packages/xod-arduino/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@glennsl/bs-revamp": "^0.1.1",
     "belt-holes": "^0.29.0",
-    "bs-platform": "5.0.0",
     "handlebars": "^4.0.6",
     "hm-def": "^0.3.2",
     "ramda": "^0.24.1",
@@ -33,6 +32,7 @@
   },
   "devDependencies": {
     "babel-plugin-inline-import": "^2.0.4",
+    "bs-platform": "5.0.0",
     "chai": "^4.1.2",
     "onchange": "^5.2.0",
     "xod-fs": "^0.29.0"

--- a/packages/xod-client-electron/package.json
+++ b/packages/xod-client-electron/package.json
@@ -70,6 +70,8 @@
     "buildDependenciesFromSource": true,
     "files": [
       "**/*",
+      "!**/node_modules/xod-arduino/**/*",
+      "**/node_modules/xod-arduino/dist/**/*",
       "!**/node_modules/bs-platform/**/*",
       "**/node_modules/bs-platform/lib/js/**/*"
     ],

--- a/packages/xod-client-electron/package.json
+++ b/packages/xod-client-electron/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.16.0",
+    "bs-platform": "5.0.0",
     "classnames": "^2.2.5",
     "cpx": "^1.5.0",
     "electron-context-menu": "^0.12.1",
@@ -67,6 +68,11 @@
     "appId": "io.xod.ide",
     "productName": "XOD IDE",
     "buildDependenciesFromSource": true,
+    "files": [
+      "**/*",
+      "!**/node_modules/bs-platform/**/*",
+      "**/node_modules/bs-platform/lib/js/**/*"
+    ],
     "extraResources": [
       {
         "from": "arduino-cli",


### PR DESCRIPTION
It fixes #1803.

It reduces the file size:
- MacOS App: 365.4MB -> 237MB
- .dmg: 123.5MB -> 87.9MB
- Windows Installer: 95.8MB -> 61.2MB
- Linux rpm: 69.1MB -> 56.4MB
- Linux deb: 72.5MB -> 56.2MB

In average excluding of `bs-platform` and excessive `xod-arduino` files reduces size for 32% 😎 