### PR TITLE
Fix positioning of the ColorPicker widget with right-sided Inspector

### DIFF
--- a/packages/xod-client/src/core/styles/components/PointingPopup.scss
+++ b/packages/xod-client/src/core/styles/components/PointingPopup.scss
@@ -2,6 +2,7 @@
   position: fixed;
   z-index: 15;
   top: 0;
+  left: 0;
   background: $sidebar-color-bg;
   border: 1px solid $chrome-outlines;
   border-radius: 5px;

--- a/packages/xod-client/src/editor/components/inspectorWidgets/ColorPickerWidget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/ColorPickerWidget.jsx
@@ -39,7 +39,7 @@ class ColorPickerWidget extends React.Component {
       <PointingPopup
         className="ColorPickerWidget"
         isVisible={this.props.isVisible}
-        selectorPointingAt={`#${this.props.widgetId}`}
+        selectorPointingAt={this.props.selectorPointingAt}
         hidePopup={this.props.onClose}
       >
         <ColorPicker
@@ -55,6 +55,7 @@ class ColorPickerWidget extends React.Component {
 ColorPickerWidget.propTypes = {
   color: colorPropType,
   isVisible: PropTypes.bool.isRequired,
+  selectorPointingAt: PropTypes.string,
   widgetId: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,

--- a/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/ColorPinWidget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/pinWidgets/ColorPinWidget.jsx
@@ -113,6 +113,7 @@ class ColorPinWidget extends React.Component {
         </span>
         <ColorPickerWidget
           widgetId={this.props.elementId}
+          selectorPointingAt={`.PinWidget[data-pinlabel="${this.props.label}"]`}
           isVisible={
             this.props.visibleColorPickerWidgetId === this.props.elementId
           }


### PR DESCRIPTION
It fixes #1968 