### PR TITLE
Support of SSD1306 based monochrome I2C displays

### DIFF
--- a/workspace/__ardulib__/README.md
+++ b/workspace/__ardulib__/README.md
@@ -11,3 +11,4 @@ The directory contains vendoring copies of some Arduino Libraries used in native
 * `WS2812_NoBuffer` -- custom library for WS2812 without buffer. Based on [SimpleNeopixelDemo](https://github.com/bigjosh/SimpleNeoPixelDemo/blob/master/SimpleNeopixelDemo/SimpleNeopixelDemo.ino) and [Adafruit Neopixel](https://github.com/adafruit/Adafruit_NeoPixel). Tested on AVR platforms and ESP8266.
 * `Graphics` -- custom library. Implements basic graphic functions in XOD.
 * `ST7735` -- custom library. It is used to drive ST7735 chip-based TFT LCD displays controlled by SPI.
+* `SSD1306` -- custom library. It is used to drive SSD1306 chip-based monochrome TFT LCDs controlled by I2C.

--- a/workspace/__ardulib__/SSD1306/SSD1306.cpp
+++ b/workspace/__ardulib__/SSD1306/SSD1306.cpp
@@ -1,0 +1,92 @@
+
+#include "SSD1306.h"
+
+SSD1306::SSD1306(TwoWire* wire, uint8_t i2cAddress, uint8_t* buffer) {
+    _wire = wire ? wire : &Wire;
+    _i2cAddress = i2cAddress;
+    _buffer = buffer;
+    _width = SSD1306_DISPLAY_WIDTH;
+    _height = SSD1306_DISPLAY_HEIGHT;
+}
+
+void SSD1306::sendCommand(uint8_t command) {
+    _wire->beginTransmission(_i2cAddress);
+    _wire->write(0x80);
+    _wire->write(command);
+    _wire->endTransmission();
+}
+
+void SSD1306::begin() {
+    _wire->begin();
+    sendCommand(SSD1306_DISPLAY_OFF);
+    sendCommand(SSD1306_SET_DISPLAY_CLOCK);
+    sendCommand(0x80);
+    sendCommand(SSD1306_SET_MULTIPLEX_RATIO);
+    sendCommand(0x3F);
+    sendCommand(SSD1306_SET_DISPLAY_OFFSET);
+    sendCommand(0x00);
+    sendCommand(SSD1306_SET_START_LINE | 0);
+    sendCommand(SSD1306_CHARGE_DCDC_PUMP);
+    sendCommand(0x14);
+    sendCommand(SSD1306_ADDR_MODE);
+    sendCommand(0x00);
+    sendCommand(SSD1306_SET_REMAP_L_TO_R);
+    sendCommand(SSD1306_SET_REMAP_T_TO_D);
+    sendCommand(SSD1306_SET_COM_PINS);
+    sendCommand(0x12);
+    sendCommand(SSD1306_SET_CONTRAST);
+    sendCommand(0xFF);
+    sendCommand(SSD1306_SET_PRECHARGE_PERIOD);
+    sendCommand(0xF1);
+    sendCommand(SSD1306_SET_VCOM_DESELECT);
+    sendCommand(0x40);
+    sendCommand(SSD1306_RAM_ON);
+    sendCommand(SSD1306_INVERT_OFF);
+    sendCommand(SSD1306_DISPLAY_ON);
+}
+
+void SSD1306::sendBuffer() {
+    sendCommand(SSD1306_ADDR_PAGE);
+    sendCommand(0);
+    sendCommand(_height / 8 - 1);
+    sendCommand(SSD1306_ADDR_COLUMN);
+    sendCommand(0);
+    sendCommand(_width - 1);
+    for (uint16_t i = 0; i < _width * _height / 8; i++) {
+        _wire->beginTransmission(_i2cAddress);
+        _wire->write(0x40);
+
+        for (uint8_t x = 0; x < 16; x++)
+            _wire->write(_buffer[i++]);
+
+        i--;
+        _wire->endTransmission();
+    }
+}
+
+void SSD1306::clearScreen() {
+    memset(_buffer, 0, _width * _height / 8);
+}
+
+void SSD1306::renderScanlinePart(int16_t scanline, int16_t xmin, int16_t xmax, const uint16_t* lineBuffer) {
+    if ((scanline >= _height) || (scanline < 0))
+        return;
+    if ((xmin < 0) || (xmax < 0) || (xmin >= _width) || (xmax >= _width) || (xmin > xmax))
+        return;
+
+    for (int16_t x = 0; x < _width; x++) {
+
+        /* The two-byte (RGB565) color value is stored in the form of RRRRRGGG:GGGBBBBB.
+         * To get a black or white color, an artificial check for the lightness is performed.
+         * Using the 11000110:00011000 bitmask, all bits except the most significant ones
+         * are clipped for each color component. 0xC618 is the hex value of the bitmask. 
+         */
+        bool color = lineBuffer[x] & 0xC618;
+
+        uint8_t p = scanline / 8;
+        uint16_t numByte = (p * 128) + x;
+        uint8_t numBit = scanline % 8;
+
+        _buffer[numByte] = color ? _buffer[numByte] |= 1 << numBit : _buffer[numByte] &= ~(1 << numBit);
+    }
+}

--- a/workspace/__ardulib__/SSD1306/SSD1306.h
+++ b/workspace/__ardulib__/SSD1306/SSD1306.h
@@ -1,0 +1,58 @@
+
+#ifndef X_SSD1306_H
+#define X_SSD1306_H
+
+#include <Wire.h>
+#include <XRender.h>
+
+
+#define SSD1306_DISPLAY_OFF 0xAE
+#define SSD1306_SET_DISPLAY_CLOCK 0xD5
+#define SSD1306_SET_MULTIPLEX_RATIO 0xA8
+#define SSD1306_SET_DISPLAY_OFFSET 0xD3
+#define SSD1306_SET_START_LINE 0x40
+#define SSD1306_CHARGE_DCDC_PUMP 0x8D
+#define SSD1306_ADDR_MODE 0x20
+#define SSD1306_SET_REMAP_L_TO_R 0xA1
+#define SSD1306_SET_REMAP_T_TO_D 0xC8
+#define SSD1306_SET_COM_PINS 0xDA
+#define SSD1306_SET_CONTRAST 0x81
+#define SSD1306_SET_PRECHARGE_PERIOD 0xD9
+#define SSD1306_SET_VCOM_DESELECT 0xDB
+#define SSD1306_RAM_ON 0xA4
+#define SSD1306_INVERT_OFF 0xA6
+#define SSD1306_DISPLAY_ON 0xAF
+#define SSD1306_ADDR_PAGE 0x22
+#define SSD1306_ADDR_COLUMN 0x21
+
+#define SSD1306_DISPLAY_WIDTH 128
+#define SSD1306_DISPLAY_HEIGHT 64
+
+class SSD1306 : public XRenderer {
+public:
+    SSD1306(TwoWire* wire, uint8_t i2cAddress, uint8_t* buffer);
+
+    int16_t getScreenWidth() const {
+        return _width;
+    }
+    int16_t getScreenHeight() const {
+        return _height;
+    }
+
+    void begin();
+    void sendBuffer();
+    void clearScreen();
+
+    void renderScanlinePart(int16_t scanline, int16_t xmin, int16_t xmax, const uint16_t* lineBuffer) override;
+
+private:
+    TwoWire* _wire = nullptr;
+    uint8_t _i2cAddress = 0x00;
+    uint8_t* _buffer;
+    int16_t _width = 0;
+    int16_t _height = 0;
+
+    void sendCommand(uint8_t command);
+};
+
+#endif // X_SSD1306_H

--- a/workspace/__lib__/xod-dev/ssd1306-display/project.xod
+++ b/workspace/__lib__/xod-dev/ssd1306-display/project.xod
@@ -1,0 +1,6 @@
+{
+  "description": "Nodes to drive SD1306-based monochrome LCDs with I2C interface.",
+  "license": "AGPL-3.0",
+  "name": "ssd1306-display",
+  "version": "0.32.1"
+}

--- a/workspace/__lib__/xod-dev/ssd1306-display/render/patch.cpp
+++ b/workspace/__lib__/xod-dev/ssd1306-display/render/patch.cpp
@@ -1,0 +1,22 @@
+
+struct State {};
+
+// clang-format off
+{{ GENERATED_CODE }}
+// clang-format on
+
+void evaluate(Context ctx) {
+    auto dev = getValue<input_DEV>(ctx);
+
+    if (isSettingUp())
+        emitValue<output_DEVU0027>(ctx, dev);
+
+    if (!isInputDirty<input_DO>(ctx))
+        return;
+
+    auto gfx = getValue<input_GFX>(ctx);
+    gfx->render(dev);
+    dev->sendBuffer();
+
+    emitValue<output_DONE>(ctx, 1);
+}

--- a/workspace/__lib__/xod-dev/ssd1306-display/render/patch.xodp
+++ b/workspace/__lib__/xod-dev/ssd1306-display/render/patch.xodp
@@ -1,0 +1,69 @@
+{
+  "description": "Renders a tree of graphic elements and display them on the device.",
+  "nodes": [
+    {
+      "id": "BJblG9nrGU",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "description": "Triggers a new rendering process.",
+      "id": "BJgmVh-7I",
+      "label": "DO",
+      "position": {
+        "units": "slots",
+        "x": 4,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "description": "Pulses when the rendering process is done.",
+      "id": "Bygxm4h-mL",
+      "label": "DONE",
+      "position": {
+        "units": "slots",
+        "x": 3,
+        "y": 3
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "description": "The display device.",
+      "id": "HJ6Zd_J8L",
+      "label": "DEV",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 1
+      },
+      "type": "@/input-ssd1306-128x64-i2c-device"
+    },
+    {
+      "description": "A tree of graphic elements created using the xod/graphics library.",
+      "id": "Sk-lm42W7I",
+      "label": "GFX",
+      "position": {
+        "units": "slots",
+        "x": 3,
+        "y": 1
+      },
+      "type": "xod/graphics/input-graphics"
+    },
+    {
+      "description": "The display device.",
+      "id": "ryqMOOkLI",
+      "label": "DEV'",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 3
+      },
+      "type": "@/output-ssd1306-128x64-i2c-device"
+    }
+  ]
+}

--- a/workspace/__lib__/xod-dev/ssd1306-display/ssd1306-128x64-i2c-device/patch.cpp
+++ b/workspace/__lib__/xod-dev/ssd1306-display/ssd1306-128x64-i2c-device/patch.cpp
@@ -1,0 +1,39 @@
+
+// clang-format off
+{{#global}}
+#include <SSD1306.h>
+{{/global}}
+// clang-format on
+
+struct State {
+    uint8_t mem[sizeof(SSD1306)];
+    uint8_t buffer[SSD1306_DISPLAY_WIDTH * SSD1306_DISPLAY_HEIGHT / 8];
+};
+
+using Type = SSD1306*;
+
+// clang-format off
+{{ GENERATED_CODE }}
+// clang-format on
+
+void evaluate(Context ctx) {
+    if (!isSettingUp())
+        return;
+
+    auto state = getState(ctx);
+
+    auto i2c = getValue<input_I2C>(ctx);
+    uint8_t addr = getValue<input_ADDR>(ctx);
+
+    if (addr > 127) {
+        raiseError(ctx);
+        return;
+    }
+
+    Type dev = new (state->mem) SSD1306(i2c, addr, state->buffer);
+
+    dev->begin();
+    dev->clearScreen();
+
+    emitValue<output_DEV>(ctx, dev);
+}

--- a/workspace/__lib__/xod-dev/ssd1306-display/ssd1306-128x64-i2c-device/patch.xodp
+++ b/workspace/__lib__/xod-dev/ssd1306-display/ssd1306-128x64-i2c-device/patch.xodp
@@ -1,0 +1,48 @@
+{
+  "description": "Device node for an SSD1306 based monochrome 128x64  TFT LCD connected through an I2C interface. ",
+  "nodes": [
+    {
+      "id": "By5FY7hsS",
+      "label": "I2C",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/i2c/input-i2c"
+    },
+    {
+      "id": "Hkg4W34xjS",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "id": "HyzldOJI8",
+      "label": "DEV",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/output-self"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "3Ch"
+      },
+      "description": "I²C address. 3Ch by default.",
+      "id": "SJRYLhZmU",
+      "label": "ADDR",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-byte"
+    }
+  ]
+}

--- a/workspace/__lib__/xod-dev/ssd1306-display/ssd1306-128x64-i2c/patch.xodp
+++ b/workspace/__lib__/xod-dev/ssd1306-display/ssd1306-128x64-i2c/patch.xodp
@@ -1,0 +1,182 @@
+{
+  "description": "A quick-start node drives an SSD1306 based monochrome 128x64 TFT LCD connected through an I2C interface.",
+  "links": [
+    {
+      "id": "B1Xz8hZmU",
+      "input": {
+        "nodeId": "S1de82bm8",
+        "pinKey": "BJgmVh-7I"
+      },
+      "output": {
+        "nodeId": "B1ls-83WmL",
+        "pinKey": "H1fx68wzB"
+      }
+    },
+    {
+      "id": "BJP9L2ZQU",
+      "input": {
+        "nodeId": "HJSlIn-QI",
+        "pinKey": "SJRYLhZmU"
+      },
+      "output": {
+        "nodeId": "SkuSL3WXU",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "BkeN_ukLL",
+      "input": {
+        "nodeId": "S1de82bm8",
+        "pinKey": "HJ6Zd_J8L"
+      },
+      "output": {
+        "nodeId": "HJSlIn-QI",
+        "pinKey": "HyzldOJI8"
+      }
+    },
+    {
+      "id": "HJ9sWIhZXI",
+      "input": {
+        "nodeId": "B1ls-83WmL",
+        "pinKey": "H13R3IvGB"
+      },
+      "output": {
+        "nodeId": "SJfsbI2bX8",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "HJjE83bQU",
+      "input": {
+        "nodeId": "HJSlIn-QI",
+        "pinKey": "By5FY7hsS"
+      },
+      "output": {
+        "nodeId": "ryVVL2Z78",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "SkFM8h-mU",
+      "input": {
+        "nodeId": "HyVi-I2b78",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "S1de82bm8",
+        "pinKey": "Bygxm4h-mL"
+      }
+    },
+    {
+      "id": "SyrG83bXU",
+      "input": {
+        "nodeId": "S1de82bm8",
+        "pinKey": "Sk-lm42W7I"
+      },
+      "output": {
+        "nodeId": "HksZIhWQI",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "r1PjZ8h-QI",
+      "input": {
+        "nodeId": "B1ls-83WmL",
+        "pinKey": "BytC28DfH"
+      },
+      "output": {
+        "nodeId": "HksZIhWQI",
+        "pinKey": "__out__"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "id": "B1ls-83WmL",
+      "position": {
+        "units": "slots",
+        "x": 6,
+        "y": 0
+      },
+      "type": "xod/core/act"
+    },
+    {
+      "id": "HJSlIn-QI",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 1
+      },
+      "type": "@/ssd1306-128x64-i2c-device"
+    },
+    {
+      "description": "A tree of graphic elements created using the xod/graphics library.",
+      "id": "HksZIhWQI",
+      "label": "GFX",
+      "position": {
+        "units": "slots",
+        "x": 5,
+        "y": -1
+      },
+      "type": "xod/graphics/input-graphics"
+    },
+    {
+      "description": "Pulses to acknowledge changes in the tree of graphic elements.",
+      "id": "HyVi-I2b78",
+      "label": "ACK",
+      "position": {
+        "units": "slots",
+        "x": 5,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "id": "S1de82bm8",
+      "position": {
+        "units": "slots",
+        "x": 4,
+        "y": 1
+      },
+      "type": "@/render"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "True"
+      },
+      "description": "Makes the display react to incoming changes in a tree of graphic elements while `ACT` is true.",
+      "id": "SJfsbI2bX8",
+      "label": "ACT",
+      "position": {
+        "units": "slots",
+        "x": 7,
+        "y": -1
+      },
+      "type": "xod/patch-nodes/input-boolean"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "3Ch"
+      },
+      "description": "I²C address. 3Ch by default.",
+      "id": "SkuSL3WXU",
+      "label": "ADDR",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-byte"
+    },
+    {
+      "id": "ryVVL2Z78",
+      "label": "I2C",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 0
+      },
+      "type": "xod/i2c/input-i2c"
+    }
+  ]
+}


### PR DESCRIPTION
XOD support of SSD1306 based monochrome I2C displays.