### PR TITLE
Make servo pulse limits match Arduino defaults

### DIFF
--- a/workspace/__lib__/xod-dev/servo/servo-device/patch.xodp
+++ b/workspace/__lib__/xod-dev/servo/servo-device/patch.xodp
@@ -3,7 +3,7 @@
   "nodes": [
     {
       "boundLiterals": {
-        "__out__": "750"
+        "__out__": "544"
       },
       "description": "The minimal rated pulse width (in µS) ",
       "id": "ByJ9IwVBV",
@@ -17,7 +17,7 @@
     },
     {
       "boundLiterals": {
-        "__out__": "2250"
+        "__out__": "2400"
       },
       "description": "The maximal rated pulse width (in µS) ",
       "id": "H15qLDVSE",


### PR DESCRIPTION
To follow a path of the least surprise I’ve changed the default servo pulse width limits to be exactly as in the Arduino Servo library. There’s no standard which clearly defines the pulse limits for hobby servos, so both variants are magic. But the 544/2400 magic matches the magic for people coming from Arduino IDE and supports servos capable to do a 180° turn.