### PR TITLE
Add missing dependency for xod-dev/pn532-nfc

### DIFF
--- a/workspace/__lib__/xod-dev/pn532-nfc/pn532-device/patch.cpp
+++ b/workspace/__lib__/xod-dev/pn532-nfc/pn532-device/patch.cpp
@@ -1,3 +1,4 @@
+#pragma XOD require "https://github.com/adafruit/Adafruit_BusIO"
 #pragma XOD require "https://github.com/adafruit/Adafruit-PN532"
 
 // clang-format off


### PR DESCRIPTION
Reported by @S-VIN.

`Adafruit-PN532` library depends on `Adafruit_BusIO` and won't compile without it.
