### PR TITLE
Fix scrolling of Project Browser and Inspector when they are alone in sidebar

### DIFF
--- a/packages/xod-client/src/core/assets/index.html
+++ b/packages/xod-client/src/core/assets/index.html
@@ -7,6 +7,9 @@
         body, #root {
             padding: 0;
             margin: 0;
+            overflow: hidden;
+            width: 100%;
+            height: 100%;
         }
 
         .loading {

--- a/packages/xod-client/src/core/styles/components/Editor.scss
+++ b/packages/xod-client/src/core/styles/components/Editor.scss
@@ -5,6 +5,8 @@
   flex-direction: row;
   align-items: stretch;
 
+  height: 100%;
+
   &.leftSidebarMaximized, &.rightSidebarMaximized {
     .Workarea {
       max-width: calc(100% - #{$sidebar-width});

--- a/packages/xod-client/src/core/styles/components/Inspector.scss
+++ b/packages/xod-client/src/core/styles/components/Inspector.scss
@@ -1,6 +1,7 @@
 .Inspector-container {
   display: flex;
   flex-grow: 1;
+  height: 100%;
 }
 .Inspector {
   flex-grow: 1;

--- a/packages/xod-client/src/core/styles/components/ProjectBrowser.scss
+++ b/packages/xod-client/src/core/styles/components/ProjectBrowser.scss
@@ -1,6 +1,7 @@
 .ProjectBrowser-container {
   display: flex;
   flex-grow: 1;
+  height: 100%;
 }
 .ProjectBrowser {
   flex-grow: 1;


### PR DESCRIPTION
There is no issue, but this is an old bug.