### PR TITLE
Fix sending data from the nested tweaks

### DIFF
--- a/packages/xod-client-electron/src/debugger/sendToSerialMiddleware.js
+++ b/packages/xod-client-electron/src/debugger/sendToSerialMiddleware.js
@@ -1,6 +1,7 @@
 import * as R from 'ramda';
 import * as XP from 'xod-project';
 import client from 'xod-client';
+import { foldMaybe } from 'xod-func-tools';
 import { formatTweakMessage } from 'xod-arduino';
 import { ipcRenderer } from 'electron';
 
@@ -30,8 +31,12 @@ export default ({ getState }) => next => action => {
     )(state);
 
     if (XP.isTweakPath(nodeType)) {
+      const nodeIdPath = R.compose(
+        foldMaybe(nodeId, R.concat(R.__, nodeId)),
+        client.getCurrentChunksPath
+      )(state);
       const debuggerNodeId = R.compose(
-        R.prop(nodeId),
+        R.prop(nodeIdPath),
         client.getInvertedDebuggerNodeIdsMap
       )(state);
 

--- a/packages/xod-client/src/debugger/selectors.js
+++ b/packages/xod-client/src/debugger/selectors.js
@@ -124,6 +124,15 @@ const getChunksPath = R.curry((activeIndex, chunks) =>
   )(chunks)
 );
 
+export const getCurrentChunksPath = createSelector(
+  [getCurrentTabId, getBreadcrumbChunks, getBreadcrumbActiveIndex],
+  (maybeTabId, chunks, activeIndex) =>
+    R.chain(tabId => {
+      if (tabId !== DEBUGGER_TAB_ID) return Maybe.Nothing();
+      return Maybe.Just(getChunksPath(activeIndex, chunks));
+    }, maybeTabId)
+);
+
 export const getWatchNodeValuesForCurrentPatch = createSelector(
   [
     getCurrentTabId,

--- a/packages/xod-client/src/debugger/sendToSimulationSerialMiddleware.js
+++ b/packages/xod-client/src/debugger/sendToSimulationSerialMiddleware.js
@@ -1,10 +1,12 @@
 import * as R from 'ramda';
 import * as XP from 'xod-project';
+import { foldMaybe } from 'xod-func-tools';
 import { formatTweakMessage } from 'xod-arduino';
 
 import { getProject } from '../project/selectors';
 import {
   isSimulationRunning,
+  getCurrentChunksPath,
   getInvertedDebuggerNodeIdsMap,
 } from './selectors';
 import * as editorSelectors from '../editor/selectors';
@@ -28,8 +30,12 @@ export default ({ getState }) => next => action => {
     )(state);
 
     if (XP.isTweakPath(nodeType)) {
+      const nodeIdPath = R.compose(
+        foldMaybe(nodeId, R.concat(R.__, nodeId)),
+        getCurrentChunksPath
+      )(state);
       const debuggerNodeId = R.compose(
-        R.prop(nodeId),
+        R.prop(nodeIdPath),
         getInvertedDebuggerNodeIdsMap
       )(state);
 


### PR DESCRIPTION
There is no issue, but there was a bug.

## How to reproduce
1. Create patch `a`
2. Place two `tweak-number`s inside
3. Place two `output-number`s
4. Link outputs and tweaks
5. Create patch `b`
6. Place node `a` with linked `watch` node
7. Run simulation or upload with debug
8. Drill down and change a value on each tweak to different values

## Expected behavior
Everything works fine.

## Actual behavior
One of the tweaks affects the nearest one. Because of both of them sends data with "undefined" instead of valid node id, which parsed in C++ as `0`. So both of them affects the value of the tweak node with `0` id.
