### PR TITLE
Add the `pulse-on-change` node specialization for graphics.

### DIFF
--- a/workspace/__lib__/xod/graphics/pulse-on-change(graphics)/patch.cpp
+++ b/workspace/__lib__/xod/graphics/pulse-on-change(graphics)/patch.cpp
@@ -1,0 +1,11 @@
+struct State {
+};
+
+{{ GENERATED_CODE }}
+
+void evaluate(Context ctx) {
+    //Change in at least one of the elements in the graphical tree is a signal that the whole tree has changed.
+
+    if (isInputDirty<input_IN>(ctx))
+        emitValue<output_OUT>(ctx, 1);
+}

--- a/workspace/__lib__/xod/graphics/pulse-on-change(graphics)/patch.xodp
+++ b/workspace/__lib__/xod/graphics/pulse-on-change(graphics)/patch.xodp
@@ -1,0 +1,32 @@
+{
+  "description": "Emits a pulse every time input value changes.",
+  "nodes": [
+    {
+      "id": "HJEC2meXI",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "id": "SJxEC27e7U",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "id": "Sk9A2mlmU",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 0
+      },
+      "type": "xod/graphics/input-graphics"
+    }
+  ]
+}


### PR DESCRIPTION
Add the `pulse-on-change(graphics)` node into the `xod/core` library.
`pulse-on-change(graphics)` is necessary for the proper work of the `act` nodes inside quickstart display nodes. 