### PR TITLE
Add the rotation of the screen for the ST7735 displays.

### DIFF
--- a/workspace/__ardulib__/ST7735/XST7735.cpp
+++ b/workspace/__ardulib__/ST7735/XST7735.cpp
@@ -9,8 +9,8 @@ ST7735::ST7735(uint8_t cs, uint8_t dc, uint8_t rst) {
     _cs = cs;
     _rs = dc;
     _rst = rst;
-    _width = ST7735_TFTWIDTH;
-    _height = ST7735_TFTHEIGHT;
+    _width = ST7735_TFTWIDTH_128;
+    _height = ST7735_TFTHEIGHT_160;
 }
 
 void ST7735::writeCmd(uint8_t cmd) {
@@ -85,6 +85,38 @@ void ST7735::commandList(const uint8_t* addr) {
             delay(ms);
         }
     }
+}
+
+void ST7735::setRotation(uint8_t rotation) {
+    uint8_t madctl = 0;
+
+    switch (rotation) {
+    case 0:
+        madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY | ST7735_MADCTL_BGR;
+        _height = ST7735_TFTHEIGHT_160;
+        _width = ST7735_TFTWIDTH_128;
+        break;
+    case 1:
+        madctl = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST7735_MADCTL_BGR;
+        _width = ST7735_TFTHEIGHT_160;
+        _height = ST7735_TFTWIDTH_128;
+        break;
+    case 2:
+        madctl = ST7735_MADCTL_BGR;
+        _height = ST7735_TFTHEIGHT_160;
+        _width = ST7735_TFTWIDTH_128;
+        break;
+    case 3:
+        madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MV | ST7735_MADCTL_BGR;
+        _width = ST7735_TFTHEIGHT_160;
+        _height = ST7735_TFTWIDTH_128;
+        break;
+    default:
+        break;
+    }
+
+    writeCmd(ST77XX_MADCTL);
+    writeData(madctl);
 }
 
 void ST7735::begin() {

--- a/workspace/__ardulib__/ST7735/XST7735.h
+++ b/workspace/__ardulib__/ST7735/XST7735.h
@@ -7,8 +7,16 @@
 
 #define DELAY 0x80
 
-#define ST7735_TFTWIDTH 128
-#define ST7735_TFTHEIGHT 160
+#define ST7735_TFTWIDTH_128 128
+#define ST7735_TFTHEIGHT_160 160
+
+#define ST7735_MADCTL_BGR 0x08
+#define ST7735_MADCTL_MH 0x04
+
+#define ST77XX_MADCTL_MX 0x40
+#define ST77XX_MADCTL_MY 0x80
+#define ST77XX_MADCTL_MV 0x20
+#define ST77XX_MADCTL 0x36
 
 #define ST7735_NOP 0x00
 #define ST7735_SWRESET 0x01
@@ -226,6 +234,8 @@ public:
 
     void renderScanlinePart(int16_t scanline, int16_t xmin, int16_t xmax, const uint16_t* lineBuffer) override;
 
+    void setRotation(uint8_t rotation);
+
     int16_t getScreenWidth() const {
         return _width;
     }
@@ -271,7 +281,7 @@ private:
 
     uint8_t _colstart;
     uint8_t _rowstart;
-#endif // ARDUINO_ARCH_SAM || __ARDUINO_ARC__ || ARDUINO_ARCH_STM32
+#endif // ARDUINO_ARCH_SAM || __ARDUINO_ARC__ || ARDUINO_ARCH_STM32 || || defined(ARDUINO_ARCH_ESP8266)
 };
 
 #endif // X_ST7735_H

--- a/workspace/__lib__/xod-dev/st7735-display/rotate/patch.cpp
+++ b/workspace/__lib__/xod-dev/st7735-display/rotate/patch.cpp
@@ -1,0 +1,21 @@
+
+struct State {};
+
+// clang-format off
+{{ GENERATED_CODE }}
+// clang-format on
+
+void evaluate(Context ctx) {
+    auto dev = getValue<input_DEV>(ctx);
+
+    if (isSettingUp())
+        emitValue<output_DEVU0027>(ctx, dev);
+
+    if (!isInputDirty<input_DO>(ctx))
+        return;
+
+    uint8_t rotation = getValue<input_R>(ctx);
+    dev->setRotation(rotation);
+
+    emitValue<output_DONE>(ctx, 1);
+}

--- a/workspace/__lib__/xod-dev/st7735-display/rotate/patch.xodp
+++ b/workspace/__lib__/xod-dev/st7735-display/rotate/patch.xodp
@@ -1,0 +1,72 @@
+{
+  "description": "Rotates the screen of the display to one of four positions: 0° vertical, 90° horizontal, 180° vertical, and 270° horizontal.",
+  "nodes": [
+    {
+      "description": "The display device.",
+      "id": "ByVf60P0VI",
+      "label": "DEV'",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 2
+      },
+      "type": "@/output-st7735"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "0d"
+      },
+      "description": "Rotation value. Sets the rotation angle. Lies in the range [0, 3] where: 0 is 0° vertical position; 1 is 90° horizontal position; 2 is 180° vertical position; 3 is 270° horizontal position.",
+      "id": "HJiaCwCEI",
+      "label": "R",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-byte"
+    },
+    {
+      "description": "Pulses when the screen rotation is done.",
+      "id": "rJMG60wC4U",
+      "label": "DONE",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/output-pulse"
+    },
+    {
+      "description": "The display device.",
+      "id": "rkxGaRwR4U",
+      "label": "DEV",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 0
+      },
+      "type": "@/input-st7735"
+    },
+    {
+      "description": "Triggers a new screen rotation.",
+      "id": "rkzpRw0EL",
+      "label": "DO",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "id": "ryZzpCv048",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    }
+  ]
+}


### PR DESCRIPTION
Add the `rotate` node that allows a user to change the display rotation.
Can be rotated in real-time;

0 degrees vertical position;
90 degrees horizontal position;
180 degrees vertical position;
270 degrees horizontal position.