### PR TITLE
Fix ST7735 and Graphics libs to be compatible with ESP8266 boards.

### DIFF
--- a/workspace/__ardulib__/Graphics/XGraphics.inl
+++ b/workspace/__ardulib__/Graphics/XGraphics.inl
@@ -22,8 +22,8 @@ void XGraphics::render(XRenderer* renderer) {
     int16_t screenWidth = renderer->getScreenWidth();
     int16_t screenHeight = renderer->getScreenHeight();
 
-    int16_t pivotX = max(0, canvasBBox.pivot.x);
-    int16_t pivotY = max(0, canvasBBox.pivot.y);
+    int16_t pivotX = max(0, (int)canvasBBox.pivot.x);
+    int16_t pivotY = max(0, (int)canvasBBox.pivot.y);
 
     size_t bufferSize = (pivotX + canvasBBox.width >= screenWidth) ? screenWidth - pivotX : canvasBBox.width;
 

--- a/workspace/__ardulib__/ST7735/XST7735.h
+++ b/workspace/__ardulib__/ST7735/XST7735.h
@@ -249,7 +249,7 @@ private:
     SPISettings spisettings;
 #endif // SPI_HAS_TRANSACTION
 
-#if defined(ARDUINO_ARCH_SAM) || defined(__ARDUINO_ARC__) || defined(ARDUINO_ARCH_STM32)
+#if defined(ARDUINO_ARCH_SAM) || defined(__ARDUINO_ARC__) || defined(ARDUINO_ARCH_STM32) || defined(ARDUINO_ARCH_ESP8266)
     volatile uint32_t *csport, *rsport;
     uint32_t _cs;
     uint32_t _rs;


### PR DESCRIPTION
- At the `XST7735.h` add the `ARDUINO_ARCH_ESP8266` condition, because ESP8266 has 4-byte ports.
- For ESP8266 math functions `min` and `max` both arguments must be explicitly specified of the same type - `max(int, int)`, `min(short int, short int)`. Added type casting to make expressions like `max(0, x)` or `min(y, 1)` compile.