### PR TITLE
Upgrade bs-platform to 7.1.1

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,7 +1,7 @@
 // @see https://reasonml.chat/t/best-practices-for-using-reasonml-in-a-monorepo/161/4
 {
   "name": "xod",
-  "version": "0.22.0",
+  "version": "0.33.0",
   "namespace": false,
   "sources": [
     {

--- a/packages/belt-holes/bsconfig.json
+++ b/packages/belt-holes/bsconfig.json
@@ -2,7 +2,7 @@
 // BuckleScript comes with its own parser for bsconfig.json, which is normal JSON, with the extra support of comments and trailing commas.
 {
   "name": "belt-holes",
-  "version": "0.1.0",
+  "version": "0.29.0",
   "sources": [
     {
       "dir" : "src",

--- a/packages/belt-holes/package.json
+++ b/packages/belt-holes/package.json
@@ -15,8 +15,8 @@
   "license": "AGPL-3.0",
   "main": "src/BeltHoles.bs.js",
   "devDependencies": {
-    "@glennsl/bs-jest": "^0.4.8",
-    "bs-platform": "5.0.0"
+    "@glennsl/bs-jest": "^0.4.9",
+    "bs-platform": "7.1.1"
   },
   "jest": {
     "testMatch": [

--- a/packages/belt-holes/test/BeltHoles_List_jest.re
+++ b/packages/belt-holes/test/BeltHoles_List_jest.re
@@ -9,7 +9,7 @@ describe("groupByString", () =>
     let outMap =
       BeltHoles.List.groupByString(
         ["foo", "Foo", "Bar", "FOO", "bAr", "baz"],
-        String.lowercase,
+        String.lowercase_ascii,
       );
     let expectedMap =
       Map.String.fromArray([|

--- a/packages/xod-arduino/bsconfig.json
+++ b/packages/xod-arduino/bsconfig.json
@@ -1,6 +1,6 @@
 {
   "name": "xod-arduino",
-  "version": "0.22.0",
+  "version": "0.33.0",
   "sources": [
     "src"
   ],

--- a/packages/xod-arduino/package.json
+++ b/packages/xod-arduino/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "babel-plugin-inline-import": "^2.0.4",
-    "bs-platform": "5.0.0",
+    "bs-platform": "7.1.1",
     "chai": "^4.1.2",
     "onchange": "^5.2.0",
     "xod-fs": "^0.33.0"

--- a/packages/xod-client-electron/package.json
+++ b/packages/xod-client-electron/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.16.0",
-    "bs-platform": "5.0.0",
+    "bs-platform": "7.1.1",
     "classnames": "^2.2.5",
     "cpx": "^1.5.0",
     "electron-context-menu": "^0.12.1",

--- a/packages/xod-func-tools/bsconfig.json
+++ b/packages/xod-func-tools/bsconfig.json
@@ -1,6 +1,6 @@
 {
   "name": "xod-func-tools",
-  "version": "0.22.0",
+  "version": "0.32.0",
   "sources": [
     "src"
   ],

--- a/packages/xod-func-tools/package.json
+++ b/packages/xod-func-tools/package.json
@@ -23,7 +23,7 @@
     "sanctuary-type-identifiers": "^2.0.1"
   },
   "devDependencies": {
-    "bs-platform": "5.0.0",
+    "bs-platform": "7.1.1",
     "chai": "^4.1.2"
   },
   "files": [

--- a/packages/xod-func-tools/src/Either.re
+++ b/packages/xod-func-tools/src/Either.re
@@ -2,11 +2,11 @@ type t('left, 'right) = Js.Types.obj_val;
 
 [@bs.module ".."]
 external foldEither : ('left => 'a, 'right => 'a, t('left, 'right)) => 'a =
-  "";
+  "foldEither";
 
-[@bs.module ".."] external eitherLeft : 'left => t('left, 'right) = "";
+[@bs.module ".."] external eitherLeft : 'left => t('left, 'right) = "eitherLeft";
 
-[@bs.module ".."] external eitherRight : 'right => t('left, 'right) = "";
+[@bs.module ".."] external eitherRight : 'right => t('left, 'right) = "eitherRight";
 
 let toResult = either =>
   either

--- a/packages/xod-func-tools/src/Errors.re
+++ b/packages/xod-func-tools/src/Errors.re
@@ -1,1 +1,1 @@
-[@bs.module ".."] external createError : (string, 'a) => Js.Exn.t = "";
+[@bs.module ".."] external createError : (string, 'a) => Js.Exn.t = "createError";

--- a/packages/xod-func-tools/src/Maybe.re
+++ b/packages/xod-func-tools/src/Maybe.re
@@ -1,6 +1,6 @@
 type t('a) = Js.Types.obj_val;
 
-[@bs.module ".."] external foldMaybe : ('b, 'a => 'b, t('a)) => 'b = "";
+[@bs.module ".."] external foldMaybe : ('b, 'a => 'b, t('a)) => 'b = "foldMaybe";
 
 let toOption = maybe =>
   maybe |> foldMaybe(None, justValue => Some(justValue));

--- a/packages/xod-project/bsconfig.json
+++ b/packages/xod-project/bsconfig.json
@@ -1,6 +1,6 @@
 {
   "name": "xod-project",
-  "version": "0.22.0",
+  "version": "0.33.0",
   "sources": [
     "src"
   ],

--- a/packages/xod-project/package.json
+++ b/packages/xod-project/package.json
@@ -31,7 +31,7 @@
     "xod-func-tools": "^0.32.0"
   },
   "devDependencies": {
-    "bs-platform": "5.0.0",
+    "bs-platform": "7.1.1",
     "chai": "^4.1.2",
     "documentation": "^4.0.0-beta12"
   },

--- a/packages/xod-project/src/PatchPath.re
+++ b/packages/xod-project/src/PatchPath.re
@@ -1,6 +1,6 @@
 type t = string;
 
-[@bs.module ".."] external getBaseName : t => string = "";
+[@bs.module ".."] external getBaseName : t => string = "getBaseName";
 
 [@bs.module ".."] external isTerminal : t => bool = "isTerminalPatchPath";
 

--- a/packages/xod-tabtest/bsconfig.json
+++ b/packages/xod-tabtest/bsconfig.json
@@ -2,7 +2,7 @@
 // BuckleScript comes with its own parser for bsconfig.json, which is normal JSON, with the extra support of comments and trailing commas.
 {
   "name": "xod-tabtest",
-  "version": "0.22.0",
+  "version": "0.33.0",
   "sources": [
     {
       "dir" : "src",

--- a/packages/xod-tabtest/package.json
+++ b/packages/xod-tabtest/package.json
@@ -23,8 +23,8 @@
     "xod-project": "^0.33.0"
   },
   "devDependencies": {
-    "@glennsl/bs-jest": "^0.4.8",
-    "bs-platform": "5.0.0",
+    "@glennsl/bs-jest": "^0.4.9",
+    "bs-platform": "7.1.1",
     "ramda": "^0.24.1",
     "xod-fs": "^0.33.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -168,10 +168,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@glennsl/bs-jest@^0.4.8":
-  version "0.4.8"
-  resolved "https://registry.yarnpkg.com/@glennsl/bs-jest/-/bs-jest-0.4.8.tgz#e756ae5b43edc1cdcb4b5592021e50984566dafb"
-  integrity sha512-RU5Bl6Sc9Xdd/BMQUHjEK4qqd3pRfoqzCnU3ncZbNWGndJUHVpuZVbk6IGTqcXSpoaN6eIOppPvLxQP/5yxwKw==
+"@glennsl/bs-jest@^0.4.9":
+  version "0.4.9"
+  resolved "https://registry.yarnpkg.com/@glennsl/bs-jest/-/bs-jest-0.4.9.tgz#a23af2668dda05947ce9c043fd5a7b295e91cef7"
+  integrity sha512-WAqXMcI6WL7JVvGdakBr1tcw8BYWXHrOZfuA1myMkFggzAv24H/OEwyqaU7x+yXd4cJaBUY8v3SjQ3Pnk/zqsg==
   dependencies:
     jest "^24.3.1"
 
@@ -3547,10 +3547,10 @@ browserslist@^2.10.0:
     caniuse-lite "^1.0.30000780"
     electron-to-chromium "^1.3.28"
 
-bs-platform@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.0.tgz#f9fded818bafc3891aeb85eb4e0d95b8d8f8b4d7"
-  integrity sha512-zxLobdIaf/r7go47hOgxcd6C0ANh7MYMEtZNb9Al7JdoekzFZI50F4GpZpP8kMh9Z+M5PoPE1WuryT4S8mT8Kg==
+bs-platform@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.1.1.tgz#ed4032de7ab15158c61d8994680a05393e3ddd74"
+  integrity sha512-ckZHR3J+yxyEKXOBHX8+hfzWG2XX5BxhQ4Iw9lulHFGYdAm9Ep9LgKkIah7G6RYADLmVfTxFE48igvY3kkkl+g==
 
 bser@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
There are a lot of new cool features:
https://bucklescript.github.io/blog/2019/11/18/whats-new-in-7
https://bucklescript.github.io/blog/2020/02/04/release-7-1-0

No reason to stay on older version.
