### PR TITLE
Pass millis() from JS into Simulation WASM

### DIFF
--- a/packages/xod-client/src/workers/wasm.worker.js
+++ b/packages/xod-client/src/workers/wasm.worker.js
@@ -56,6 +56,17 @@ const Serial = {
     }),
 };
 
+// Time object provides a way to pass the millis() into simulation
+// It used only in Simulation, because Tabtests may mock the time
+// for testing purposes.
+const Time = {
+  value: 0,
+  get: () => Time.value,
+  set: newT => {
+    Time.value = newT;
+  },
+};
+
 let wasmInstance;
 _self.onmessage = e => {
   switch (e.data.type) {
@@ -92,6 +103,11 @@ _self.onmessage = e => {
       // eslint-disable-next-line no-undef
       wasmInstance = new Module(opts);
       wasmInstance.Serial = Serial;
+      wasmInstance.Time = Time;
+      // Make Time updating each millisecond
+      setInterval(() => {
+        wasmInstance.Time.value += 1;
+      }, 1);
       return;
     }
     case 'serial:send': {


### PR DESCRIPTION
- It optimizes the performance of patterns like: `do { ... } while (millis() < timeout);`
   For example, in the [worldtimeapi.xodball](https://github.com/xodio/xod/files/4627824/worldtimeapi.xodball.zip) the timer indicates a time to read the whole response from the server. It was about 33.5 seconds in the simulation, now it takes about 9.5 seconds. (3.5x faster).
    Meanwhile, the same patch still works faster on the MCU, it takes about 4.5 seconds on Uno and ESP8266. 😞

- Replaces a no-op `delay` with something like a real delay, which blocks other code until the delay has ended up.

To test the example above, you need to cherry-pick this commit on top of the https://github.com/xodio/xod/tree/feat-1974-tethering-internet branch, which provides a tethering-inet. And use the staging server (`XOD_HOSTNAME=xod.show`), until the changes on the server-side were not released to the production server.