### PR TITLE
Fix and add nodes that works with errored pulses

### DIFF
--- a/workspace/__lib__/xod/core/error(pulse)/patch.cpp
+++ b/workspace/__lib__/xod/core/error(pulse)/patch.cpp
@@ -6,10 +6,11 @@ struct State {
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-    if (getValue<input_ERR>(ctx)) {
+    if (!isInputDirty<input_IN>(ctx))
+        return;
+
+    if (getValue<input_ERR>(ctx))
         raiseError<output_OUT>(ctx);
-    } else {
-        if (isInputDirty<input_IN>(ctx))
-            emitValue<output_OUT>(ctx, 1);
-    }
+    else
+        emitValue<output_OUT>(ctx, 1);
 }

--- a/workspace/__lib__/xod/core/has-error(pulse)/patch.cpp
+++ b/workspace/__lib__/xod/core/has-error(pulse)/patch.cpp
@@ -1,0 +1,22 @@
+
+#pragma XOD error_catch enable
+
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    if (isInputDirty<input_IN>(ctx) && getError<input_IN>(ctx)) {
+        emitValue<output_OUT>(ctx, true);
+        // Manually trigger a reevaluation by setting timeout.
+        // The reevaluation is needed to set the output to False
+        // even when no pulse is received.
+        setTimeout(ctx, 0);
+        return;
+    }
+
+    if (isTimedOut(ctx)) {
+        emitValue<output_OUT>(ctx, false);
+    }
+}

--- a/workspace/__lib__/xod/core/has-error(pulse)/patch.xodp
+++ b/workspace/__lib__/xod/core/has-error(pulse)/patch.xodp
@@ -1,0 +1,32 @@
+{
+  "description": "Outputs `True` while the upstream node is in the error state.",
+  "nodes": [
+    {
+      "id": "BJDwgk0-r",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "id": "S1WPi66aWH",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/output-boolean"
+    },
+    {
+      "id": "rklviT6T-B",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/core/if-error(pulse)/patch.cpp
+++ b/workspace/__lib__/xod/core/if-error(pulse)/patch.cpp
@@ -1,0 +1,27 @@
+#pragma XOD error_raise enable
+#pragma XOD error_catch enable
+
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    auto defDirty = isInputDirty<input_DEF>(ctx);
+    auto defError = getError<input_DEF>(ctx);
+
+    if (defDirty && defError) {
+        // "DEF" input should not contain an error — reraise it
+        raiseError<output_OUT>(ctx);
+        return;
+    }
+
+    if (!isInputDirty<input_IN>(ctx))
+        return;
+
+    if (!getError<input_IN>(ctx))
+        emitValue<output_OUT>(ctx, 1);
+
+    if (defDirty)
+        emitValue<output_OUT>(ctx, 1);
+}

--- a/workspace/__lib__/xod/core/if-error(pulse)/patch.xodp
+++ b/workspace/__lib__/xod/core/if-error(pulse)/patch.xodp
@@ -1,0 +1,42 @@
+{
+  "description": "Passes pulse from IN to OUT if it does not carry an error. Otherwise, pulses on error if the DEF pin received a pulse.",
+  "nodes": [
+    {
+      "id": "By0ja1RbS",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "id": "H1z2a1RbB",
+      "label": "DEF",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "id": "rJWppkRWr",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "id": "rymujakRZB",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    }
+  ]
+}


### PR DESCRIPTION
There is no issue.

In short, not all nodes that handle errors (`if-error`, `has-error`) worked correctly with a pulse type. Even the `error(pulse)` node did not work correctly.

Here is an example project:  [test-pulse-errors.xodball.zip](https://github.com/xodio/xod/files/3406640/test-pulse-errors.xodball.zip)

