### PR TITLE
Use upstream ESP8266 package index instead of locked v2.4.3

### DIFF
--- a/packages/xod-deploy-bin/src/constants.js
+++ b/packages/xod-deploy-bin/src/constants.js
@@ -1,10 +1,15 @@
 export const ARDUINO_PACKAGES_DIRNAME = '__packages__';
+// Default additional urls
 export const BUNDLED_ADDITIONAL_URLS = [
-  // TODO:
-  // Replace our fixed esp8266 package with original:
-  // http://arduino.esp8266.com/stable/package_esp8266com_index.json
-  // When they release new version >2.4.2
-  'https://storage.googleapis.com/releases.xod.io/packages/esp8266-2.4.3/package_esp8266com_index.json',
+  'http://arduino.esp8266.com/stable/package_esp8266com_index.json',
+];
+// Additional URLS that should migrate to the new one
+// [[OldURL, NewURL]]
+export const MIGRATE_BUNDLED_ADDITIONAL_URLS = [
+  [
+    'https://storage.googleapis.com/releases.xod.io/packages/esp8266-2.4.3/package_esp8266com_index.json',
+    'http://arduino.esp8266.com/stable/package_esp8266com_index.json',
+  ],
 ];
 export const ARDUINO_LIBRARIES_DIRNAME = '__ardulib__';
 export const ARDUINO_CLI_LIBRARIES_DIRNAME = 'libraries';


### PR DESCRIPTION
There is no issue.
But we used this version by default because the latest release at that time had some critical bug.
Now the latest version works fine.