### PR TITLE
Updating arduino-cli to 0.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ defs:
     step-install-arduino-cli-on-linux: &step-install-arduino-cli-on-linux
       name: Install arduino-cli
       command: |
-        curl -L -s --create-dirs -o "$HOME/arduino-cli.tar.bz2" "https://github.com/arduino/arduino-cli/releases/download/0.10.0/arduino-cli_0.10.0_Linux_64bit.tar.gz" \
+        curl -L -s --create-dirs -o "$HOME/arduino-cli.tar.gz" "https://github.com/arduino/arduino-cli/releases/download/0.10.0/arduino-cli_0.10.0_Linux_64bit.tar.gz" \
         && tar xvjf "$HOME/arduino-cli.tar.gz" -C "$HOME" \
         && cp "$HOME/arduino-cli" "./packages/xod-client-electron/arduino-cli" \
         && mkdir "/tmp/arduino-cli" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ defs:
       name: Install arduino-cli
       command: |
         curl -L -s --create-dirs -o "$HOME/arduino-cli.tar.gz" "https://github.com/arduino/arduino-cli/releases/download/0.10.0/arduino-cli_0.10.0_macOS_64bit.tar.gz" \
-        && tar xvjf "$HOME/arduino-cli.tar.gz" -C "$HOME" \
+        && tar xvf "$HOME/arduino-cli.tar.gz" -C "$HOME" \
         && cp "$HOME/arduino-cli" "./packages/xod-client-electron/arduino-cli" \
         && mkdir "/tmp/arduino-cli" \
         && cp "$HOME/arduino-cli" "/tmp/arduino-cli/arduino-cli"
@@ -42,7 +42,7 @@ defs:
       name: Install arduino-cli
       command: |
         curl -L -s --create-dirs -o "$HOME/arduino-cli.tar.gz" "https://github.com/arduino/arduino-cli/releases/download/0.10.0/arduino-cli_0.10.0_Linux_64bit.tar.gz" \
-        && tar xvjf "$HOME/arduino-cli.tar.gz" -C "$HOME" \
+        && tar xvf "$HOME/arduino-cli.tar.gz" -C "$HOME" \
         && cp "$HOME/arduino-cli" "./packages/xod-client-electron/arduino-cli" \
         && mkdir "/tmp/arduino-cli" \
         && cp "$HOME/arduino-cli" "/tmp/arduino-cli/arduino-cli"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,8 @@ defs:
     step-install-arduino-cli-on-mac: &step-install-arduino-cli-on-mac
       name: Install arduino-cli
       command: |
-        curl -s --create-dirs -o "$HOME/arduino-cli.zip" "http://downloads.arduino.cc/PR/arduino-cli/arduino-cli-25-PR91-osx.zip" \
-        && unzip "$HOME/arduino-cli.zip" -d "$HOME" \
-        && mv "$HOME/arduino-cli-25-PR91-osx" "$HOME/arduino-cli" \
+        curl -L -s --create-dirs -o "$HOME/arduino-cli.tar.gz" "https://github.com/arduino/arduino-cli/releases/download/0.10.0/arduino-cli_0.10.0_macOS_64bit.tar.gz" \
+        && tar xvjf "$HOME/arduino-cli.tar.gz" -C "$HOME" \
         && cp "$HOME/arduino-cli" "./packages/xod-client-electron/arduino-cli" \
         && mkdir "/tmp/arduino-cli" \
         && cp "$HOME/arduino-cli" "/tmp/arduino-cli/arduino-cli"
@@ -42,9 +41,8 @@ defs:
     step-install-arduino-cli-on-linux: &step-install-arduino-cli-on-linux
       name: Install arduino-cli
       command: |
-        curl -s --create-dirs -o "$HOME/arduino-cli.tar.bz2" "http://downloads.arduino.cc/PR/arduino-cli/arduino-cli-25-PR91-linux64.tar.bz2" \
-        && tar xvjf "$HOME/arduino-cli.tar.bz2" -C "$HOME" \
-        && mv "$HOME/arduino-cli-25-PR91-linux64" "$HOME/arduino-cli" \
+        curl -L -s --create-dirs -o "$HOME/arduino-cli.tar.bz2" "https://github.com/arduino/arduino-cli/releases/download/0.10.0/arduino-cli_0.10.0_Linux_64bit.tar.gz" \
+        && tar xvjf "$HOME/arduino-cli.tar.gz" -C "$HOME" \
         && cp "$HOME/arduino-cli" "./packages/xod-client-electron/arduino-cli" \
         && mkdir "/tmp/arduino-cli" \
         && cp "$HOME/arduino-cli" "/tmp/arduino-cli/arduino-cli"

--- a/packages/arduino-cli/README.md
+++ b/packages/arduino-cli/README.md
@@ -11,10 +11,10 @@ A javascript wrapper over the [arduino-cli](https://github.com/arduino/arduino-c
 3.  Create an instance and pass the path to the installed `arduino-cli` and config:
     ```js
     const cli = arduinoCli('/bin/arduino-cli', {
-      directories:{
+      directories: {
         user: '~/arduino-cli/sketches',
         data: '~/arduino-cli/data',
-      }
+      },
     });
     ```
     It will create a config file for the `arduino-cli` in your OS temp directory and pass it to any command you'll call later.

--- a/packages/arduino-cli/README.md
+++ b/packages/arduino-cli/README.md
@@ -11,8 +11,10 @@ A javascript wrapper over the [arduino-cli](https://github.com/arduino/arduino-c
 3.  Create an instance and pass the path to the installed `arduino-cli` and config:
     ```js
     const cli = arduinoCli('/bin/arduino-cli', {
-      arduino_data: '~/arduino-cli/data',
-      sketchbook_path: '~/arduino-cli/sketches',
+      directories:{
+        user: '~/arduino-cli/sketches',
+        data: '~/arduino-cli/data',
+      }
     });
     ```
     It will create a config file for the `arduino-cli` in your OS temp directory and pass it to any command you'll call later.

--- a/packages/arduino-cli/src/config.js
+++ b/packages/arduino-cli/src/config.js
@@ -7,8 +7,10 @@ import YAML from 'yamljs';
 export const ADDITIONAL_URLS_PATH = ['board_manager', 'additional_urls'];
 
 const getDefaultConfig = configDir => ({
-  sketchbook_path: resolve(configDir, 'sketchbook'),
-  arduino_data: resolve(configDir, 'data'),
+  directories: {
+    user: resolve(configDir, 'sketchbook'),
+    data: resolve(configDir, 'data'),
+  },
 });
 
 const stringifyConfig = cfg => YAML.stringify(cfg, 10, 2);
@@ -21,8 +23,8 @@ export const saveConfig = (configPath, config) => {
   fse.writeFileSync(configPath, yamlString);
 
   // Ensure that sketchbook and data directories are exist
-  fse.ensureDirSync(config.sketchbook_path);
-  fse.ensureDirSync(config.arduino_data);
+  fse.ensureDirSync(config.directories.user);
+  fse.ensureDirSync(config.directories.data);
 
   return {
     config,
@@ -33,9 +35,10 @@ export const saveConfig = (configPath, config) => {
 // :: Object -> { config: Object, path: Path }
 export const configure = inputConfig => {
   const configDir = fse.mkdtempSync(resolve(tmpdir(), 'arduino-cli'));
-  const configPath = resolve(configDir, '.cli-config.yml');
+  const configPath = resolve(configDir, 'arduino-cli.yaml');
   const config = inputConfig || getDefaultConfig(configDir);
-  return saveConfig(configPath, config);
+  const saved = saveConfig(configPath, config);
+  return { config: saved.config, path: saved.path, dir: configDir };
 };
 
 // :: Path -> [URL] -> Promise [URL] Error

--- a/packages/arduino-cli/src/index.js
+++ b/packages/arduino-cli/src/index.js
@@ -13,6 +13,7 @@ import parseProgressLog from './parseProgressLog';
 const spawn = (bin, args, options) =>
   promisifyChildProcess(crossSpawn(bin, args, options), {
     encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
   });
 
 const noop = () => {};

--- a/packages/arduino-cli/src/index.js
+++ b/packages/arduino-cli/src/index.js
@@ -37,7 +37,10 @@ const ArduinoCli = (pathToBin, config = null) => {
   };
 
   const runWithProgress = async (onProgress, args) => {
-    const spawnArgs = R.concat([`--config-file=${configDir}`], args);
+    const spawnArgs = R.compose(
+      R.concat([`--config-file=${configDir}`]),
+      R.reject(R.isEmpty)
+    )(args);
     const proc = spawn(pathToBin, spawnArgs, {
       stdio: ['inherit', 'pipe', 'pipe'],
     });
@@ -94,7 +97,7 @@ const ArduinoCli = (pathToBin, config = null) => {
       runWithProgress(onProgress, [
         'compile',
         `--fqbn=${fqbn}`,
-        `${verbose ? '--verbose' : ''}`,
+        verbose ? '--verbose' : '',
         sketch(sketchName),
       ]),
     upload: (onProgress, port, fqbn, sketchName, verbose = false) =>
@@ -102,7 +105,7 @@ const ArduinoCli = (pathToBin, config = null) => {
         'upload',
         `--fqbn=${fqbn}`,
         `--port=${port}`,
-        `${verbose ? '--verbose' : ''}`,
+        verbose ? '--verbose' : '',
         '-t',
         sketch(sketchName),
       ]),

--- a/packages/arduino-cli/src/index.js
+++ b/packages/arduino-cli/src/index.js
@@ -23,7 +23,10 @@ const noop = () => {};
  * @param {Object} config Plain-object representation of `.cli-config.yml`
  */
 const ArduinoCli = (pathToBin, config = null) => {
-  let { path: configPath, config: cfg } = configure(config);
+  const configureVal = configure(config);
+  let configPath = configureVal.path;
+  let cfg = configureVal.config;
+  const configDir = configureVal.dir;
   let runningProcesses = [];
 
   const appendProcess = proc => {
@@ -34,7 +37,7 @@ const ArduinoCli = (pathToBin, config = null) => {
   };
 
   const runWithProgress = async (onProgress, args) => {
-    const spawnArgs = R.concat([`--config-file=${configPath}`], args);
+    const spawnArgs = R.concat([`--config-file=${configDir}`], args);
     const proc = spawn(pathToBin, spawnArgs, {
       stdio: ['inherit', 'pipe', 'pipe'],
     });
@@ -47,23 +50,21 @@ const ArduinoCli = (pathToBin, config = null) => {
     return proc.then(R.prop('stdout'));
   };
 
-  const sketch = name => resolve(cfg.sketchbook_path, name);
+  const sketch = name => resolve(cfg.directories.user, name);
 
   const runAndParseJson = args => runWithProgress(noop, args).then(JSON.parse);
 
   const listCores = () =>
     runWithProgress(noop, ['core', 'list', '--format=json'])
-      .then(R.when(R.isEmpty, R.always('{}')))
-      .then(JSON.parse)
-      .then(R.propOr([], 'Platforms'))
-      .then(R.map(R.over(R.lensProp('ID'), R.replace(/(@.+)$/, ''))));
+      .then(R.when(R.isEmpty, R.always('[]')))
+      .then(JSON.parse);
 
   const listBoardsWith = (listCmd, boardsGetter) =>
     Promise.all([
       listCores(),
       runAndParseJson(['board', listCmd, '--format=json']),
     ]).then(([cores, boards]) =>
-      patchBoardsWithOptions(cfg.arduino_data, cores, boardsGetter(boards))
+      patchBoardsWithOptions(cfg.directories.data, cores, boardsGetter(boards))
     );
 
   const getConfig = () =>
@@ -87,7 +88,8 @@ const ArduinoCli = (pathToBin, config = null) => {
     },
     listConnectedBoards: () => listBoardsWith('list', R.prop('serialBoards')),
     listInstalledBoards: () => listBoardsWith('listall', R.prop('boards')),
-    listAvailableBoards: () => listAvailableBoards(getConfig, cfg.arduino_data),
+    listAvailableBoards: () =>
+      listAvailableBoards(getConfig, cfg.directories.data),
     compile: (onProgress, fqbn, sketchName, verbose = false) =>
       runWithProgress(onProgress, [
         'compile',
@@ -109,7 +111,7 @@ const ArduinoCli = (pathToBin, config = null) => {
         // TODO:
         // Get rid of `remove` the staging directory when
         // arduino-cli fix issue https://github.com/arduino/arduino-cli/issues/43
-        remove(resolve(cfg.arduino_data, 'staging')).then(() =>
+        remove(resolve(cfg.directories.data, 'staging')).then(() =>
           runWithProgress(parseProgressLog(onProgress), [
             'core',
             'download',
@@ -120,7 +122,7 @@ const ArduinoCli = (pathToBin, config = null) => {
         // TODO:
         // Get rid of `remove` the staging directory when
         // arduino-cli fix issue https://github.com/arduino/arduino-cli/issues/43
-        remove(resolve(cfg.arduino_data, 'staging')).then(() =>
+        remove(resolve(cfg.directories.data, 'staging')).then(() =>
           runWithProgress(parseProgressLog(onProgress), [
             'core',
             'install',
@@ -141,7 +143,7 @@ const ArduinoCli = (pathToBin, config = null) => {
     version: () => runAndParseJson(['version']).then(R.prop('version')),
     createSketch: sketchName =>
       runWithProgress(noop, ['sketch', 'new', sketchName]).then(
-        R.always(resolve(cfg.sketchbook_path, sketchName, `${sketchName}.ino`))
+        R.always(resolve(cfg.directories.user, sketchName, `${sketchName}.ino`))
       ),
     setPackageIndexUrls: urls => setPackageIndexUrls(configPath, urls),
   };

--- a/packages/arduino-cli/src/index.js
+++ b/packages/arduino-cli/src/index.js
@@ -142,7 +142,7 @@ const ArduinoCli = (pathToBin, config = null) => {
     },
     version: () => runAndParseJson(['version']).then(R.prop('version')),
     createSketch: sketchName =>
-      runWithProgress(noop, ['sketch', 'new', sketchName]).then(
+      runWithProgress(noop, ['sketch', 'new', sketch(sketchName)]).then(
         R.always(resolve(cfg.directories.user, sketchName, `${sketchName}.ino`))
       ),
     setPackageIndexUrls: urls => setPackageIndexUrls(configPath, urls),

--- a/packages/arduino-cli/src/optionParser.js
+++ b/packages/arduino-cli/src/optionParser.js
@@ -146,6 +146,7 @@ const parseDisableRts = R.compose(
 
 /**
  * Loads `boards.txt` of installed cores and patches Board objects with options.
+ * Normalises 'FQBN' to 'fqbn' for compatability across xod packages.
  *
  * :: Path -> [Core] -> [InstalledBoard | AvailableBoard] -> [InstalledBoard | AvailableBoard]
  */
@@ -170,9 +171,10 @@ export const patchBoardsWithOptions = R.curry(
     );
 
     return R.map(board => {
-      if (!R.has('fqbn', board)) return board;
+      if (!R.has('FQBN', board)) return board;
 
-      const fqbnParts = board.fqbn.split(':');
+      const fqbn = board.FQBN;
+      const fqbnParts = fqbn.split(':');
       const coreId = R.compose(R.join(':'), R.init)(fqbnParts);
       const boardId = R.last(fqbnParts);
 
@@ -192,8 +194,9 @@ export const patchBoardsWithOptions = R.curry(
         {
           options,
           disableRts,
+          fqbn,
         },
-        board
+        R.omit(['FQBN'], board)
       );
     }, boards);
   }

--- a/packages/arduino-cli/test-func/index.spec.js
+++ b/packages/arduino-cli/test-func/index.spec.js
@@ -21,8 +21,10 @@ describe('Arduino Cli', () => {
 
   const tmpDir = resolve(__dirname, 'tmp');
   const cfg = {
-    sketchbook_path: resolve(tmpDir, 'sketchbook'),
-    arduino_data: resolve(tmpDir, 'data'),
+    directories: {
+      user: resolve(tmpDir, 'sketchbook'),
+      data: resolve(tmpDir, 'data'),
+    },
   };
 
   describe('Initializes arduino-cli', () => {
@@ -31,15 +33,15 @@ describe('Arduino Cli', () => {
       arduinoCli(PATH_TO_CLI)
         .dumpConfig()
         .then(res => {
-          assert.include(res.sketchbook_path, '/sketchbook');
-          assert.include(res.arduino_data, '/data');
+          assert.include(res.directories.user, '/sketchbook');
+          assert.include(res.directories.data, '/data');
         }));
     it('with custom config', () =>
       arduinoCli(PATH_TO_CLI, cfg)
         .dumpConfig()
         .then(res => {
-          assert.strictEqual(res.sketchbook_path, cfg.sketchbook_path);
-          assert.strictEqual(res.arduino_data, cfg.arduino_data);
+          assert.strictEqual(res.directories.user, cfg.directories.user);
+          assert.strictEqual(res.directories.data, cfg.directories.data);
         }));
   });
 
@@ -49,16 +51,16 @@ describe('Arduino Cli', () => {
       const cli = arduinoCli(PATH_TO_CLI, cfg);
       const curConf = await cli.dumpConfig();
 
-      assert.strictEqual(curConf.sketchbook_path, cfg.sketchbook_path);
-      assert.strictEqual(curConf.arduino_data, cfg.arduino_data);
+      assert.strictEqual(curConf.directories.user, cfg.directories.user);
+      assert.strictEqual(curConf.directories.data, cfg.directories.data);
 
       const newDataDir = resolve(tmpDir, 'newData');
-      const newConf = R.assoc('arduino_data', newDataDir, curConf);
+      const newConf = R.assocPath(['directories', 'data'], newDataDir, curConf);
       cli.updateConfig(newConf);
       const updatedConf = await cli.dumpConfig();
 
-      assert.strictEqual(updatedConf.sketchbook_path, cfg.sketchbook_path);
-      assert.strictEqual(updatedConf.arduino_data, newDataDir);
+      assert.strictEqual(updatedConf.directories.user, cfg.directories.user);
+      assert.strictEqual(updatedConf.directories.data, newDataDir);
 
       return cli;
     });
@@ -83,7 +85,7 @@ describe('Arduino Cli', () => {
         .then(() => cli.core.updateIndex())
         .then(() =>
           fse.pathExists(
-            resolve(cfg.arduino_data, 'package_esp8266com_index.json')
+            resolve(cfg.directories.data, 'package_esp8266com_index.json')
           )
         )
         .then(assert.isTrue);
@@ -102,7 +104,7 @@ describe('Arduino Cli', () => {
       cli.core
         .updateIndex()
         .then(() =>
-          fse.pathExists(resolve(cfg.arduino_data, 'package_index.json'))
+          fse.pathExists(resolve(cfg.directories.data, 'package_index.json'))
         )
         .then(assert.isTrue));
     it('Returns empty list of installed packages', () =>
@@ -121,7 +123,7 @@ describe('Arduino Cli', () => {
         .then(() =>
           fse.pathExists(
             resolve(
-              cfg.arduino_data,
+              cfg.directories.data,
               'packages',
               'arduino',
               'hardware',

--- a/packages/arduino-cli/test/optionParser.spec.js
+++ b/packages/arduino-cli/test/optionParser.spec.js
@@ -96,15 +96,15 @@ const cpuFrequencyOptions = {
 const boards = [
   {
     name: 'Generic ESP8266 Module',
-    fqbn: 'esp8266:esp8266:generic',
+    FQBN: 'esp8266:esp8266:generic',
   },
   {
     name: 'Amperka WiFi Slot',
-    fqbn: 'esp8266:esp8266:wifi_slot',
+    FQBN: 'esp8266:esp8266:wifi_slot',
   },
   {
     name: 'Arduino Due',
-    fqbn: 'arduino:sam:due',
+    FQBN: 'arduino:sam:due',
   },
   {
     name: 'Arduino/Genuino Uno (not installed)',
@@ -114,11 +114,11 @@ const boards = [
   },
   {
     name: 'Generic Fictional Board',
-    fqbn: 'fictional:fake:generic',
+    FQBN: 'fictional:fake:generic',
   },
   {
     name: 'Another Fictional Board',
-    fqbn: 'fictional:fake:another_one',
+    FQBN: 'fictional:fake:another_one',
   },
 ];
 

--- a/packages/xod-cli/test-func/installArch.spec.js
+++ b/packages/xod-cli/test-func/installArch.spec.js
@@ -28,7 +28,7 @@ const its = wd => {
         assert.equal(ctx.stdout, '', 'stdout must be empty');
         assert.include(
           ctx.stderr,
-          'Error: invalid item',
+          'Invalid argument passed: invalid item',
           'stderr must contain error'
         );
         assert.notEqual(process.exitCode, 0, 'exit code must be non-zero');

--- a/packages/xod-deploy-bin/src/arduinoCli.js
+++ b/packages/xod-deploy-bin/src/arduinoCli.js
@@ -338,8 +338,10 @@ export const createCli = async (
   }
 
   const cli = arduinoCli(arduinoCliPath, {
-    arduino_data: packagesDirPath,
-    sketchbook_path: sketchDir,
+    directories: {
+      user: sketchDir,
+      data: packagesDirPath,
+    },
   });
 
   await syncAdditionalPackages(wsPath, cli);
@@ -348,7 +350,7 @@ export const createCli = async (
 };
 
 /**
- * Updates path to the `arduino_data` in the arduino-cli `.cli-config.yml`
+ * Updates path to the `directories.data` in the arduino-cli `arduino-cli.yaml`
  * and prepares `__packages__` directory in the user's workspace if needed.
  *
  * We have to call this function when user changes workspace to make all
@@ -362,7 +364,11 @@ export const switchWorkspace = async (cli, wsBundledPath, newWsPath) => {
     wsBundledPath,
     newWsPath
   );
-  const newConfig = R.assoc('arduino_data', packagesDirPath, oldConfig);
+  const newConfig = R.assocPath(
+    ['directories', 'data'],
+    packagesDirPath,
+    oldConfig
+  );
   const result = cli.updateConfig(newConfig);
   await syncAdditionalPackages(newWsPath, cli);
   return result;

--- a/packages/xod-deploy-bin/src/arduinoCli.js
+++ b/packages/xod-deploy-bin/src/arduinoCli.js
@@ -5,7 +5,6 @@ import * as R from 'ramda';
 import * as fse from 'fs-extra';
 import arduinoCli from 'arduino-cli';
 import { createError } from 'xod-func-tools';
-import * as cpx from 'cpx';
 
 import {
   ARDUINO_LIBRARIES_DIRNAME,
@@ -61,20 +60,16 @@ const getLibsDir = p => path.join(p, ARDUINO_LIBRARIES_DIRNAME);
 const parseExtraTxtContent = R.compose(R.reject(R.isEmpty), R.split(/\r\n|\n/));
 
 // :: Path -> Path -> Promise Path -> Error
-const copy = async (from, to) =>
-  new Promise((resolve, reject) => {
-    cpx.copy(from, to, err => {
-      if (err) return reject(err);
-      return resolve(to);
-    });
+const copy = (from, to) =>
+  fse.pathExists(from).then(exist => {
+    if (exist) return fse.copy(from, to).then(() => to);
+    return fse.ensureDir(to).then(() => to);
   });
-
-const recWildcard = p => path.join(p, '**');
 
 // :: Path -> Path -> Path -> Promise Path Error
 const copyLibraries = async (bundledLibDir, userLibDir, sketchbookLibDir) => {
-  await copy(recWildcard(bundledLibDir), sketchbookLibDir);
-  await copy(recWildcard(userLibDir), sketchbookLibDir);
+  await copy(bundledLibDir, sketchbookLibDir);
+  await copy(userLibDir, sketchbookLibDir);
   return sketchbookLibDir;
 };
 
@@ -137,7 +132,7 @@ const copyPackageIndexes = async (wsBundledPath, wsPackageDir) => {
 const copyLibrariesToSketchbook = async (cli, wsBundledPath, ws) => {
   const sketchbookLibDir = await R.composeP(
     p => path.join(p, ARDUINO_CLI_LIBRARIES_DIRNAME),
-    R.prop('sketchbook_path'),
+    R.path(['directories', 'user']),
     cli.dumpConfig
   )();
   const bundledLibPath = getLibsDir(wsBundledPath);

--- a/packages/xod-deploy-bin/src/arduinoCli.js
+++ b/packages/xod-deploy-bin/src/arduinoCli.js
@@ -518,8 +518,7 @@ export const compile = async (onProgress, cli, payload) => {
           tab: 'compiler',
         }),
       payload.board.fqbn,
-      sketchName,
-      true
+      sketchName
     )
     .catch(wrapCompileError);
 

--- a/tools/install-arduinocli.ps1
+++ b/tools/install-arduinocli.ps1
@@ -1,8 +1,7 @@
 # Install arduino-cli
 
-Invoke-RestMethod -Uri "http://downloads.arduino.cc/PR/arduino-cli/arduino-cli-25-PR91-windows.zip" -Method GET -OutFile "$env:HOME/arduino-cli.zip"
+Invoke-RestMethod -Uri "https://github.com/arduino/arduino-cli/releases/download/0.10.0/arduino-cli_0.10.0_Windows_64bit.zip" -Method GET -OutFile "$env:HOME/arduino-cli.zip"
 unzip "$env:HOME/arduino-cli.zip" -d "$env:HOME"
-mv "$env:HOME/arduino-cli-25-PR91-windows.exe" "$env:HOME/arduino-cli.exe"
 copy "$env:HOME/arduino-cli.exe" "./packages/xod-client-electron/arduino-cli.exe"
 
 $env:XOD_ARDUINO_CLI="$env:HOME/arduino-cli.exe"


### PR DESCRIPTION
fixes #1896 

`yarn test-func` is still reporting some errors in the `xod-cli` package. Some of these are popping up in a simple `master` repository using the older arduino-cli binary. This leads me to believe that some errors are an issue with my environment.