### PR TITLE
Fix quickstart node for 20x4 I2C text LCD

### DIFF
--- a/workspace/__lib__/xod-dev/text-lcd/text-lcd-i2c-20x4/patch.xodp
+++ b/workspace/__lib__/xod-dev/text-lcd/text-lcd-i2c-20x4/patch.xodp
@@ -13,6 +13,17 @@
       }
     },
     {
+      "id": "BJ4EAF_dH",
+      "input": {
+        "nodeId": "rJKigL6bmH",
+        "pinKey": "SJKHrSeQH"
+      },
+      "output": {
+        "nodeId": "SJPaQlHyXS",
+        "pinKey": "H1fx68wzB"
+      }
+    },
+    {
       "id": "BJN_L6WQS",
       "input": {
         "nodeId": "B1kUeSkmB",
@@ -343,6 +354,17 @@
       }
     },
     {
+      "id": "r1LERKO_H",
+      "input": {
+        "nodeId": "r1GbUaZmB",
+        "pinKey": "SJKHrSeQH"
+      },
+      "output": {
+        "nodeId": "By0rlrkXS",
+        "pinKey": "H1fx68wzB"
+      }
+    },
+    {
       "id": "r1kgaQgH17r",
       "input": {
         "nodeId": "B1HaXxBy7r",
@@ -373,6 +395,17 @@
       "output": {
         "nodeId": "r1s6XeSyXS",
         "pinKey": "ByHmL0uHPk-"
+      }
+    },
+    {
+      "id": "rkDV0Yuur",
+      "input": {
+        "nodeId": "BklzZU6WmB",
+        "pinKey": "SJKHrSeQH"
+      },
+      "output": {
+        "nodeId": "B1kUeSkmB",
+        "pinKey": "H1fx68wzB"
       }
     },
     {


### PR DESCRIPTION
There is no issue.
Error noted by @gabbapeople, produced by me 😬 
Missing links between `act` nodes and `print-at` nodes of second, third and fourth lines.