### PR TITLE
Remove one stale mention of error code from `i2c/read-byte`

### DIFF
--- a/workspace/__lib__/xod/i2c/read-byte/patch.xodp
+++ b/workspace/__lib__/xod/i2c/read-byte/patch.xodp
@@ -1,5 +1,5 @@
 {
-  "description": "Reads the next byte received from an I²C device after `request` succeeded.\n\nPossible errors:\n236 - Can't read byte",
+  "description": "Reads the next byte received from an I²C device after `request` succeeded.\n\nPossible errors:\n- Can't read byte",
   "nodes": [
     {
       "description": "The byte read",


### PR DESCRIPTION
There is no issue.