### PR TITLE
Add the Point graphic primitive to the Graphic library.

### DIFF
--- a/workspace/__ardulib__/Graphics/Point.h
+++ b/workspace/__ardulib__/Graphics/Point.h
@@ -1,0 +1,29 @@
+
+#ifndef POINT_H
+#define POINT_H
+
+#include "XGraphics.h"
+
+/*
+ * Represents a point given by coordinates (x, y).
+ * The `setStyle` method sets up stroke color of the point otherwise
+ * the default foreground color of the scene is used.
+ */
+class Point : public XGraphics {
+private:
+    XVector2<int16_t> _a;
+
+    XColor* _strokeColor = nullptr;
+
+public:
+    Point(XGraphics* parent);
+
+    void setPosition(int16_t x, int16_t y);
+    void setStyle(XColor* strokeColor);
+
+    void renderScanline(XRenderer* renderer, int16_t scanline, uint16_t* buffer, size_t bufferSize);
+};
+
+#include "Point.inl"
+
+#endif // POINT_H

--- a/workspace/__ardulib__/Graphics/Point.inl
+++ b/workspace/__ardulib__/Graphics/Point.inl
@@ -1,0 +1,22 @@
+
+Point::Point(XGraphics* parent)
+    : XGraphics(parent) {}
+
+void Point::setPosition(int16_t x, int16_t y) {
+    _a = XVector2<int16_t>(x, y);
+}
+
+void Point::setStyle(XColor* strokeColor) {
+    _strokeColor = strokeColor;
+}
+
+void Point::renderScanline(XRenderer* renderer, int16_t scanline, uint16_t* buffer, size_t bufferSize) {
+
+    if (scanline != _a.y)
+        return;
+
+    uint16_t color = xcolorTo565(_strokeColor ? *_strokeColor : getFGColor());
+
+    if (_a.x >= 0 && _a.x < bufferSize)
+        buffer[_a.x] = color;
+}

--- a/workspace/__lib__/xod/graphics/line-colored/patch.xodp
+++ b/workspace/__lib__/xod/graphics/line-colored/patch.xodp
@@ -1,5 +1,5 @@
 {
-  "description": "Represents a line of the custom style.\n",
+  "description": "Represents a line with a custom style.",
   "nodes": [
     {
       "id": "S14b4Iwh-8",

--- a/workspace/__lib__/xod/graphics/line/patch.xodp
+++ b/workspace/__lib__/xod/graphics/line/patch.xodp
@@ -1,5 +1,5 @@
 {
-  "description": "Represents a line of the default scene style.\n",
+  "description": "Represents a line drawn with the foreground color.",
   "nodes": [
     {
       "description": "Y coordinate of the end point of the line on the canvas.",

--- a/workspace/__lib__/xod/graphics/point-colored/patch.cpp
+++ b/workspace/__lib__/xod/graphics/point-colored/patch.cpp
@@ -1,0 +1,44 @@
+
+// clang-format off
+{{#global}}
+#include <Point.h>
+{{/global}}
+// clang-format on
+
+struct State {
+    uint8_t mem[sizeof(Point)];
+    Point* pointColored;
+    int16_t x, y;
+    XColor strokeColor;
+};
+
+// clang-format off
+{{ GENERATED_CODE }}
+// clang-format on
+
+void evaluate(Context ctx) {
+
+    auto state = getState(ctx);
+    auto gfx = getValue<input_GFX>(ctx);
+
+    state->strokeColor = getValue<input_C>(ctx);
+
+    int16_t x = (int16_t)getValue<input_X>(ctx);
+    int16_t y = (int16_t)getValue<input_Y>(ctx);
+
+    if (isSettingUp()) {
+        state->pointColored = new (state->mem) Point(gfx);
+    }
+
+    if (isSettingUp() || state->x != x || state->y != y || isInputDirty<input_C>(ctx)) {
+        state->x = x;
+        state->y = y;
+        state->pointColored->setPosition(x, y);
+        state->pointColored->setStyle(&state->strokeColor);
+        emitValue<output_GFXU0027>(ctx, state->pointColored);
+    }
+
+    if (isInputDirty<input_GFX>(ctx)) {
+        emitValue<output_GFXU0027>(ctx, state->pointColored);
+    }
+}

--- a/workspace/__lib__/xod/graphics/point-colored/patch.xodp
+++ b/workspace/__lib__/xod/graphics/point-colored/patch.xodp
@@ -1,0 +1,67 @@
+{
+  "description": "Represents a point (dot) with a custom style.",
+  "nodes": [
+    {
+      "id": "B1fQYkLnb8",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "id": "BJXXYyU2bL",
+      "label": "GFX",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 0
+      },
+      "type": "@/input-graphics"
+    },
+    {
+      "description": "Y coordinate of the point on the canvas.",
+      "id": "HJlrc-qlMU",
+      "label": "Y",
+      "position": {
+        "units": "slots",
+        "x": 3,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "description": "X coordinate of the point on the canvas.",
+      "id": "HkSqWcgML",
+      "label": "X",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "S1gQt182-L",
+      "label": "GFX'",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 2
+      },
+      "type": "@/output-graphics"
+    },
+    {
+      "description": "Point color.",
+      "id": "SyqKJUnZL",
+      "label": "C",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 0
+      },
+      "type": "xod/color/input-color"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/graphics/point/patch.cpp
+++ b/workspace/__lib__/xod/graphics/point/patch.cpp
@@ -1,0 +1,40 @@
+
+// clang-format off
+{{#global}}
+#include <Point.h>
+{{/global}}
+// clang-format on
+
+struct State {
+    uint8_t mem[sizeof(Point)];
+    Point* point;
+    int16_t x, y;
+};
+
+// clang-format off
+{{ GENERATED_CODE }}
+// clang-format on
+
+void evaluate(Context ctx) {
+
+    auto state = getState(ctx);
+    auto gfx = getValue<input_GFX>(ctx);
+
+    int16_t x = (int16_t)getValue<input_X>(ctx);
+    int16_t y = (int16_t)getValue<input_Y>(ctx);
+
+    if (isSettingUp()) {
+        state->point = new (state->mem) Point(gfx);
+    }
+
+    if (isSettingUp() || state->x != x || state->y != y) {
+        state->x = x;
+        state->y = y;
+        state->point->setPosition(x, y);
+        emitValue<output_GFXU0027>(ctx, state->point);
+    }
+
+    if (isInputDirty<input_GFX>(ctx)) {
+        emitValue<output_GFXU0027>(ctx, state->point);
+    }
+}

--- a/workspace/__lib__/xod/graphics/point/patch.xodp
+++ b/workspace/__lib__/xod/graphics/point/patch.xodp
@@ -1,0 +1,56 @@
+{
+  "description": "Represents a simple point (dot) drawn with the foreground color.",
+  "nodes": [
+    {
+      "description": "X coordinate of the point on the canvas.",
+      "id": "BJlNyZ2UaS",
+      "label": "X",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "ByMfQzXb8",
+      "label": "GFX'",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 2
+      },
+      "type": "@/output-graphics"
+    },
+    {
+      "description": "Y coordinate of the point on the canvas.",
+      "id": "S1EV1-2I6H",
+      "label": "Y",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "id": "SJW41-hL6S",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "id": "rJlMGmfQZU",
+      "label": "GFX",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 0
+      },
+      "type": "@/input-graphics"
+    }
+  ]
+}


### PR DESCRIPTION
- Add the `Point` class to the `__ardulib__/Graphics/` and `xod/graphics` library.
- Correct `line` and `line-colored` nodes description.

