### PR TITLE
fix(stdlib): fix `xod/i2c/read-byte` node error reading `0x00` value bug

### DIFF
--- a/workspace/__lib__/xod/i2c/read-byte/patch.cpp
+++ b/workspace/__lib__/xod/i2c/read-byte/patch.cpp
@@ -15,11 +15,12 @@ void evaluate(Context ctx) {
         return;
     }
 
-    uint8_t res = (uint8_t)wire->read();
-    if (res) {
-        emitValue<output_BYTE>(ctx, res);
-        emitValue<output_DONE>(ctx, 1);
-    } else {
+    auto res = wire->read();
+    if (res == -1) {
         raiseError(ctx); // Can't read byte
-    }
+        return;
+     }
+
+    emitValue<output_BYTE>(ctx, (uint8_t)res);
+    emitValue<output_DONE>(ctx, 1);
 }


### PR DESCRIPTION
Reading the `0x00` byte value from I2C should not provide XOD error.
Here is an example:
https://forum.xod.io/t/rtc-ds3231-cant-dispay-plain-hours-eg-12-00/2923

Originally the `virtual int read(void)` method of the `TwoWire` class returns `-1` on failed byte read.