### PR TITLE
Make the `lineBuffer` of the rendering process immutable.

### DIFF
--- a/workspace/__ardulib__/Graphics/XRender.h
+++ b/workspace/__ardulib__/Graphics/XRender.h
@@ -7,7 +7,7 @@
  */
 class XRenderer {
 public:
-    virtual void renderScanlinePart(int16_t scanline, int16_t xmin, int16_t xmax, uint16_t* lineBuffer) = 0;
+    virtual void renderScanlinePart(int16_t scanline, int16_t xmin, int16_t xmax, const uint16_t* lineBuffer) = 0;
 
     virtual int16_t getScreenWidth() const;
     virtual int16_t getScreenHeight() const;


### PR DESCRIPTION
The `lineBuffer` of the `renderScanlinePart` method should be `const`.
This issue was found in making the LCD display libraies.