### PR TITLE
Fix up the RST pin conditions and the assertion in the ST7735 display library.

### DIFF
--- a/workspace/__ardulib__/ST7735/XST7735.cpp
+++ b/workspace/__ardulib__/ST7735/XST7735.cpp
@@ -114,7 +114,7 @@ void ST7735::begin() {
 
     // Toggle RST low to reset; CS low so it'll listen to us.
     *csport &= ~cspinmask;
-    if (_rst == NOT_A_PIN)
+    if (_rst == 255)
         return;
 
     pinMode(_rst, OUTPUT);

--- a/workspace/__lib__/xod-dev/st7735-display/st7735/patch.cpp
+++ b/workspace/__lib__/xod-dev/st7735-display/st7735/patch.cpp
@@ -35,6 +35,6 @@ template <uint8_t cs, uint8_t dc, uint8_t rst>
 void evaluateTmpl(Context ctx) {
     static_assert(isValidDigitalPort(cs), "must be a valid digital port");
     static_assert(isValidDigitalPort(dc), "must be a valid digital port");
-    static_assert(isValidDigitalPort(rst), "must be a valid digital port");
+    static_assert(rst == 255 || isValidDigitalPort(rst), "must be a valid digital port");
     evaluate(ctx);
 }


### PR DESCRIPTION
- Fix up the wrong `static_assert` for the `st7735` node, add the condition for the `255` default value of the `RST` port. 
- Fix the `_rst` port check at the `XST7735.cpp`. 
By now the "default" `RST` pin value is `D255`.
After complile it is `constexpr uint8_t PIN_VAL = 225` but not `D255`,  so the  `_rst == NOT_A_PIN` check is not working.