### PR TITLE
Fix a bug that caused compilation error if a defer node was used in a feedback loop without an upstream error raiser

### DIFF
--- a/packages/xod-arduino/platform/program.tpl.cpp
+++ b/packages/xod-arduino/platform/program.tpl.cpp
@@ -28,7 +28,7 @@ struct TransactionState {
   {{#each outputs}}
     bool node_{{ ../id }}_isOutputDirty_{{ pinKey }} : 1;
   {{/each}}
-  {{#if (hasUpstreamErrorRaisers this)}}
+  {{#if (needsHasUpstreamErrorFlag this)}}
     bool node_{{id}}_hasUpstreamError : 1;
   {{/if}}
 {{/unless}}

--- a/packages/xod-arduino/src/templates.js
+++ b/packages/xod-arduino/src/templates.js
@@ -236,9 +236,14 @@ Handlebars.registerHelper('cppValue', (type, value) =>
   })(value)
 );
 
+const hasUpstreamErrorRaisers = nodeOrInput =>
+  nodeOrInput.upstreamErrorRaisers.length > 0;
+
+Handlebars.registerHelper('hasUpstreamErrorRaisers', hasUpstreamErrorRaisers);
+
 Handlebars.registerHelper(
-  'hasUpstreamErrorRaisers',
-  nodeOrInput => nodeOrInput.upstreamErrorRaisers.length > 0
+  'needsHasUpstreamErrorFlag',
+  R.either(hasUpstreamErrorRaisers, R.path(['patch', 'isDefer']))
 );
 
 const isTweakNode = R.pipe(R.path(['patch', 'patchPath']), XP.isTweakPath);

--- a/workspace/count-with-feedback-loops/__fixtures__/arduino.cpp
+++ b/workspace/count-with-feedback-loops/__fixtures__/arduino.cpp
@@ -2353,8 +2353,10 @@ struct TransactionState {
     bool node_23_hasUpstreamError : 1;
     bool node_24_isNodeDirty : 1;
     bool node_24_isOutputDirty_OUT : 1;
+    bool node_24_hasUpstreamError : 1;
     bool node_25_isNodeDirty : 1;
     bool node_25_isOutputDirty_OUT : 1;
+    bool node_25_hasUpstreamError : 1;
     TransactionState() {
         node_0_isNodeDirty = true;
         node_0_isOutputDirty_OUT = false;


### PR DESCRIPTION
The issue was reported [on our forum](https://forum.xod.io/t/xod-0-31-0-released-standard-library-improvements/2643/5).