### PR TITLE
Fix the scanline boundary condition for the canvas rendering process.

### DIFF
--- a/workspace/__ardulib__/Graphics/XGraphics.inl
+++ b/workspace/__ardulib__/Graphics/XGraphics.inl
@@ -29,7 +29,7 @@ void XGraphics::render(XRenderer* renderer) {
 
     int16_t scanlineCount = (pivotY + canvasBBox.height >= screenHeight) ? screenHeight - pivotY : canvasBBox.height;
 
-    for (int16_t scanline = 0; scanline <= scanlineCount; scanline++) {
+    for (int16_t scanline = 0; scanline < scanlineCount; scanline++) {
         uint16_t buffer[bufferSize];
         renderScanlineRecursively(renderer, scanline, buffer, bufferSize);
         renderer->renderScanlinePart(pivotY + scanline, pivotX, pivotX + bufferSize - 1, buffer);


### PR DESCRIPTION
Fixed the boundary conditions for the canvas rendering process. There was an extra line.
This issue was found rendering the 1-pixel height canvas.