### PR TITLE
Tweak `xod/debug/stream-string` node

### DIFF
--- a/workspace/__lib__/xod/debug/stream-string/patch.cpp
+++ b/workspace/__lib__/xod/debug/stream-string/patch.cpp
@@ -8,9 +8,8 @@ struct State {
 void evaluate(Context ctx) {
     auto state = getState(ctx);
 
-    auto str = getValue<input_IN>(ctx);
-
-    if (isSettingUp()) {
+    if (isInputDirty<input_IN>(ctx)) {
+        auto str = getValue<input_IN>(ctx);
         state->it = str.iterate();
     }
 


### PR DESCRIPTION
Old implementation works only once on the boot.
This one will stream the string on the change. So now this node can be used with `tweak-string` or any other dynamically changed input value.

Example: 
![image](https://user-images.githubusercontent.com/1897530/66134124-79d68080-e600-11e9-98be-138a5868455a.png)

❗️ 
Probably, it should be moved to `xod/stream` and should not be a utility node anymore.
What do you think?