### PR TITLE
Fix an uncaught exception when transpiling a patch with a “dangling” defer node

### DIFF
--- a/packages/xod-arduino/src/templates.js
+++ b/packages/xod-arduino/src/templates.js
@@ -252,7 +252,7 @@ Handlebars.registerHelper('cppValue', (type, value) =>
 );
 
 const hasUpstreamErrorRaisers = nodeOrInput =>
-  nodeOrInput.upstreamErrorRaisers.length > 0;
+  R.pathOr(0, ['upstreamErrorRaisers', 'length'], nodeOrInput) > 0;
 
 Handlebars.registerHelper('hasUpstreamErrorRaisers', hasUpstreamErrorRaisers);
 


### PR DESCRIPTION
The bug was discovered by @yurybotov.

Here is a minimal example to reproduce the problem:
![Screen Shot 2020-06-02 at 17 50 32](https://user-images.githubusercontent.com/2527093/83534747-e9876d00-a4f9-11ea-8c4a-00bf5b72e649.png)
