### PR TITLE
Add C++ API to raise errors separately for each output

### DIFF
--- a/packages/xod-arduino/platform/patchContext.tpl.cpp
+++ b/packages/xod-arduino/platform/patchContext.tpl.cpp
@@ -4,10 +4,7 @@
 struct Node {
     State state;
   {{#if raisesErrors}}
-    uint8_t ownError;
-  {{/if}}
-  {{#if catchesErrors}}
-    uint8_t prevCaughtError;
+    bool hasOwnError;
   {{/if}}
   {{#if usesTimeouts}}
     TimeMs timeoutAt;
@@ -121,6 +118,24 @@ uint16_t getNodeId(Context ctx) {
     return ctx->_nodeId;
 }
 {{/if}}
+
+
+{{#if raisesErrors}}
+void raiseError(Context ctx) {
+    ctx->_node->hasOwnError = true;
+
+    {{#each outputs}}
+    {{#if isDirtyable}}
+    ctx->_node->isOutputDirty_{{ pinKey }} = true;
+    {{/if}}
+    {{/each}}
+
+#if defined(XOD_DEBUG) || defined(XOD_SIMULATION)
+    detail::printErrorToDebugSerial(ctx->_nodeId, 1);
+#endif
+}
+{{/if}}
+
 
 {{#if catchesErrors}}
 

--- a/packages/xod-arduino/platform/runtime.cpp
+++ b/packages/xod-arduino/platform/runtime.cpp
@@ -156,15 +156,6 @@ bool isValidAnalogPort(uint8_t port) {
 #endif
 }
 
-template<typename ContextT>
-void raiseError(ContextT* ctx) {
-    ctx->_node->ownError = 1;
-
-#if defined(XOD_DEBUG) || defined(XOD_SIMULATION)
-    detail::printErrorToDebugSerial(ctx->_nodeId, 1);
-#endif
-}
-
 } // namespace xod
 
 //----------------------------------------------------------------------------

--- a/packages/xod-arduino/platform/runtime.cpp
+++ b/packages/xod-arduino/platform/runtime.cpp
@@ -98,18 +98,18 @@ void clearStaleTimeout(NodeT* node) {
         clearTimeout(node);
 }
 
+void printErrorToDebugSerial(uint16_t nodeId, uint8_t errorFlags) {
 #if defined(XOD_DEBUG) || defined(XOD_SIMULATION)
-void printErrorToDebugSerial(uint16_t nodeId, uint8_t errCode) {
     XOD_DEBUG_SERIAL.print(F("+XOD_ERR:"));
     XOD_DEBUG_SERIAL.print(g_transactionTime);
     XOD_DEBUG_SERIAL.print(':');
     XOD_DEBUG_SERIAL.print(nodeId);
     XOD_DEBUG_SERIAL.print(':');
-    XOD_DEBUG_SERIAL.print((int)errCode);
+    XOD_DEBUG_SERIAL.print(errorFlags, DEC);
     XOD_DEBUG_SERIAL.print('\r');
     XOD_DEBUG_SERIAL.print('\n');
-}
 #endif
+}
 
 } // namespace detail
 

--- a/packages/xod-arduino/platform/types.h
+++ b/packages/xod-arduino/platform/types.h
@@ -14,4 +14,5 @@ typedef double Number;
 typedef bool Logic;
 typedef unsigned long TimeMs;
 typedef uint8_t DirtyFlags;
+typedef uint8_t ErrorFlags;
 } // namespace xod

--- a/packages/xod-arduino/src/templates.js
+++ b/packages/xod-arduino/src/templates.js
@@ -276,6 +276,10 @@ registerHandlebarsFilterLoopHelper(
   'eachInputPinWithUpstreamRaisers',
   R.pathOr(0, ['upstreamErrorRaisers', 'length'])
 );
+registerHandlebarsFilterLoopHelper(
+  'eachPulseOutput',
+  R.propEq('type', XP.PIN_TYPE.PULSE)
+);
 
 // =============================================================================
 //

--- a/packages/xod-arduino/src/transpiler.js
+++ b/packages/xod-arduino/src/transpiler.js
@@ -397,10 +397,17 @@ const calculateUpstreamErrorRaisers = R.compose(
   R.reduce((accTNodesMap, tNode) => {
     const inputsWithCalculatedUpstreamErrorRaisers = R.map(tNodeInput => {
       const upstreamRaisersForPin = R.compose(
-        R.reject(R.equals(tNode.id)), // could happen with defers
+        R.reject(R.propEq('nodeId', tNode.id)), // could happen with defers
         foldMaybe([], upstreamTNode =>
           R.concat(
-            upstreamTNode.patch.raisesErrors ? [upstreamTNode.id] : [],
+            upstreamTNode.patch.raisesErrors
+              ? [
+                  {
+                    nodeId: upstreamTNode.id,
+                    pinKey: tNodeInput.fromPinKey,
+                  },
+                ]
+              : [],
             upstreamTNode.patch.catchesErrors
               ? []
               : upstreamTNode.upstreamErrorRaisers

--- a/packages/xod-arduino/src/types.js
+++ b/packages/xod-arduino/src/types.js
@@ -86,11 +86,16 @@ const TNodeInput = Model('TNodeInput', {
   fromPinKey: TPinKey,
 });
 
+const UpstreamErrorRaiser = Model('UpstreamErrorRaiser', {
+  nodeId: TNodeId,
+  pinKey: TPinKey,
+});
+
 export const TNode = Model('TNode', {
   id: TNodeId,
   originalId: NodeId,
   patch: TPatch,
-  upstreamErrorRaisers: $.Array(TNodeId),
+  upstreamErrorRaisers: $.Array(UpstreamErrorRaiser),
   outputs: $.Array(TNodeOutput),
   inputs: $.Array(TNodeInput),
 });

--- a/packages/xod-tabtest/src/Tabtest.re
+++ b/packages/xod-tabtest/src/Tabtest.re
@@ -226,14 +226,20 @@ module TestCase = {
       |. Probes.map(probe => {
            let name = probe |. Probe.getTargetPin |. Pin.getLabel;
            switch (record |. Map.String.get(name)) {
-           | Some(NaN) => Cpp.requireIsNan({j|probe_$name.state.lastValue|j})
+           | Some(NaN) => Cpp.source([
+             Cpp.requireIsNan({j|probe_$name.state.lastValue|j}),
+             Cpp.requireEqual({j|probe_$name.state.hadError|j}, "false")
+           ])
            | Some(RaisedError) =>
             Cpp.requireEqual({j|probe_$name.state.hadError|j}, "true")
            | Some(value) =>
+            Cpp.source([
              Cpp.requireEqual(
                {j|probe_$name.state.lastValue|j},
                valueToLiteral(value),
-             )
+             ),
+             Cpp.requireEqual({j|probe_$name.state.hadError|j}, "false")
+            ])
            | None => {j|// no expectation for $name|j}
            };
          });

--- a/packages/xod-tabtest/src/Tabtest.re
+++ b/packages/xod-tabtest/src/Tabtest.re
@@ -228,7 +228,7 @@ module TestCase = {
            switch (record |. Map.String.get(name)) {
            | Some(NaN) => Cpp.requireIsNan({j|probe_$name.state.lastValue|j})
            | Some(RaisedError) =>
-            Cpp.requireEqual({j|probe_$name.prevCaughtError|j}, "1")
+            Cpp.requireEqual({j|probe_$name.state.hadError|j}, "true")
            | Some(value) =>
              Cpp.requireEqual(
                {j|probe_$name.state.lastValue|j},
@@ -287,11 +287,12 @@ module TestCase = {
         "",
         "#define INJECT(probe, value) \\",
         "        (probe).output_VAL = (value); \\",
-        "        (probe).ownError = 0; \\",
+        "        (probe).state.shouldRaise = false; \\",
         "        (probe).isNodeDirty = true;",
         "",
         "#define INJECT_ERROR(probe) \\",
-        "        (probe).ownError = 1;",
+        "        (probe).state.shouldRaise = true;\\",
+        "        (probe).isNodeDirty = true;",
         "",
         catch2TestCase(name, [source(sections)]),
       ])

--- a/packages/xod-tabtest/workspace/__lib__/xod/tabtest/capture-boolean/patch.cpp
+++ b/packages/xod-tabtest/workspace/__lib__/xod/tabtest/capture-boolean/patch.cpp
@@ -2,10 +2,13 @@
 
 struct State {
     bool lastValue;
+    bool hadError = false;
 };
 
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-    getState(ctx)->lastValue = getValue<input_VAL>(ctx);
+    auto state = getState(ctx);
+    state->lastValue = getValue<input_VAL>(ctx);
+    state->hadError = getError<input_VAL>(ctx);
 }

--- a/packages/xod-tabtest/workspace/__lib__/xod/tabtest/capture-byte/patch.cpp
+++ b/packages/xod-tabtest/workspace/__lib__/xod/tabtest/capture-byte/patch.cpp
@@ -2,10 +2,13 @@
 
 struct State {
     uint8_t lastValue;
+    bool hadError = false;
 };
 
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-    getState(ctx)->lastValue = getValue<input_VAL>(ctx);
+    auto state = getState(ctx);
+    state->lastValue = getValue<input_VAL>(ctx);
+    state->hadError = getError<input_VAL>(ctx);
 }

--- a/packages/xod-tabtest/workspace/__lib__/xod/tabtest/capture-number/patch.cpp
+++ b/packages/xod-tabtest/workspace/__lib__/xod/tabtest/capture-number/patch.cpp
@@ -2,10 +2,13 @@
 
 struct State {
     Number lastValue;
+    bool hadError = false;
 };
 
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-    getState(ctx)->lastValue = getValue<input_VAL>(ctx);
+    auto state = getState(ctx);
+    state->lastValue = getValue<input_VAL>(ctx);
+    state->hadError = getError<input_VAL>(ctx);
 }

--- a/packages/xod-tabtest/workspace/__lib__/xod/tabtest/capture-pulse/patch.cpp
+++ b/packages/xod-tabtest/workspace/__lib__/xod/tabtest/capture-pulse/patch.cpp
@@ -2,12 +2,15 @@
 
 struct State {
     bool lastValue = false;
+    bool hadError = false;
 };
 
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-    getState(ctx)->lastValue = isInputDirty<input_VAL>(ctx);
+    auto state = getState(ctx);
+    state->lastValue = isInputDirty<input_VAL>(ctx);
+    state->hadError = getError<input_VAL>(ctx);
     // This node should check dirtieness of input port on each transaction
     // so we set timeout 0 to mark this node as dirty on the next transaction
     setTimeout(ctx, 0);

--- a/packages/xod-tabtest/workspace/__lib__/xod/tabtest/capture-string/patch.cpp
+++ b/packages/xod-tabtest/workspace/__lib__/xod/tabtest/capture-string/patch.cpp
@@ -2,10 +2,13 @@
 
 struct State {
     XString lastValue;
+    bool hadError = false;
 };
 
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-    getState(ctx)->lastValue = getValue<input_VAL>(ctx);
+    auto state = getState(ctx);
+    state->lastValue = getValue<input_VAL>(ctx);
+    state->hadError = getError<input_VAL>(ctx);
 }

--- a/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-boolean/patch.cpp
+++ b/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-boolean/patch.cpp
@@ -9,7 +9,7 @@ struct State {
 void evaluate(Context ctx) {
     auto state = getState(ctx);
     if (state->shouldRaise) {
-        raiseError(ctx);
+        raiseError<output_VAL>(ctx);
         state->shouldRaise = false;
     } else {
         emitValue<output_VAL>(ctx, getValue<output_VAL>(ctx));

--- a/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-boolean/patch.cpp
+++ b/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-boolean/patch.cpp
@@ -1,10 +1,17 @@
 #pragma XOD error_raise enable
 
 struct State {
+    bool shouldRaise = false;
 };
 
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-    emitValue<output_VAL>(ctx, getValue<output_VAL>(ctx));
+    auto state = getState(ctx);
+    if (state->shouldRaise) {
+        raiseError(ctx);
+        state->shouldRaise = false;
+    } else {
+        emitValue<output_VAL>(ctx, getValue<output_VAL>(ctx));
+    }
 }

--- a/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-byte/patch.cpp
+++ b/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-byte/patch.cpp
@@ -9,7 +9,7 @@ struct State {
 void evaluate(Context ctx) {
     auto state = getState(ctx);
     if (state->shouldRaise) {
-        raiseError(ctx);
+        raiseError<output_VAL>(ctx);
         state->shouldRaise = false;
     } else {
         emitValue<output_VAL>(ctx, getValue<output_VAL>(ctx));

--- a/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-byte/patch.cpp
+++ b/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-byte/patch.cpp
@@ -1,9 +1,17 @@
 #pragma XOD error_raise enable
 
-struct State {};
+struct State {
+    bool shouldRaise = false;
+};
 
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-    emitValue<output_VAL>(ctx, getValue<output_VAL>(ctx));
+    auto state = getState(ctx);
+    if (state->shouldRaise) {
+        raiseError(ctx);
+        state->shouldRaise = false;
+    } else {
+        emitValue<output_VAL>(ctx, getValue<output_VAL>(ctx));
+    }
 }

--- a/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-number/patch.cpp
+++ b/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-number/patch.cpp
@@ -9,7 +9,7 @@ struct State {
 void evaluate(Context ctx) {
     auto state = getState(ctx);
     if (state->shouldRaise) {
-        raiseError(ctx);
+        raiseError<output_VAL>(ctx);
         state->shouldRaise = false;
     } else {
         emitValue<output_VAL>(ctx, getValue<output_VAL>(ctx));

--- a/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-number/patch.cpp
+++ b/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-number/patch.cpp
@@ -1,9 +1,17 @@
 #pragma XOD error_raise enable
 
-struct State {};
+struct State {
+    bool shouldRaise = false;
+};
 
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-    emitValue<output_VAL>(ctx, getValue<output_VAL>(ctx));
+    auto state = getState(ctx);
+    if (state->shouldRaise) {
+        raiseError(ctx);
+        state->shouldRaise = false;
+    } else {
+        emitValue<output_VAL>(ctx, getValue<output_VAL>(ctx));
+    }
 }

--- a/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-pulse/patch.cpp
+++ b/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-pulse/patch.cpp
@@ -9,7 +9,7 @@ struct State {
 void evaluate(Context ctx) {
     auto state = getState(ctx);
     if (state->shouldRaise) {
-        raiseError(ctx);
+        raiseError<output_VAL>(ctx);
         state->shouldRaise = false;
     } else if (getValue<output_VAL>(ctx)) {
         // Any call of `emitValue` marks output port as dirty

--- a/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-pulse/patch.cpp
+++ b/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-pulse/patch.cpp
@@ -1,11 +1,17 @@
 #pragma XOD error_raise enable
 
-struct State {};
+struct State {
+    bool shouldRaise = false;
+};
 
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-    if (getValue<output_VAL>(ctx)) {
+    auto state = getState(ctx);
+    if (state->shouldRaise) {
+        raiseError(ctx);
+        state->shouldRaise = false;
+    } else if (getValue<output_VAL>(ctx)) {
         // Any call of `emitValue` marks output port as dirty
         // and it means that pulse emited.
         // But the tabtest engine injects `true` or `false` into `output_VAL`

--- a/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-string/patch.cpp
+++ b/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-string/patch.cpp
@@ -9,7 +9,7 @@ struct State {
 void evaluate(Context ctx) {
     auto state = getState(ctx);
     if (state->shouldRaise) {
-        raiseError(ctx);
+        raiseError<output_VAL>(ctx);
         state->shouldRaise = false;
     } else {
         emitValue<output_VAL>(ctx, getValue<output_VAL>(ctx));

--- a/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-string/patch.cpp
+++ b/packages/xod-tabtest/workspace/__lib__/xod/tabtest/inject-string/patch.cpp
@@ -1,9 +1,17 @@
 #pragma XOD error_raise enable
 
-struct State {};
+struct State {
+    bool shouldRaise = false;
+};
 
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-    emitValue<output_VAL>(ctx, getValue<output_VAL>(ctx));
+    auto state = getState(ctx);
+    if (state->shouldRaise) {
+        raiseError(ctx);
+        state->shouldRaise = false;
+    } else {
+        emitValue<output_VAL>(ctx, getValue<output_VAL>(ctx));
+    }
 }

--- a/workspace/__lib__/xod/core/defer(boolean)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(boolean)/patch.cpp
@@ -9,7 +9,7 @@ struct State {
 void evaluate(Context ctx) {
     auto err = getError<input_IN>(ctx);
     if (err) {
-        raiseError(ctx);
+        raiseError<output_OUT>(ctx);
         setTimeout(ctx, 0);
     } else {
         if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated

--- a/workspace/__lib__/xod/core/defer(boolean)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(boolean)/patch.cpp
@@ -10,6 +10,7 @@ void evaluate(Context ctx) {
     auto err = getError<input_IN>(ctx);
     if (err) {
         raiseError(ctx);
+        setTimeout(ctx, 0);
     } else {
         if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated
             setTimeout(ctx, 0);

--- a/workspace/__lib__/xod/core/defer(byte)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(byte)/patch.cpp
@@ -9,7 +9,7 @@ struct State {
 void evaluate(Context ctx) {
     auto err = getError<input_IN>(ctx);
     if (err) {
-        raiseError(ctx);
+        raiseError<output_OUT>(ctx);
         setTimeout(ctx, 0);
     } else {
         if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated

--- a/workspace/__lib__/xod/core/defer(byte)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(byte)/patch.cpp
@@ -10,6 +10,7 @@ void evaluate(Context ctx) {
     auto err = getError<input_IN>(ctx);
     if (err) {
         raiseError(ctx);
+        setTimeout(ctx, 0);
     } else {
         if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated
             setTimeout(ctx, 0);

--- a/workspace/__lib__/xod/core/defer(number)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(number)/patch.cpp
@@ -9,7 +9,7 @@ struct State {
 void evaluate(Context ctx) {
     auto err = getError<input_IN>(ctx);
     if (err) {
-        raiseError(ctx);
+        raiseError<output_OUT>(ctx);
         setTimeout(ctx, 0);
     } else {
         if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated

--- a/workspace/__lib__/xod/core/defer(number)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(number)/patch.cpp
@@ -10,6 +10,7 @@ void evaluate(Context ctx) {
     auto err = getError<input_IN>(ctx);
     if (err) {
         raiseError(ctx);
+        setTimeout(ctx, 0);
     } else {
         if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated
             setTimeout(ctx, 0);

--- a/workspace/__lib__/xod/core/defer(pulse)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(pulse)/patch.cpp
@@ -9,7 +9,7 @@ struct State {
 void evaluate(Context ctx) {
     auto err = getError<input_IN>(ctx);
     if (err) {
-        raiseError(ctx);
+        raiseError<output_OUT>(ctx);
         setTimeout(ctx, 0);
     } else {
         if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated

--- a/workspace/__lib__/xod/core/defer(pulse)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(pulse)/patch.cpp
@@ -10,6 +10,7 @@ void evaluate(Context ctx) {
     auto err = getError<input_IN>(ctx);
     if (err) {
         raiseError(ctx);
+        setTimeout(ctx, 0);
     } else {
         if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated
             setTimeout(ctx, 0);

--- a/workspace/__lib__/xod/core/defer(string)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(string)/patch.cpp
@@ -9,7 +9,7 @@ struct State {
 void evaluate(Context ctx) {
     auto err = getError<input_IN>(ctx);
     if (err) {
-        raiseError(ctx);
+        raiseError<output_OUT>(ctx);
         setTimeout(ctx, 0);
     } else {
         if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated

--- a/workspace/__lib__/xod/core/defer(string)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(string)/patch.cpp
@@ -10,6 +10,7 @@ void evaluate(Context ctx) {
     auto err = getError<input_IN>(ctx);
     if (err) {
         raiseError(ctx);
+        setTimeout(ctx, 0);
     } else {
         if (isInputDirty<input_IN>(ctx)) { // This happens only when all nodes are evaluated
             setTimeout(ctx, 0);

--- a/workspace/__lib__/xod/core/error(pulse)/patch.cpp
+++ b/workspace/__lib__/xod/core/error(pulse)/patch.cpp
@@ -7,7 +7,7 @@ struct State {
 
 void evaluate(Context ctx) {
     if (getValue<input_ERR>(ctx)) {
-        raiseError(ctx);
+        raiseError<output_OUT>(ctx);
     } else {
         if (isInputDirty<input_IN>(ctx))
             emitValue<output_OUT>(ctx, 1);

--- a/workspace/__lib__/xod/core/error/patch.cpp
+++ b/workspace/__lib__/xod/core/error/patch.cpp
@@ -7,7 +7,7 @@ struct State {
 
 void evaluate(Context ctx) {
     if (getValue<input_ERR>(ctx)) {
-        raiseError(ctx);
+        raiseError<output_OUT>(ctx);
     } else {
         emitValue<output_OUT>(ctx, getValue<input_IN>(ctx));
     }

--- a/workspace/__lib__/xod/core/if-error/patch.cpp
+++ b/workspace/__lib__/xod/core/if-error/patch.cpp
@@ -11,7 +11,7 @@ void evaluate(Context ctx) {
 
     if (defError) {
         // "DEF" input should not contain an error — reraise it
-        raiseError(ctx);
+        raiseError<output_OUT>(ctx);
     } else {
         emitValue<output_OUT>(ctx, getError<input_IN>(ctx) ? getValue<input_DEF>(ctx) : getValue<input_IN>(ctx));
     }

--- a/workspace/__lib__/xod/core/pulse-on-error/patch.xodp
+++ b/workspace/__lib__/xod/core/pulse-on-error/patch.xodp
@@ -1,50 +1,6 @@
 {
   "description": "Fires a pulse when the upstream node enters the error state.",
-  "links": [
-    {
-      "id": "BJSN7mber",
-      "input": {
-        "nodeId": "HkPQCTHiE",
-        "pinKey": "__in__"
-      },
-      "output": {
-        "nodeId": "BJz4XQWeH",
-        "pinKey": "__out__"
-      }
-    },
-    {
-      "id": "HJm4Qm-er",
-      "input": {
-        "nodeId": "BJz4XQWeH",
-        "pinKey": "__in__"
-      },
-      "output": {
-        "nodeId": "SkTXXQbeH",
-        "pinKey": "rJagQXblS"
-      }
-    },
-    {
-      "id": "HkkEmQZxr",
-      "input": {
-        "nodeId": "SkTXXQbeH",
-        "pinKey": "Hygwgm7Wgr"
-      },
-      "output": {
-        "nodeId": "BypMC6riE",
-        "pinKey": "__out__"
-      }
-    }
-  ],
   "nodes": [
-    {
-      "id": "BJz4XQWeH",
-      "position": {
-        "units": "slots",
-        "x": 0,
-        "y": 2
-      },
-      "type": "@/pulse-on-true"
-    },
     {
       "id": "BypMC6riE",
       "position": {
@@ -59,18 +15,18 @@
       "position": {
         "units": "slots",
         "x": 0,
-        "y": 3
+        "y": 2
       },
       "type": "xod/patch-nodes/output-pulse"
     },
     {
-      "id": "SkTXXQbeH",
+      "id": "S1XIK3x-S",
       "position": {
         "units": "slots",
         "x": 0,
         "y": 1
       },
-      "type": "@/has-error"
+      "type": "xod/patch-nodes/not-implemented-in-xod"
     }
   ]
 }

--- a/workspace/__lib__/xod/gpio/digital-write/patch.cpp
+++ b/workspace/__lib__/xod/gpio/digital-write/patch.cpp
@@ -11,7 +11,7 @@ void evaluate(Context ctx) {
 
     const uint8_t port = getValue<input_PORT>(ctx);
     if (!isValidDigitalPort(port)) {
-        raiseError(ctx);
+        raiseError<output_DONE>(ctx);
         return;
     }
 

--- a/workspace/lcd-time/__fixtures__/arduino.cpp
+++ b/workspace/lcd-time/__fixtures__/arduino.cpp
@@ -83,6 +83,7 @@ typedef double Number;
 typedef bool Logic;
 typedef unsigned long TimeMs;
 typedef uint8_t DirtyFlags;
+typedef uint8_t ErrorFlags;
 } // namespace xod
 
 /*=============================================================================
@@ -864,18 +865,18 @@ void clearStaleTimeout(NodeT* node) {
         clearTimeout(node);
 }
 
+void printErrorToDebugSerial(uint16_t nodeId, uint8_t errorFlags) {
 #if defined(XOD_DEBUG) || defined(XOD_SIMULATION)
-void printErrorToDebugSerial(uint16_t nodeId, uint8_t errCode) {
     XOD_DEBUG_SERIAL.print(F("+XOD_ERR:"));
     XOD_DEBUG_SERIAL.print(g_transactionTime);
     XOD_DEBUG_SERIAL.print(':');
     XOD_DEBUG_SERIAL.print(nodeId);
     XOD_DEBUG_SERIAL.print(':');
-    XOD_DEBUG_SERIAL.print((int)errCode);
+    XOD_DEBUG_SERIAL.print(errorFlags, DEC);
     XOD_DEBUG_SERIAL.print('\r');
     XOD_DEBUG_SERIAL.print('\n');
-}
 #endif
+}
 
 } // namespace detail
 
@@ -1222,7 +1223,13 @@ struct State {
 
 struct Node {
     State state;
-    bool hasOwnError;
+    union {
+        struct {
+            bool outputHasError_DONE : 1;
+        };
+
+        ErrorFlags errorFlags;
+    };
     Logic output_DONE;
 
     union {
@@ -1345,14 +1352,20 @@ uint16_t getNodeId(Context ctx) {
     return ctx->_nodeId;
 }
 
-void raiseError(Context ctx) {
-    ctx->_node->hasOwnError = true;
+template<typename OutputT> void raiseError(Context ctx) {
+    static_assert(always_false<OutputT>::value,
+            "Invalid output descriptor. Expected one of:" \
+            " output_DONE");
+}
 
+template<> void raiseError<output_DONE>(Context ctx) {
+    ctx->_node->outputHasError_DONE = true;
     ctx->_node->isOutputDirty_DONE = true;
+}
 
-#if defined(XOD_DEBUG) || defined(XOD_SIMULATION)
-    detail::printErrorToDebugSerial(ctx->_nodeId, 1);
-#endif
+void raiseError(Context ctx) {
+    ctx->_node->outputHasError_DONE = true;
+    ctx->_node->isOutputDirty_DONE = true;
 }
 
 void printLine(LiquidCrystal* lcd, uint8_t lineIndex, XString str) {
@@ -1471,7 +1484,7 @@ xod__core__cast_to_string__number::Node node_9 = {
 };
 xod__common_hardware__text_lcd_16x2::Node node_10 = {
     xod__common_hardware__text_lcd_16x2::State(), // state default
-    false, // hasOwnError
+    false, // DONE has no errors on start
     node_10_output_DONE, // output DONE default
     false, // DONE dirty
     true // node itself dirty
@@ -1589,17 +1602,16 @@ void runTransaction() {
             ctxObj._isInputDirty_UPD = node_7.isOutputDirty_TICK;
 
 #if defined(XOD_DEBUG) || defined(XOD_SIMULATION)
-            uint8_t hadOwnErrorBeforeEvaluation = node_10.hasOwnError;
+            ErrorFlags previousErrorFlags = node_10.errorFlags;
 #endif
-            // give the node a chance to recover from it's own previous error
-            node_10.hasOwnError = false;
+            // give the node a chance to recover from it's own previous errors
+            node_10.errorFlags = 0;
 
             xod__common_hardware__text_lcd_16x2::evaluate(&ctxObj);
 
 #if defined(XOD_DEBUG) || defined(XOD_SIMULATION)
-            if (hadOwnErrorBeforeEvaluation && !node_10.hasOwnError) {
-                // report that the node recovered from error
-                detail::printErrorToDebugSerial(10, 0);
+            if (previousErrorFlags != node_10.errorFlags) {
+                detail::printErrorToDebugSerial(10, node_10.errorFlags);
             }
 #endif
 
@@ -1612,6 +1624,13 @@ void runTransaction() {
     node_8.dirtyFlags = 0;
     node_9.dirtyFlags = 0;
     node_10.dirtyFlags = 0;
+
+    // Сlean errors from pulse outputs
+    if (node_10.outputHasError_DONE) {
+      node_10.outputHasError_DONE = false;
+      detail::printErrorToDebugSerial(10, node_10.errorFlags);
+    }
+
     detail::clearStaleTimeout(&node_7);
 
     XOD_TRACE_F("Transaction completed, t=");

--- a/workspace/test/test-core/reraise-if/patch.cpp
+++ b/workspace/test/test-core/reraise-if/patch.cpp
@@ -8,7 +8,7 @@ struct State {
 
 void evaluate(Context ctx) {
     if (getValue<input_RR>(ctx)) {
-        raiseError(ctx);
+        raiseError<output_OUT>(ctx);
     } else {
         emitValue<output_OUT>(ctx, getValue<input_IN>(ctx));
     }

--- a/workspace/test/test-core/test-error-handling-basics/patch.test.tsv
+++ b/workspace/test/test-core/test-error-handling-basics/patch.test.tsv
@@ -2,6 +2,6 @@ IN	IS_ERR	OUT	ERR_P
 12345	false	12345	no-pulse
 42	false	42	no-pulse
 // if IS_ERR is true, error is raised
-	true	42	pulse
+	true	error	pulse
 // after recovery from error
 	false	42	no-pulse

--- a/workspace/test/test-core/test-error-propagation-through-defer-nodes/patch.test.tsv
+++ b/workspace/test/test-core/test-error-propagation-through-defer-nodes/patch.test.tsv
@@ -1,6 +1,6 @@
 __time(ms)	ERR	OUT1	OUT2	OUT3	OUT4	OUT5
-0	false	false	pulse	""	0	0
-5	true	false	pulse	""	0	0
+0	false	false	no-pulse	""	0	0
+5	true	false	no-pulse	""	0	0
 6	true	error	error	error	error	error
 15	false	error	error	error	error	error
 16	false	false	no-pulse	""	0	0

--- a/workspace/test/test-core/test-error-propagation-through-defer-nodes/patch.xodp
+++ b/workspace/test/test-core/test-error-propagation-through-defer-nodes/patch.xodp
@@ -12,17 +12,6 @@
       }
     },
     {
-      "id": "B1cf3HY1r",
-      "input": {
-        "nodeId": "B1ePmGu-pN",
-        "pinKey": "rkdPED3cE"
-      },
-      "output": {
-        "nodeId": "HktG3BKyB",
-        "pinKey": "ryVmUAOrvkb"
-      }
-    },
-    {
       "id": "BkrN9ZYkr",
       "input": {
         "nodeId": "rkQ4qZYyr",
@@ -290,15 +279,6 @@
         "y": 3
       },
       "type": "xod/core/defer(boolean)"
-    },
-    {
-      "id": "HktG3BKyB",
-      "position": {
-        "units": "slots",
-        "x": 5,
-        "y": 1
-      },
-      "type": "xod/core/boot"
     },
     {
       "id": "Hy-zG7dZTE",

--- a/workspace/test/test-core/test-error-raising-from-all-outputs-at-once/patch.cpp
+++ b/workspace/test/test-core/test-error-raising-from-all-outputs-at-once/patch.cpp
@@ -1,0 +1,13 @@
+
+struct State {};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    if (getValue<input_ERR>(ctx)) {
+        raiseError(ctx);
+    } else {
+        emitValue<output_OUT1>(ctx, 1.0);
+        emitValue<output_OUT2>(ctx, 2.0);
+    }
+}

--- a/workspace/test/test-core/test-error-raising-from-all-outputs-at-once/patch.test.tsv
+++ b/workspace/test/test-core/test-error-raising-from-all-outputs-at-once/patch.test.tsv
@@ -1,0 +1,4 @@
+ERR	OUT1	OUT2
+false	1	2
+true	error	error
+false	1	2

--- a/workspace/test/test-core/test-error-raising-from-all-outputs-at-once/patch.xodp
+++ b/workspace/test/test-core/test-error-raising-from-all-outputs-at-once/patch.xodp
@@ -1,0 +1,50 @@
+{
+  "nodes": [
+    {
+      "id": "BJIBk5VbB",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "id": "BkZLSk5VbS",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "HJlUSkqNWr",
+      "label": "ERR",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-boolean"
+    },
+    {
+      "id": "r1X8r1q4br",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "rJN8r1c4Wr",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/tabtest"
+    }
+  ]
+}

--- a/workspace/test/test-core/test-error-raising-from-multiple-outputs/patch.cpp
+++ b/workspace/test/test-core/test-error-raising-from-multiple-outputs/patch.cpp
@@ -1,0 +1,18 @@
+
+struct State {};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    if (getValue<input_ERR1>(ctx)) {
+        raiseError<output_OUT1>(ctx);
+    } else {
+        emitValue<output_OUT1>(ctx, 1.0);
+    }
+
+    if (getValue<input_ERR2>(ctx)) {
+        raiseError<output_OUT2>(ctx);
+    } else {
+        emitValue<output_OUT2>(ctx, 2.0);
+    }
+}

--- a/workspace/test/test-core/test-error-raising-from-multiple-outputs/patch.test.tsv
+++ b/workspace/test/test-core/test-error-raising-from-multiple-outputs/patch.test.tsv
@@ -1,0 +1,5 @@
+ERR1	ERR2	OUT1	OUT2
+false	false	1	2
+true	true	error	error
+true	false	error	2
+false	true	1	error

--- a/workspace/test/test-core/test-error-raising-from-multiple-outputs/patch.xodp
+++ b/workspace/test/test-core/test-error-raising-from-multiple-outputs/patch.xodp
@@ -1,0 +1,60 @@
+{
+  "nodes": [
+    {
+      "id": "HJfR_eZbS",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "id": "HkpiulbZB",
+      "label": "ERR1",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-boolean"
+    },
+    {
+      "id": "S1VT_lW-B",
+      "position": {
+        "units": "slots",
+        "x": 3,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "Syx3Ol-Wr",
+      "label": "ERR2",
+      "position": {
+        "units": "slots",
+        "x": 3,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-boolean"
+    },
+    {
+      "id": "rJMTux-WH",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "ryvlFlW-r",
+      "position": {
+        "units": "slots",
+        "x": 3,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/tabtest"
+    }
+  ]
+}

--- a/workspace/test/test-core/test-pulse-on-error/patch.test.tsv
+++ b/workspace/test/test-core/test-pulse-on-error/patch.test.tsv
@@ -3,3 +3,5 @@ IN	OUT
 error	pulse
 5	no-pulse
 error	pulse
+error	pulse	// must work even if there were no "normal" values in between
+error	pulse


### PR DESCRIPTION
In addition to existing `raiseError(ctx)`, there is now a `raiseError<output_OUT>(ctx)`, which raises an error only for a specific output.

Also,
- uses dirtiness to spread errors
  - this allows to stop storing `prevCaughtError` byte for catchers
  - makes nodes like `pulse-on-error` react to _each_ error even when they were raised consequently without "normal" values in between
- makes tabtests strictly check that no error was raised when a "normal" value was specified
 - errors from pulse outputs are cleaned after each transaction to be consistent with how "normal" pulses behave
