### PR TITLE
Fix compiling of WS2812 on ESP8266

### DIFF
--- a/workspace/__ardulib__/WS2812_NoBufffer/WS2812.inl
+++ b/workspace/__ardulib__/WS2812_NoBufffer/WS2812.inl
@@ -162,7 +162,7 @@ void WS2812::fill(XColor color) {
   show();
 }
 
-void WS2812::fill(XColor color, uint32_t pixelCount, bool fromTail = false) {
+void WS2812::fill(XColor color, uint32_t pixelCount, bool fromTail) {
   cli();
   // If fromTail is true
   // Skip pixels by filling them with black color
@@ -178,7 +178,7 @@ void WS2812::fill(XColor color, uint32_t pixelCount, bool fromTail = false) {
   show();
 }
 
-void WS2812::fillPattern(Pattern* pat, uint32_t shift = 0) {
+void WS2812::fillPattern(Pattern* pat, uint32_t shift) {
     PatternNode* first = pat->first();
     PatternNode* cur = first;
     uint32_t _shift = (uint32_t) shift % _length;


### PR DESCRIPTION
The error caused by duplicating default values on arguments of `fill` and `fillPattern` methods in the implementation (`ws2812.inl` file), while it defined in the header file.

```
In file included from /var/folders/l3/68wttmkn0wz2wwc6knfbf9780000gn/T/xod_temp_sketchbookmPu8LH/libraries/WS2812_NoBufffer/WS2812.h:58:0,
                 from /var/folders/l3/68wttmkn0wz2wwc6knfbf9780000gn/T/xod_temp_sketchbookmPu8LH/xod_1591098769767_sketch/xod_1591098769767_sketch.ino:1131:
/var/folders/l3/68wttmkn0wz2wwc6knfbf9780000gn/T/xod_temp_sketchbookmPu8LH/libraries/WS2812_NoBufffer/WS2812.inl:165:75: error: default argument given for parameter 3 of 'void WS2812::fill(xod::XColor, uint32_t, bool)' [-fpermissive]
 void WS2812::fill(XColor color, uint32_t pixelCount, bool fromTail = false) {
                                                                           ^
In file included from /var/folders/l3/68wttmkn0wz2wwc6knfbf9780000gn/T/xod_temp_sketchbookmPu8LH/xod_1591098769767_sketch/xod_1591098769767_sketch.ino:1131:0:
/var/folders/l3/68wttmkn0wz2wwc6knfbf9780000gn/T/xod_temp_sketchbookmPu8LH/libraries/WS2812_NoBufffer/WS2812.h:36:10: error: after previous specification in 'void WS2812::fill(xod::XColor, uint32_t, bool)' [-fpermissive]
     void fill(XColor color, uint32_t pixelCount, bool fromTail = false);
          ^

In file included from /var/folders/l3/68wttmkn0wz2wwc6knfbf9780000gn/T/xod_temp_sketchbookmPu8LH/libraries/WS2812_NoBufffer/WS2812.h:58:0,
                 from /var/folders/l3/68wttmkn0wz2wwc6knfbf9780000gn/T/xod_temp_sketchbookmPu8LH/xod_1591098769767_sketch/xod_1591098769767_sketch.ino:1131:
/var/folders/l3/68wttmkn0wz2wwc6knfbf9780000gn/T/xod_temp_sketchbookmPu8LH/libraries/WS2812_NoBufffer/WS2812.inl:181:58: error: default argument given for parameter 2 of 'void WS2812::fillPattern(Pattern*, uint32_t)' [-fpermissive]
 void WS2812::fillPattern(Pattern* pat, uint32_t shift = 0) {
                                                          ^

In file included from /var/folders/l3/68wttmkn0wz2wwc6knfbf9780000gn/T/xod_temp_sketchbookmPu8LH/xod_1591098769767_sketch/xod_1591098769767_sketch.ino:1131:0:
/var/folders/l3/68wttmkn0wz2wwc6knfbf9780000gn/T/xod_temp_sketchbookmPu8LH/libraries/WS2812_NoBufffer/WS2812.h:37:10: error: after previous specification in 'void WS2812::fillPattern(Pattern*, uint32_t)' [-fpermissive]
     void fillPattern(Pattern* pat, uint32_t shift = 0);
          ^

Multiple libraries were found for "XColorPattern.h"
 Used: /var/folders/l3/68wttmkn0wz2wwc6knfbf9780000gn/T/xod_temp_sketchbookmPu8LH/libraries/WS2812_NoBufffer

Using library WS2812_NoBufffer in folder: /var/folders/l3/68wttmkn0wz2wwc6knfbf9780000gn/T/xod_temp_sketchbookmPu8LH/libraries/WS2812_NoBufffer (legacy)
```

I did get rid of them and now it compiles OK (tested on esp8266 WeMos and Arduino Uno).