### PR TITLE
XOD Graphics library basics

### DIFF
--- a/packages/xod-arduino/platform/types.h
+++ b/packages/xod-arduino/platform/types.h
@@ -16,13 +16,21 @@ typedef unsigned long TimeMs;
 typedef uint8_t ErrorFlags;
 
 struct Pulse {
-  Pulse() {}
-  Pulse(bool) {}
-  Pulse(int) {}
+    Pulse() {}
+    Pulse(bool) {}
+    Pulse(int) {}
 };
 
 struct XColor {
-  uint8_t r, g, b;
+    constexpr XColor()
+        : r(0)
+        , g(0)
+        , b(0) {}
+    constexpr XColor(uint8_t cr, uint8_t cg, uint8_t cb)
+        : r(cr)
+        , g(cg)
+        , b(cb) {}
+    uint8_t r, g, b;
 };
 
 } // namespace xod

--- a/workspace/__ardulib__/Graphics/Canvas.h
+++ b/workspace/__ardulib__/Graphics/Canvas.h
@@ -1,0 +1,34 @@
+
+#ifndef CANVAS_H
+#define CANVAS_H
+
+#include "XGraphics.h"
+
+/*
+ * Represents a rectangular piece of the screen (i.e. scene) which gets redrawn
+ * completely when at least a single child `XGraphics` element on it is updated.
+ * Holds the backgound color for the scene and the default foreground color for
+ * the child graphics primitives. 
+ */
+class Canvas : public XGraphics {
+private:
+    XColor _bgColor;
+    XColor _fgColor = { 0xFF, 0xFF, 0xFF };
+
+    XVector2<int16_t> _pivot;
+    int16_t _w;
+    int16_t _h;
+
+public:
+    void setPosition(int16_t x, int16_t y, int16_t w, int16_t h);
+    void setStyle(XColor bgColor, XColor fgColor);
+
+    BBox getUpstreamCanvasBBox() const;
+    XColor getFGColor() const;
+
+    void renderScanline(XRenderer* renderer, int16_t scanline, uint16_t* buffer, size_t bufferSize);
+};
+
+#include "Canvas.inl"
+
+#endif // CANVAS_H

--- a/workspace/__ardulib__/Graphics/Canvas.inl
+++ b/workspace/__ardulib__/Graphics/Canvas.inl
@@ -1,0 +1,27 @@
+
+void Canvas::setPosition(int16_t x, int16_t y, int16_t w, int16_t h) {
+    _pivot = XVector2<int16_t>(x, y);
+    _w = w;
+    _h = h;
+}
+
+void Canvas::setStyle(XColor bgColor, XColor fgColor) {
+    _bgColor = bgColor;
+    _fgColor = fgColor;
+}
+
+BBox Canvas::getUpstreamCanvasBBox() const {
+    return { _pivot, _w, _h };
+}
+
+XColor Canvas::getFGColor() const {
+    return _fgColor;
+}
+
+void Canvas::renderScanline(XRenderer* renderer, int16_t scanline, uint16_t* buffer, size_t bufferSize) {
+
+    uint16_t color = xcolorTo565(_bgColor);
+
+    for (int16_t x = 0; x < bufferSize; x++)
+        buffer[x] = color;
+}

--- a/workspace/__ardulib__/Graphics/Line.h
+++ b/workspace/__ardulib__/Graphics/Line.h
@@ -1,0 +1,30 @@
+
+#ifndef LINE_H
+#define LINE_H
+
+#include "XGraphics.h"
+
+/*
+ * Represents a line given by two points A(x0, y0) and B(x1, y1).
+ * The `setStyle` method sets up stroke color of the line otherwise
+ * the default foreground color of the scene is used.
+ */
+class Line : public XGraphics {
+private:
+    XVector2<int16_t> _a;
+    XVector2<int16_t> _b;
+
+    XColor* _strokeColor = nullptr;
+
+public:
+    Line(XGraphics* parent);
+
+    void setPosition(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
+    void setStyle(XColor* strokeColor);
+
+    void renderScanline(XRenderer* renderer, int16_t scanline, uint16_t* buffer, size_t bufferSize);
+};
+
+#include "Line.inl"
+
+#endif // LINE_H

--- a/workspace/__ardulib__/Graphics/Line.inl
+++ b/workspace/__ardulib__/Graphics/Line.inl
@@ -1,0 +1,100 @@
+
+void swapInt16(int16_t& a, int16_t& b) {
+    int16_t t = a;
+    a = b;
+    b = t;
+}
+
+/*
+ * The Bresenham's line algorithm [Wikipedia](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm).
+ * This implementation is augmented by the scanline intersection check during rasterisation.
+ * The standard algorithm assumes that the `b.x` > `a.x` and `b.y` > `a.y`. The `steep` value is used to eliminate
+ * this condition and to calculate a line at points with any coordinates.
+ */
+void putLineOnScanline(XVector2<int16_t> a, XVector2<int16_t> b, int16_t scanline, uint16_t* buffer, size_t bufferSize, uint16_t color) {
+
+    int16_t steep = abs(b.y - a.y) > abs(b.x - a.x);
+    if (steep) {
+        swapInt16(a.x, a.y);
+        swapInt16(b.x, b.y);
+    }
+
+    if (a.x > b.x) {
+        swapInt16(a.x, b.x);
+        swapInt16(a.y, b.y);
+    }
+
+    int16_t dx, dy;
+    dx = b.x - a.x;
+    dy = abs(b.y - a.y);
+
+    int16_t err = dx / 2;
+    int16_t ystep;
+
+    if (a.y < b.y) {
+        ystep = 1;
+    } else {
+        ystep = -1;
+    }
+
+    for (; a.x <= b.x; a.x++) {
+        if (steep) {
+            if (scanline == a.x)
+                if (a.y >= 0 && a.y < bufferSize)
+                    buffer[a.y] = color;
+        } else {
+            if (scanline == a.y)
+                if (a.x >= 0 && a.x < bufferSize)
+                    buffer[a.x] = color;
+        }
+        err -= dy;
+        if (err < 0) {
+            a.y += ystep;
+            err += dx;
+        }
+    }
+}
+
+Line::Line(XGraphics* parent)
+    : XGraphics(parent) {}
+
+void Line::setPosition(int16_t x0, int16_t y0, int16_t x1, int16_t y1) {
+    _a = XVector2<int16_t>(x0, y0);
+    _b = XVector2<int16_t>(x1, y1);
+}
+
+void Line::setStyle(XColor* strokeColor) {
+    _strokeColor = strokeColor;
+}
+
+void Line::renderScanline(XRenderer* renderer, int16_t scanline, uint16_t* buffer, size_t bufferSize) {
+
+    int16_t lineMinY = min(_a.y, _b.y);
+    int16_t lineMaxY = max(_a.y, _b.y);
+
+    int16_t lineMinX = min(_a.x, _b.x);
+    int16_t lineMaxX = max(_a.x, _b.x);
+
+    if (scanline > lineMaxY || scanline < lineMinY)
+        return;
+
+    uint16_t color = xcolorTo565(_strokeColor ? *_strokeColor : getFGColor());
+
+    if (lineMinY == lineMaxY) {
+        // Straight horizontal line. Use shortcut instead of slow algorithm.
+
+        for (int16_t x = lineMinX; x <= lineMaxX; x++)
+            if (x >= 0 && x < bufferSize)
+                buffer[x] = color;
+
+    } else if (lineMinX == lineMaxX) {
+        // Straight vertical line. Use shortcut instead of slow algorithm.
+
+        if (_a.x >= 0 && _a.x < bufferSize)
+            buffer[_a.x] = color;
+
+    } else {
+        // Regular diagonal line.
+        putLineOnScanline(_a, _b, scanline, buffer, bufferSize, color);
+    }
+}

--- a/workspace/__ardulib__/Graphics/XGraphics.h
+++ b/workspace/__ardulib__/Graphics/XGraphics.h
@@ -1,0 +1,51 @@
+
+#ifndef X_GRAPHICS_H
+#define X_GRAPHICS_H
+
+#include <Arduino.h>
+
+#include "XRender.h"
+#include "XVector2.h"
+
+using xod::XColor;
+
+/*
+ * A structure to hold a boundary box of a geometric object.
+ */
+struct BBox {
+    XVector2<int16_t> pivot;
+    int16_t width;
+    int16_t height;
+};
+
+/*
+ * A base class for graphics primitives. A primitive is a single node in the scene tree which eventually
+ * gets rendered. The `XGraphics` and derived classes are device-independent. They hold geometry
+ * and style data, and have methods to rasterize them [scan]line-by-line into a plain pixel buffer.
+ */
+class XGraphics {
+protected:
+    XGraphics* _parent;
+
+public:
+    XGraphics();
+    XGraphics(XGraphics* parent);
+
+    virtual XColor getFGColor() const;
+    virtual BBox getUpstreamCanvasBBox() const;
+
+    /*
+     * Rasterizes a specific graphics primitive for the specified `scanline`.
+     */
+    virtual void renderScanline(XRenderer* renderer, int16_t scanline, uint16_t* buffer, size_t bufferSize) {}
+    /*
+     * Rasterizes all graphics primitives in the scene tree for the specified `scanline`.
+     */
+    void renderScanlineRecursively(XRenderer* renderer, int16_t scanline, uint16_t* buffer, size_t bufferSize);
+    /*
+     * Rasterizes all graphics primitives for the specified scene.
+     */
+    void render(XRenderer* renderer);
+};
+
+#include "XGraphics.inl"

--- a/workspace/__ardulib__/Graphics/XGraphics.inl
+++ b/workspace/__ardulib__/Graphics/XGraphics.inl
@@ -1,0 +1,49 @@
+
+XGraphics::XGraphics() {
+    _parent = nullptr;
+}
+
+XGraphics::XGraphics(XGraphics* parent) {
+    _parent = parent;
+}
+
+XColor XGraphics::getFGColor() const {
+    return _parent ? _parent->getFGColor() : XColor();
+}
+
+BBox XGraphics::getUpstreamCanvasBBox() const {
+    return _parent ? _parent->getUpstreamCanvasBBox() : BBox({ { 0, 0 }, 0, 0 });
+}
+
+void XGraphics::render(XRenderer* renderer) {
+
+    BBox canvasBBox = getUpstreamCanvasBBox();
+
+    int16_t screenWidth = renderer->getScreenWidth();
+    int16_t screenHeight = renderer->getScreenHeight();
+
+    int16_t pivotX = max(0, canvasBBox.pivot.x);
+    int16_t pivotY = max(0, canvasBBox.pivot.y);
+
+    size_t bufferSize = (pivotX + canvasBBox.width >= screenWidth) ? screenWidth - pivotX : canvasBBox.width;
+
+    int16_t scanlineCount = (pivotY + canvasBBox.height >= screenHeight) ? screenHeight - pivotY : canvasBBox.height;
+
+    for (int16_t scanline = 0; scanline <= scanlineCount; scanline++) {
+        uint16_t buffer[bufferSize];
+        renderScanlineRecursively(renderer, scanline, buffer, bufferSize);
+        renderer->renderScanlinePart(pivotY + scanline, pivotX, pivotX + bufferSize - 1, buffer);
+    }
+}
+
+void XGraphics::renderScanlineRecursively(XRenderer* renderer, int16_t scanline, uint16_t* buffer, size_t bufferSize) {
+
+    if (_parent != nullptr)
+        _parent->renderScanlineRecursively(renderer, scanline, buffer, bufferSize);
+
+    renderScanline(renderer, scanline, buffer, bufferSize);
+}
+
+inline uint16_t xcolorTo565(XColor color) {
+    return ((color.r & 0xF8) << 8) | ((color.g & 0xFC) << 3) | (color.b >> 3);
+}

--- a/workspace/__ardulib__/Graphics/XRender.h
+++ b/workspace/__ardulib__/Graphics/XRender.h
@@ -1,0 +1,16 @@
+
+#ifndef X_RENDERER_H
+#define X_RENDERER_H
+
+/*
+ * Pure virtual renderer, should be overridden by the renderer of a specific device.
+ */
+class XRenderer {
+public:
+    virtual void renderScanlinePart(int16_t scanline, int16_t xmin, int16_t xmax, uint16_t* lineBuffer) = 0;
+
+    virtual int16_t getScreenWidth() const;
+    virtual int16_t getScreenHeight() const;
+};
+
+#endif // X_RENDERER_H

--- a/workspace/__ardulib__/Graphics/XVector2.h
+++ b/workspace/__ardulib__/Graphics/XVector2.h
@@ -1,0 +1,145 @@
+
+#ifndef X_VECTOR2_H
+#define X_VECTOR2_H
+
+/*
+ * Utility template class for manipulating 2-dimensional vectors.
+ */
+template <typename T>
+class XVector2 {
+public:
+    XVector2();
+    XVector2(T X, T Y);
+
+    template <typename U>
+    explicit XVector2(const XVector2<U>& vector);
+
+    T x;
+    T y;
+};
+
+template <typename T>
+XVector2<T> operator-(const XVector2<T>& right);
+
+template <typename T>
+XVector2<T>& operator+=(XVector2<T>& left, const XVector2<T>& right);
+
+template <typename T>
+XVector2<T>& operator-=(XVector2<T>& left, const XVector2<T>& right);
+
+template <typename T>
+XVector2<T> operator+(const XVector2<T>& left, const XVector2<T>& right);
+
+template <typename T>
+XVector2<T> operator-(const XVector2<T>& left, const XVector2<T>& right);
+
+template <typename T>
+XVector2<T> operator*(const XVector2<T>& left, T right);
+
+template <typename T>
+XVector2<T> operator*(T left, const XVector2<T>& right);
+
+template <typename T>
+XVector2<T>& operator*=(XVector2<T>& left, T right);
+
+template <typename T>
+XVector2<T> operator/(const XVector2<T>& left, T right);
+
+template <typename T>
+XVector2<T>& operator/=(XVector2<T>& left, T right);
+
+template <typename T>
+bool operator==(const XVector2<T>& left, const XVector2<T>& right);
+
+template <typename T>
+bool operator!=(const XVector2<T>& left, const XVector2<T>& right);
+
+template <typename T>
+inline XVector2<T>::XVector2()
+    : x(0)
+    , y(0) {}
+
+template <typename T>
+inline XVector2<T>::XVector2(T X, T Y)
+    : x(X)
+    , y(Y) {}
+
+template <typename T>
+template <typename U>
+inline XVector2<T>::XVector2(const XVector2<U>& vector)
+    : x(static_cast<T>(vector.x))
+    , y(static_cast<T>(vector.y)) {}
+
+template <typename T>
+inline XVector2<T> operator-(const XVector2<T>& right) {
+    return XVector2<T>(-right.x, -right.y);
+}
+
+template <typename T>
+inline XVector2<T>& operator+=(XVector2<T>& left, const XVector2<T>& right) {
+    left.x += right.x;
+    left.y += right.y;
+
+    return left;
+}
+
+template <typename T>
+inline XVector2<T>& operator-=(XVector2<T>& left, const XVector2<T>& right) {
+    left.x -= right.x;
+    left.y -= right.y;
+
+    return left;
+}
+
+template <typename T>
+inline XVector2<T> operator+(const XVector2<T>& left, const XVector2<T>& right) {
+    return XVector2<T>(left.x + right.x, left.y + right.y);
+}
+
+template <typename T>
+inline XVector2<T> operator-(const XVector2<T>& left, const XVector2<T>& right) {
+    return XVector2<T>(left.x - right.x, left.y - right.y);
+}
+
+template <typename T>
+inline XVector2<T> operator*(const XVector2<T>& left, T right) {
+    return XVector2<T>(left.x * right, left.y * right);
+}
+
+template <typename T>
+inline XVector2<T> operator*(T left, const XVector2<T>& right) {
+    return XVector2<T>(right.x * left, right.y * left);
+}
+
+template <typename T>
+inline XVector2<T>& operator*=(XVector2<T>& left, T right) {
+    left.x *= right;
+    left.y *= right;
+
+    return left;
+}
+
+template <typename T>
+inline XVector2<T> operator/(const XVector2<T>& left, T right) {
+    return XVector2<T>(left.x / right, left.y / right);
+}
+
+template <typename T>
+inline XVector2<T>& operator/=(XVector2<T>& left, T right) {
+    left.x /= right;
+    left.y /= right;
+
+    return left;
+}
+
+template <typename T>
+inline bool operator==(const XVector2<T>& left, const XVector2<T>& right) {
+    return (left.x == right.x) && (left.y == right.y);
+}
+
+template <typename T>
+inline bool operator!=(const XVector2<T>& left, const XVector2<T>& right) {
+    return (left.x != right.x) || (left.y != right.y);
+}
+
+#endif // X_VECTOR2_H

--- a/workspace/__ardulib__/README.md
+++ b/workspace/__ardulib__/README.md
@@ -8,3 +8,4 @@ The directory contains vendoring copies of some Arduino Libraries used in native
 * `Servo` -- the standard library
 * `Ethernet2` -- https://github.com/xodio/Ethernet2 (modified https://github.com/adafruit/Ethernet2)
 * `ESP8266UART` -- custom library. Should be published to the XOD GitHub repository along with the "UART" library, which is bundled into `xod-arduino/platform` and some `xod/uart` nodes.
+* `Graphics` -- custom library. Implements basic graphic functions in XOD.

--- a/workspace/__lib__/xod/color/color/patch.cpp
+++ b/workspace/__lib__/xod/color/color/patch.cpp
@@ -9,7 +9,7 @@ using Type = XColor;
 // clang-format on
 
 void evaluate(Context ctx) {
-    Type color;
+    Type color = getValue<output_OUT>(ctx);
     emitValue<output_OUT>(ctx, color);
 }
 

--- a/workspace/__lib__/xod/graphics/canvas/patch.cpp
+++ b/workspace/__lib__/xod/graphics/canvas/patch.cpp
@@ -1,0 +1,43 @@
+
+// clang-format off
+{{#global}}
+#include <Canvas.h>
+{{/global}}
+// clang-format on
+
+struct State {
+    uint8_t mem[sizeof(Canvas)];
+    Canvas* canvas;
+    int16_t x, y, w, h;
+};
+
+// clang-format off
+{{ GENERATED_CODE }}
+// clang-format on
+
+void evaluate(Context ctx) {
+
+    auto state = getState(ctx);
+
+    auto bgColor = getValue<input_BG>(ctx);
+    auto fgColor = getValue<input_FG>(ctx);
+
+    int16_t x = (int16_t)getValue<input_X>(ctx);
+    int16_t y = (int16_t)getValue<input_Y>(ctx);
+    int16_t w = (int16_t)getValue<input_W>(ctx);
+    int16_t h = (int16_t)getValue<input_H>(ctx);
+
+    if (isSettingUp()) {
+        state->canvas = new (state->mem) Canvas();
+    }
+
+    if (isSettingUp() || x != state->x || y != state->y || w != state->w || h != state->h || isInputDirty<input_BG>(ctx) || isInputDirty<input_FG>(ctx)) {
+        state->x = x;
+        state->y = y;
+        state->w = w;
+        state->h = h;
+        state->canvas->setPosition(x, y, w, h);
+        state->canvas->setStyle(bgColor, fgColor);
+        emitValue<output_GFX>(ctx, state->canvas);
+    }
+}

--- a/workspace/__lib__/xod/graphics/canvas/patch.xodp
+++ b/workspace/__lib__/xod/graphics/canvas/patch.xodp
@@ -1,0 +1,93 @@
+{
+  "description": "Canvas is a rectangular piece of the screen (i.e. scene) which gets redrawn completely when at least a single graphics element on it is updated.\n",
+  "nodes": [
+    {
+      "id": "H1wRGzm-U",
+      "label": "GFX",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 2
+      },
+      "type": "@/output-graphics"
+    },
+    {
+      "description": "Background color of the scene.",
+      "id": "HJiLQ5ATB",
+      "label": "BG",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/color/input-color"
+    },
+    {
+      "description": "Width of the canvas.",
+      "id": "SJCd0mhbU",
+      "label": "W",
+      "position": {
+        "units": "slots",
+        "x": 4,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "description": "X coordinate of the canvas pivot point on the screen.",
+      "id": "SJs_CQ3ZU",
+      "label": "X",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "description": "Height of the canvas.",
+      "id": "Skx0dA7nWI",
+      "label": "H",
+      "position": {
+        "units": "slots",
+        "x": 5,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "description": "Y coordinate of the canvas pivot point on the screen.",
+      "id": "rJp_R73Z8",
+      "label": "Y",
+      "position": {
+        "units": "slots",
+        "x": 3,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "rk02qu0TB",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "#FFFFFF"
+      },
+      "description": "Foreground color. The default color for subsequent graphics elements.",
+      "id": "ryyuAQnWL",
+      "label": "FG",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 0
+      },
+      "type": "xod/color/input-color"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/graphics/graphics/patch.cpp
+++ b/workspace/__lib__/xod/graphics/graphics/patch.cpp
@@ -1,0 +1,16 @@
+
+// clang-format off
+{{#global}}
+#include <XGraphics.h>
+{{/global}}
+// clang-format on
+
+struct State {};
+
+using Type = XGraphics*;
+
+// clang-format off
+{{ GENERATED_CODE }}
+// clang-format on
+
+void evaluate(Context ctx) {}

--- a/workspace/__lib__/xod/graphics/graphics/patch.xodp
+++ b/workspace/__lib__/xod/graphics/graphics/patch.xodp
@@ -1,0 +1,32 @@
+{
+  "nodes": [
+    {
+      "id": "ByI99dRaH",
+      "position": {
+        "units": "slots",
+        "x": 3,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/utility"
+    },
+    {
+      "id": "S1ekqVgsB",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "id": "SJWV3yviS",
+      "label": "GFX",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/output-self"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/graphics/line-colored/patch.cpp
+++ b/workspace/__lib__/xod/graphics/line-colored/patch.cpp
@@ -1,0 +1,47 @@
+
+// clang-format off
+{{#global}}
+#include <Line.h>
+{{/global}}
+// clang-format on
+
+struct State {
+    uint8_t mem[sizeof(Line)];
+    Line* lineColored;
+    int16_t x0, y0, x1, y1;
+    XColor strokeColor;
+};
+
+// clang-format off
+{{ GENERATED_CODE }}
+// clang-format on
+
+void evaluate(Context ctx) {
+    auto state = getState(ctx);
+
+    auto gfx = getValue<input_GFX>(ctx);
+    state->strokeColor = getValue<input_C>(ctx);
+
+    int16_t x0 = (int16_t)getValue<input_X0>(ctx);
+    int16_t y0 = (int16_t)getValue<input_Y0>(ctx);
+    int16_t x1 = (int16_t)getValue<input_X1>(ctx);
+    int16_t y1 = (int16_t)getValue<input_Y1>(ctx);
+
+    if (isSettingUp()) {
+        state->lineColored = new (state->mem) Line(gfx);
+    }
+
+    if (isSettingUp() || x0 != state->x0 || y0 != state->y0 || x1 != state->x1 || y1 != state->y1 || isInputDirty<input_C>(ctx)) {
+        state->x0 = x0;
+        state->y0 = y0;
+        state->x1 = x1;
+        state->y1 = y1;
+        state->lineColored->setPosition(x0, y0, x1, y1);
+        state->lineColored->setStyle(&state->strokeColor);
+        emitValue<output_GFXU0027>(ctx, state->lineColored);
+    }
+
+    if (isInputDirty<input_GFX>(ctx)) {
+        emitValue<output_GFXU0027>(ctx, state->lineColored);
+    }
+}

--- a/workspace/__lib__/xod/graphics/line-colored/patch.xodp
+++ b/workspace/__lib__/xod/graphics/line-colored/patch.xodp
@@ -1,0 +1,89 @@
+{
+  "description": "Represents a line of the custom style.\n",
+  "nodes": [
+    {
+      "id": "S14b4Iwh-8",
+      "label": "GFX'",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 2
+      },
+      "type": "@/output-graphics"
+    },
+    {
+      "description": "Y coordinate of the end point of the line on the canvas.",
+      "id": "S1j0CIxf8",
+      "label": "Y1",
+      "position": {
+        "units": "slots",
+        "x": 5,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "SkG-VIwhZU",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "id": "SkXbELD3bI",
+      "label": "GFX",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 0
+      },
+      "type": "@/input-graphics"
+    },
+    {
+      "description": "X coordinate of the end point of the line on the canvas.",
+      "id": "SyGoRAUlz8",
+      "label": "X1",
+      "position": {
+        "units": "slots",
+        "x": 4,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "description": "X coordinate of the start point of the line on the canvas.",
+      "id": "r1ejR0UeMU",
+      "label": "X0",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "description": "Stroke color.",
+      "id": "r1qVIP3b8",
+      "label": "C",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 0
+      },
+      "type": "xod/color/input-color"
+    },
+    {
+      "description": "Y coordinate of the start point of the line on the canvas.",
+      "id": "rkbi0RIgGU",
+      "label": "Y0",
+      "position": {
+        "units": "slots",
+        "x": 3,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/graphics/line/patch.cpp
+++ b/workspace/__lib__/xod/graphics/line/patch.cpp
@@ -1,0 +1,44 @@
+
+// clang-format off
+{{#global}}
+#include <Line.h>
+{{/global}}
+// clang-format on
+
+struct State {
+    uint8_t mem[sizeof(Line)];
+    Line* line;
+    int16_t x0, y0, x1, y1;
+};
+
+// clang-format off
+{{ GENERATED_CODE }}
+// clang-format on
+
+void evaluate(Context ctx) {
+    auto state = getState(ctx);
+
+    auto gfx = getValue<input_GFX>(ctx);
+
+    int16_t x0 = (int16_t)getValue<input_X0>(ctx);
+    int16_t y0 = (int16_t)getValue<input_Y0>(ctx);
+    int16_t x1 = (int16_t)getValue<input_X1>(ctx);
+    int16_t y1 = (int16_t)getValue<input_Y1>(ctx);
+
+    if (isSettingUp()) {
+        state->line = new (state->mem) Line(gfx);
+    }
+
+    if (isSettingUp() || x0 != state->x0 || y0 != state->y0 || x1 != state->x1 || y1 != state->y1) {
+        state->x0 = x0;
+        state->y0 = y0;
+        state->x1 = x1;
+        state->y1 = y1;
+        state->line->setPosition(x0, y0, x1, y1);
+        emitValue<output_GFXU0027>(ctx, state->line);
+    }
+
+    if (isInputDirty<input_GFX>(ctx)) {
+        emitValue<output_GFXU0027>(ctx, state->line);
+    }
+}

--- a/workspace/__lib__/xod/graphics/line/patch.xodp
+++ b/workspace/__lib__/xod/graphics/line/patch.xodp
@@ -1,0 +1,78 @@
+{
+  "description": "Represents a line of the default scene style.\n",
+  "nodes": [
+    {
+      "description": "Y coordinate of the end point of the line on the canvas.",
+      "id": "ByQTRKFoS",
+      "label": "Y1",
+      "position": {
+        "units": "slots",
+        "x": 5,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "description": "X coordinate of the start point of the line on the canvas.",
+      "id": "HJA2AKYsS",
+      "label": "X0",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "HyDFCKYoB",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "id": "Hyx-QfXWL",
+      "label": "GFX",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 0
+      },
+      "type": "@/input-graphics"
+    },
+    {
+      "id": "S14bQzmbU",
+      "label": "GFX'",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 2
+      },
+      "type": "@/output-graphics"
+    },
+    {
+      "description": "Y coordinate of the start point of the line on the canvas.",
+      "id": "Sk-6Cttsr",
+      "label": "Y0",
+      "position": {
+        "units": "slots",
+        "x": 3,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "description": "X coordinate of the end point of the line on the canvas.",
+      "id": "SkM6RFKjS",
+      "label": "X1",
+      "position": {
+        "units": "slots",
+        "x": 4,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/graphics/project.xod
+++ b/workspace/__lib__/xod/graphics/project.xod
@@ -1,0 +1,9 @@
+{
+  "authors": [
+    "XOD"
+  ],
+  "description": "Nodes to work with graphics in XOD",
+  "license": "AGPL-3.0",
+  "name": "graphics",
+  "version": "0.32.1"
+}

--- a/workspace/big-patch/__fixtures__/arduino.cpp
+++ b/workspace/big-patch/__fixtures__/arduino.cpp
@@ -85,13 +85,21 @@ typedef unsigned long TimeMs;
 typedef uint8_t ErrorFlags;
 
 struct Pulse {
-  Pulse() {}
-  Pulse(bool) {}
-  Pulse(int) {}
+    Pulse() {}
+    Pulse(bool) {}
+    Pulse(int) {}
 };
 
 struct XColor {
-  uint8_t r, g, b;
+    constexpr XColor()
+        : r(0)
+        , g(0)
+        , b(0) {}
+    constexpr XColor(uint8_t cr, uint8_t cg, uint8_t cb)
+        : r(cr)
+        , g(cg)
+        , b(cb) {}
+    uint8_t r, g, b;
 };
 
 } // namespace xod

--- a/workspace/blink/__fixtures__/arduino.cpp
+++ b/workspace/blink/__fixtures__/arduino.cpp
@@ -85,13 +85,21 @@ typedef unsigned long TimeMs;
 typedef uint8_t ErrorFlags;
 
 struct Pulse {
-  Pulse() {}
-  Pulse(bool) {}
-  Pulse(int) {}
+    Pulse() {}
+    Pulse(bool) {}
+    Pulse(int) {}
 };
 
 struct XColor {
-  uint8_t r, g, b;
+    constexpr XColor()
+        : r(0)
+        , g(0)
+        , b(0) {}
+    constexpr XColor(uint8_t cr, uint8_t cg, uint8_t cb)
+        : r(cr)
+        , g(cg)
+        , b(cb) {}
+    uint8_t r, g, b;
 };
 
 } // namespace xod

--- a/workspace/count-with-feedback-loops/__fixtures__/arduino.cpp
+++ b/workspace/count-with-feedback-loops/__fixtures__/arduino.cpp
@@ -85,13 +85,21 @@ typedef unsigned long TimeMs;
 typedef uint8_t ErrorFlags;
 
 struct Pulse {
-  Pulse() {}
-  Pulse(bool) {}
-  Pulse(int) {}
+    Pulse() {}
+    Pulse(bool) {}
+    Pulse(int) {}
 };
 
 struct XColor {
-  uint8_t r, g, b;
+    constexpr XColor()
+        : r(0)
+        , g(0)
+        , b(0) {}
+    constexpr XColor(uint8_t cr, uint8_t cg, uint8_t cb)
+        : r(cr)
+        , g(cg)
+        , b(cb) {}
+    uint8_t r, g, b;
 };
 
 } // namespace xod

--- a/workspace/lcd-time/__fixtures__/arduino.cpp
+++ b/workspace/lcd-time/__fixtures__/arduino.cpp
@@ -85,13 +85,21 @@ typedef unsigned long TimeMs;
 typedef uint8_t ErrorFlags;
 
 struct Pulse {
-  Pulse() {}
-  Pulse(bool) {}
-  Pulse(int) {}
+    Pulse() {}
+    Pulse(bool) {}
+    Pulse(int) {}
 };
 
 struct XColor {
-  uint8_t r, g, b;
+    constexpr XColor()
+        : r(0)
+        , g(0)
+        , b(0) {}
+    constexpr XColor(uint8_t cr, uint8_t cg, uint8_t cb)
+        : r(cr)
+        , g(cg)
+        , b(cb) {}
+    uint8_t r, g, b;
 };
 
 } // namespace xod

--- a/workspace/two-button-switch/__fixtures__/arduino.cpp
+++ b/workspace/two-button-switch/__fixtures__/arduino.cpp
@@ -85,13 +85,21 @@ typedef unsigned long TimeMs;
 typedef uint8_t ErrorFlags;
 
 struct Pulse {
-  Pulse() {}
-  Pulse(bool) {}
-  Pulse(int) {}
+    Pulse() {}
+    Pulse(bool) {}
+    Pulse(int) {}
 };
 
 struct XColor {
-  uint8_t r, g, b;
+    constexpr XColor()
+        : r(0)
+        , g(0)
+        , b(0) {}
+    constexpr XColor(uint8_t cr, uint8_t cg, uint8_t cb)
+        : r(cr)
+        , g(cg)
+        , b(cb) {}
+    uint8_t r, g, b;
 };
 
 } // namespace xod


### PR DESCRIPTION
- Introduce `xod/graphics` and ` __ardulib__ /Graphics` library basics.
- Add the `Line` graphic element.
- Add  `XColor()` struct constructors into the `packages/xod-arduino/platform/types.h`.
- Clang-format the `packages/xod-arduino/platform/types.h`.
- Update Fixtures.

