### PR TITLE
fix(stdlib) : ssd1306, fix `renderScanlinePart` behaviour

### DIFF
--- a/workspace/__ardulib__/SSD1306/SSD1306.cpp
+++ b/workspace/__ardulib__/SSD1306/SSD1306.cpp
@@ -9,57 +9,55 @@ SSD1306::SSD1306(TwoWire* wire, uint8_t i2cAddress, uint8_t* buffer) {
     _height = SSD1306_DISPLAY_HEIGHT;
 }
 
-void SSD1306::sendCommand(uint8_t command) {
+void SSD1306::_sendCommand(uint8_t command) {
     _wire->beginTransmission(_i2cAddress);
     _wire->write(0x80);
     _wire->write(command);
     _wire->endTransmission();
 }
 
+void SSD1306::_sendCommand(uint8_t command, uint8_t value) {
+    _sendCommand(command);
+    _sendCommand(value);
+}
+
+void SSD1306::_sendCommand(uint8_t command, uint8_t value1, uint8_t value2) {
+    _sendCommand(command);
+    _sendCommand(value1);
+    _sendCommand(value2);
+}
+
 void SSD1306::begin() {
     _wire->begin();
-    sendCommand(SSD1306_DISPLAY_OFF);
-    sendCommand(SSD1306_SET_DISPLAY_CLOCK);
-    sendCommand(0x80);
-    sendCommand(SSD1306_SET_MULTIPLEX_RATIO);
-    sendCommand(0x3F);
-    sendCommand(SSD1306_SET_DISPLAY_OFFSET);
-    sendCommand(0x00);
-    sendCommand(SSD1306_SET_START_LINE | 0);
-    sendCommand(SSD1306_CHARGE_DCDC_PUMP);
-    sendCommand(0x14);
-    sendCommand(SSD1306_ADDR_MODE);
-    sendCommand(0x00);
-    sendCommand(SSD1306_SET_REMAP_L_TO_R);
-    sendCommand(SSD1306_SET_REMAP_T_TO_D);
-    sendCommand(SSD1306_SET_COM_PINS);
-    sendCommand(0x12);
-    sendCommand(SSD1306_SET_CONTRAST);
-    sendCommand(0xFF);
-    sendCommand(SSD1306_SET_PRECHARGE_PERIOD);
-    sendCommand(0xF1);
-    sendCommand(SSD1306_SET_VCOM_DESELECT);
-    sendCommand(0x40);
-    sendCommand(SSD1306_RAM_ON);
-    sendCommand(SSD1306_INVERT_OFF);
-    sendCommand(SSD1306_DISPLAY_ON);
+    _sendCommand(SSD1306_DISPLAY_OFF);
+    _sendCommand(SSD1306_SET_DISPLAY_CLOCK, 0x80);
+    _sendCommand(SSD1306_SET_MULTIPLEX_RATIO, 0x3F);
+    _sendCommand(SSD1306_SET_DISPLAY_OFFSET, 0x00);
+    _sendCommand(SSD1306_SET_START_LINE | 0);
+    _sendCommand(SSD1306_CHARGE_DCDC_PUMP, 0x14);
+    _sendCommand(SSD1306_ADDR_MODE, 0x00);
+    _sendCommand(SSD1306_SET_REMAP_L_TO_R);
+    _sendCommand(SSD1306_SET_REMAP_T_TO_D);
+    _sendCommand(SSD1306_SET_COM_PINS, 0x12);
+    _sendCommand(SSD1306_SET_CONTRAST, 0xFF);
+    _sendCommand(SSD1306_SET_PRECHARGE_PERIOD, 0xF1);
+    _sendCommand(SSD1306_SET_VCOM_DESELECT, 0x40);
+    _sendCommand(SSD1306_RAM_ON);
+    _sendCommand(SSD1306_INVERT_OFF);
+    _sendCommand(SSD1306_DISPLAY_ON);
 }
 
 void SSD1306::sendBuffer() {
-    sendCommand(SSD1306_ADDR_PAGE);
-    sendCommand(0);
-    sendCommand(_height / 8 - 1);
-    sendCommand(SSD1306_ADDR_COLUMN);
-    sendCommand(0);
-    sendCommand(_width - 1);
-    for (uint16_t i = 0; i < _width * _height / 8; i++) {
+    _sendCommand(SSD1306_ADDR_PAGE, 0, _height / 8 - 1);
+    _sendCommand(SSD1306_ADDR_COLUMN, 0, _width - 1);
+
+    for (uint16_t i = 0; i < _width * _height / 8;  /* realy blank */) {
         _wire->beginTransmission(_i2cAddress);
         _wire->write(0x40);
 
         for (uint8_t x = 0; x < 16; x++)
             _wire->write(_buffer[i++]);
 
-        i--;
         _wire->endTransmission();
     }
 }
@@ -74,7 +72,7 @@ void SSD1306::renderScanlinePart(int16_t scanline, int16_t xmin, int16_t xmax, c
     if ((xmin < 0) || (xmax < 0) || (xmin >= _width) || (xmax >= _width) || (xmin > xmax))
         return;
 
-    for (int16_t x = 0; x < _width; x++) {
+    for (int16_t x = 0; x <= xmax - xmin; x++) {
 
         /* The two-byte (RGB565) color value is stored in the form of RRRRRGGG:GGGBBBBB.
          * To get a black or white color, an artificial check for the lightness is performed.
@@ -84,7 +82,7 @@ void SSD1306::renderScanlinePart(int16_t scanline, int16_t xmin, int16_t xmax, c
         bool color = lineBuffer[x] & 0xC618;
 
         uint8_t p = scanline / 8;
-        uint16_t numByte = (p * 128) + x;
+        uint16_t numByte = (p * 128) + xmin + x;
         uint8_t numBit = scanline % 8;
 
         _buffer[numByte] = color ? _buffer[numByte] |= 1 << numBit : _buffer[numByte] &= ~(1 << numBit);

--- a/workspace/__ardulib__/SSD1306/SSD1306.h
+++ b/workspace/__ardulib__/SSD1306/SSD1306.h
@@ -52,7 +52,9 @@ private:
     int16_t _width = 0;
     int16_t _height = 0;
 
-    void sendCommand(uint8_t command);
+    void _sendCommand(uint8_t command);
+    void _sendCommand(uint8_t command, uint8_t value);
+    void _sendCommand(uint8_t command, uint8_t value1, uint8_t value2);
 };
 
 #endif // X_SSD1306_H

--- a/workspace/__lib__/xod-dev/ssd1306-display/ssd1306-128x64-i2c-device/patch.cpp
+++ b/workspace/__lib__/xod-dev/ssd1306-display/ssd1306-128x64-i2c-device/patch.cpp
@@ -34,6 +34,7 @@ void evaluate(Context ctx) {
 
     dev->begin();
     dev->clearScreen();
+    dev->sendBuffer();
 
     emitValue<output_DEV>(ctx, dev);
 }


### PR DESCRIPTION
Some problems were found working with the XOD graphics library and SSD1306 display for "UNO slot educations sets".

- Add `sendBuffer()` on device init to clear the screen.
- Fix ` SSD1306::renderScanlinePart(int16_t scanline, int16_t xmin, int16_t xmax, const uint16_t* lineBuffer)` wrong behaviour found moving the `canvas`.
- Replicate private `_sendCommand` for two and three arguments.

P.S. This lib still works horribly on weak controllers like Arduino Uno due to lack of memory 😢

Summoning @yurybotov