### PR TITLE
Make tweak nodes works fine with the new literals like `=XOD_PROJECT`

### DIFF
--- a/packages/xod-client-electron/src/debugger/sendToSerialMiddleware.js
+++ b/packages/xod-client-electron/src/debugger/sendToSerialMiddleware.js
@@ -40,9 +40,17 @@ export default ({ getState }) => next => action => {
         client.getInvertedDebuggerNodeIdsMap
       )(state);
 
+      const globals = client.getStoredGlobals(state);
+
+      // If value looks like a global literal — get value from the stored globals
+      const valueToSend = R.when(
+        R.startsWith('='),
+        R.compose(R.propOr(value, R.__, globals), R.tail)
+      )(value);
+
       ipcRenderer.send(
         DEBUG_SERIAL_SEND,
-        formatTweakMessage(nodeType, debuggerNodeId, value)
+        formatTweakMessage(nodeType, debuggerNodeId, valueToSend)
       );
     }
   }

--- a/packages/xod-client-electron/src/view/containers/App.jsx
+++ b/packages/xod-client-electron/src/view/containers/App.jsx
@@ -288,15 +288,18 @@ class App extends client.App {
 
     stopDebuggerSession();
 
+    let sessionGlobals = []; // TODO: Refactor
+
     eitherToPromise(eitherTProject)
       .then(tProject => {
         const globalsInProject = listGlobals(tProject);
-        return this.getGlobals(globalsInProject).then(globals =>
-          R.compose(eitherToPromise, extendTProjectWithGlobals)(
+        return this.getGlobals(globalsInProject).then(globals => {
+          sessionGlobals = globals; // TODO: Refactor
+          return R.compose(eitherToPromise, extendTProjectWithGlobals)(
             globals,
             tProject
-          )
-        );
+          );
+        });
       })
       .then(
         tapP(tProj => {
@@ -393,7 +396,8 @@ class App extends client.App {
                 nodeIdsMap,
                 nodePinKeysMap,
                 pinsAffectedByErrorRaisers,
-                currentPatchPath
+                currentPatchPath,
+                sessionGlobals
               );
               debuggerIPC.sendStartDebuggerSession(
                 ipcRenderer,

--- a/packages/xod-client/src/core/containers/App.jsx
+++ b/packages/xod-client/src/core/containers/App.jsx
@@ -113,15 +113,17 @@ export default class App extends React.Component {
       LIVENESS.SIMULATION
     );
 
+    let sessionGlobals = []; // TODO: Refactor
     eitherToPromise(eitherTProject)
       .then(tProject => {
         const globalsInProject = listGlobals(tProject);
-        return this.getGlobals(globalsInProject).then(globals =>
-          R.compose(eitherToPromise, extendTProjectWithGlobals)(
+        return this.getGlobals(globalsInProject).then(globals => {
+          sessionGlobals = globals; // TODO: Refactor
+          return R.compose(eitherToPromise, extendTProjectWithGlobals)(
             globals,
             tProject
-          )
-        );
+          );
+        });
       })
       .then(
         R.applySpec({
@@ -148,7 +150,8 @@ export default class App extends React.Component {
             nodeIdsMap,
             nodePinKeysMap,
             code,
-            pinsAffectedByErrorRaisers
+            pinsAffectedByErrorRaisers,
+            sessionGlobals
           )
       )
       .catch(

--- a/packages/xod-client/src/debugger/actions.js
+++ b/packages/xod-client/src/debugger/actions.js
@@ -35,7 +35,8 @@ export const startDebuggerSession = (
   nodeIdsMap,
   nodePinKeysMap,
   pinsAffectedByErrorRaisers,
-  currentPatchPath
+  currentPatchPath,
+  globals
 ) => ({
   type: AT.DEBUG_SESSION_STARTED,
   payload: {
@@ -44,6 +45,7 @@ export const startDebuggerSession = (
     nodePinKeysMap,
     pinsAffectedByErrorRaisers,
     patchPath: currentPatchPath,
+    globals,
   },
 });
 

--- a/packages/xod-client/src/debugger/reducer.js
+++ b/packages/xod-client/src/debugger/reducer.js
@@ -474,6 +474,7 @@ export default (state = initialState, action) => {
         ),
         R.assoc('activeSession', SESSION_TYPE.DEBUG),
         R.assoc('isOutdated', false),
+        R.assoc('globals', action.payload.globals),
         showDebuggerPane
       )(state);
     }
@@ -499,6 +500,7 @@ export default (state = initialState, action) => {
         R.assoc('pinsAffectedByErrorRaisers', {}),
         R.assoc('watchNodeValues', {}),
         R.assoc('nodeIdsMap', {}),
+        R.assoc('globals', {}),
         R.assoc('activeSession', SESSION_TYPE.NONE)
       )(state);
     case MARK_DEBUG_SESSION_OUTDATED:
@@ -570,6 +572,7 @@ export default (state = initialState, action) => {
         R.assoc('uploadProgress', null),
         R.assoc('nodeIdsMap', invertedNodeIdsMap),
         R.assoc('nodePinKeysMap', action.payload.nodePinKeysMap),
+        R.assoc('globals', action.payload.globals),
         rekeyAndAssocPinsAffectedByErrorRaisers(
           invertedNodeIdsMap,
           action.payload.pinsAffectedByErrorRaisers
@@ -583,6 +586,7 @@ export default (state = initialState, action) => {
         R.assoc('watchNodeValues', {}),
         R.assoc('interactiveErroredNodePins', {}),
         R.assoc('pinsAffectedByErrorRaisers', {}),
+        R.assoc('globals', {}),
         R.assoc('isPreparingSimulation', false),
         hideProgressBar
       )(state);
@@ -593,6 +597,7 @@ export default (state = initialState, action) => {
         ),
         R.assoc('activeSession', SESSION_TYPE.NONE),
         R.assoc('isPreparingSimulation', false),
+        R.assoc('globals', {}),
         hideProgressBar,
         showDebuggerPane
       )(state);

--- a/packages/xod-client/src/debugger/selectors.js
+++ b/packages/xod-client/src/debugger/selectors.js
@@ -251,3 +251,5 @@ export const getInteractiveErroredNodePinsForCurrentChunk = createMemoizedSelect
       maybeTabId
     )
 );
+
+export const getStoredGlobals = R.compose(R.prop('globals'), getDebuggerState);

--- a/packages/xod-client/src/debugger/state.js
+++ b/packages/xod-client/src/debugger/state.js
@@ -36,4 +36,5 @@ export default {
   uploadProgress: null,
   interactiveErroredNodePins: {},
   pinsAffectedByErrorRaisers: {},
+  globals: {},
 };

--- a/packages/xod-client/src/editor/actions.js
+++ b/packages/xod-client/src/editor/actions.js
@@ -819,7 +819,8 @@ export const runSimulation = (
   nodeIdsMap,
   nodePinKeysMap,
   code,
-  pinsAffectedByErrorRaisers
+  pinsAffectedByErrorRaisers,
+  globals
 ) => (dispatch, getState) => {
   dispatch({ type: ActionType.SIMULATION_GENERATED_CPP });
 
@@ -852,6 +853,7 @@ export const runSimulation = (
               nodePinKeysMap,
               pinsAffectedByErrorRaisers,
               patchPath: simulationPatchPath,
+              globals,
             },
           });
 

--- a/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/StringPinWidget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/StringPinWidget.jsx
@@ -35,7 +35,7 @@ const StringWidget = compose(
   withHandlers({
     onChangeHandler: props => event => {
       const value = event.target.value;
-      props.onChange(props.isStringMode ? requote(value) : value);
+      props.onChange(props.isStringMode ? enquote(value) : value);
     },
     onKeyDown: props => event => {
       if (


### PR DESCRIPTION
There is no issue. Probably it is an overlooked part of the previously closed issues: #1882
Also, it fixes a bug introduced in the #1888 — do not remove the leading quote in a string mode (already quoted by "virtual" quotes).