### PR TITLE
Fix throttle node: pass the constant values on setting up

### DIFF
--- a/workspace/__lib__/xod/core/throttle/patch.cpp
+++ b/workspace/__lib__/xod/core/throttle/patch.cpp
@@ -12,8 +12,6 @@ struct State {
 {{ GENERATED_CODE }}
 
 void evaluate(Context ctx) {
-    if (isSettingUp()) return;
-
     auto state = getState(ctx);
     auto inValue = getValue<input_IN>(ctx);
 

--- a/workspace/test/test-core/test-throttle-numbers/patch.test.tsv
+++ b/workspace/test/test-core/test-throttle-numbers/patch.test.tsv
@@ -1,11 +1,12 @@
 __time(ms)	IN	OUT
 // T == 1 second
 0	0	0	// Setting up
-0	1	1
+500	1	0	// Throttling timer is turned on setting up
 1001	1	1
-3000	3	3
+2000	1	1
+3003	3	3
 3100	4	3	// Do not emit new values while throttling in the progress
 3200	5	3
 3500	6	3
 4000	6	3	// Throttle still is in the progress
-4001	6	6	// Emit the last input value when throttle progress finished
+4004	6	6	// Emit the last input value when throttle progress finished


### PR DESCRIPTION
There is no issue, but I've found the bug while testing quick-start nodes for `ws2812`. Without this fix, `throttle` node returns the default value for the data type until the input values do not change.

Tabtests and consumer nodes keep working.