### PR TITLE
Fix `xod/core/act` node

### DIFF
--- a/workspace/__lib__/xod/core/act/patch.xodp
+++ b/workspace/__lib__/xod/core/act/patch.xodp
@@ -20,7 +20,7 @@
       },
       "output": {
         "nodeId": "SyfN0n4l7H",
-        "pinKey": "SygDsK4MS"
+        "pinKey": "ByAIWR_UZ"
       }
     },
     {
@@ -71,7 +71,7 @@
       "id": "rynA2NlXS",
       "input": {
         "nodeId": "SyfN0n4l7H",
-        "pinKey": "SJHwjt4fr"
+        "pinKey": "BkjI-COLb"
       },
       "output": {
         "nodeId": "BytC28DfH",
@@ -147,7 +147,7 @@
         "x": 1,
         "y": 1
       },
-      "type": "@/pulse-on-change(boolean)"
+      "type": "@/pulse-on-change"
     }
   ]
 }


### PR DESCRIPTION
There is no issue.
I switched the specialization for testing purposes (to avoid conflict between `@/pulse-on-change` and `xod/core/pulse-on-change`) and then forget to switch it back 🙈 
Fixed.