### PR TITLE
Add missing “files” fileds in package.json

### DIFF
--- a/packages/xod-cloud-compile/package.json
+++ b/packages/xod-cloud-compile/package.json
@@ -27,5 +27,9 @@
     "babel-plugin-inline-import": "^2.0.4",
     "chai": "^4.1.2",
     "xod-fs": "^0.30.0"
-  }
+  },
+  "files": [
+    "dist",
+    "src"
+  ]
 }

--- a/packages/xod-deploy-bin/package.json
+++ b/packages/xod-deploy-bin/package.json
@@ -24,5 +24,9 @@
   },
   "devDependencies": {
     "chai": "4.2.0"
-  }
+  },
+  "files": [
+    "dist",
+    "src"
+  ]
 }

--- a/packages/xod-deploy/package.json
+++ b/packages/xod-deploy/package.json
@@ -39,5 +39,9 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "chai-fs": "^2.0.0"
-  }
+  },
+  "files": [
+    "dist",
+    "src"
+  ]
 }

--- a/packages/xod-fs/package.json
+++ b/packages/xod-fs/package.json
@@ -27,5 +27,9 @@
     "chai-as-promised": "^6.0.0",
     "dir-compare": "^1.4.0",
     "shelljs": "^0.7.7"
-  }
+  },
+  "files": [
+    "dist",
+    "src"
+  ]
 }


### PR DESCRIPTION
For `xod-cloud-compile`, `xod-deploy-bin`, `xod-deploy` and `xod-fs`

Related to #1843
