### PR TITLE
Fix follow log in Debugger pane

### DIFF
--- a/packages/xod-client/src/debugger/actions.js
+++ b/packages/xod-client/src/debugger/actions.js
@@ -20,8 +20,9 @@ export const startSkippingNewLogLines = () => ({
   type: AT.DEBUGGER_LOG_START_SKIPPING_NEW_LINES,
 });
 
-export const stopSkippingNewLogLines = () => ({
+export const stopSkippingNewLogLines = (force = true) => ({
   type: AT.DEBUGGER_LOG_STOP_SKIPPING_NEW_LINES,
+  payload: { force },
 });
 
 export const toggleCapturingDebuggerProtocolMessages = () => ({

--- a/packages/xod-client/src/debugger/containers/Log.jsx
+++ b/packages/xod-client/src/debugger/containers/Log.jsx
@@ -31,9 +31,15 @@ class Log extends React.PureComponent {
     }, 0);
   }
 
-  onFollowLog() {
+  componentDidUpdate() {
+    if (this.props.log.length === 0) {
+      this.onFollowLog(false);
+    }
+  }
+
+  onFollowLog(addSkipMessage = true) {
     this.scrollToBottom();
-    this.props.stopSkippingNewLogLines();
+    this.props.stopSkippingNewLogLines(addSkipMessage);
   }
 
   scrollToBottom() {

--- a/packages/xod-client/src/debugger/reducer.js
+++ b/packages/xod-client/src/debugger/reducer.js
@@ -402,9 +402,13 @@ export default (state = initialState, action) => {
       return R.compose(
         R.assoc('isSkippingNewSerialLogLines', false),
         R.assoc('numberOfSkippedSerialLogLines', 0),
-        addMessageToDebuggerLog(
-          createSystemMessage(
-            `Skipped ${state.numberOfSkippedSerialLogLines} lines`
+        R.when(
+          ({ numberOfSkippedSerialLogLines }) =>
+            action.payload.force || numberOfSkippedSerialLogLines > 0,
+          addMessageToDebuggerLog(
+            createSystemMessage(
+              `Skipped ${state.numberOfSkippedSerialLogLines} lines`
+            )
           )
         )
       )(state);

--- a/packages/xod-client/src/editor/reducer.js
+++ b/packages/xod-client/src/editor/reducer.js
@@ -25,6 +25,8 @@ import { setCurrentPatchOffset, switchPatchUnsafe } from './actions';
 
 import { getInitialPatchOffset } from '../project/utils';
 
+import { default as initialState } from './state';
+
 // =============================================================================
 //
 // Utils
@@ -371,7 +373,7 @@ const openDebuggerTab = R.curry((patchPath, state) => {
 //
 // =============================================================================
 
-const editorReducer = (state = {}, action) => {
+const editorReducer = (state = initialState, action) => {
   switch (action.type) {
     //
     // selection management

--- a/packages/xod-client/src/utils/components/Autoscroll.jsx
+++ b/packages/xod-client/src/utils/components/Autoscroll.jsx
@@ -9,18 +9,19 @@ import * as R from 'ramda';
 import React from 'react';
 import PropTypes from 'prop-types';
 
+const SCROLLED_DOWN_THRESHOLD = 0;
+
 /* eslint-disable no-param-reassign */
 const hasOverflow = el => el.clientHeight < el.scrollHeight;
 const isScrolledDown = (el, threshold) => {
-  const bottom = el.scrollTop + el.clientHeight;
-  return bottom >= el.scrollHeight - threshold;
+  const actualScrollTop = el.scrollTop;
+  const bottomScrollTop = el.scrollHeight - el.clientHeight - threshold;
+  return actualScrollTop >= bottomScrollTop;
 };
 const isScrolledUp = el => el.scrollTop === 0;
 const scrollDown = el => (el.scrollTop = el.scrollHeight - el.clientHeight);
 const scrollDownBy = (amount, el) => (el.scrollTop += amount);
 /* eslint-enable no-param-reassign */
-
-const isScrolledDownThreshold = 0;
 
 class Autoscroll extends React.PureComponent {
   constructor(props) {
@@ -28,18 +29,16 @@ class Autoscroll extends React.PureComponent {
     this._isScrolledDown = true; /* whether the user has scrolled down */
     this._el = null;
     this._scrollHeight = null;
-    this._isScrolledUp = null;
   }
   componentDidMount() {
     this.scrollDownIfNeeded();
   }
   componentWillUpdate() {
     this._scrollHeight = this._el.scrollHeight;
-    this._isScrolledUp = isScrolledUp(this._el);
   }
   componentDidUpdate() {
     /* if the list is scrolled all the way up and new items are added, preserve the current scroll position */
-    if (this._isScrolledUp && this._scrollHeight !== null) {
+    if (isScrolledUp(this._el) && this._scrollHeight !== null) {
       /* the scroll height increased by this much during the update */
       const difference = this._el.scrollHeight - this._scrollHeight;
       this._scrollHeight = null;
@@ -53,11 +52,12 @@ class Autoscroll extends React.PureComponent {
   }
   scrollDown() {
     scrollDown(this._el);
+    this._isScrolledDown = true;
   }
   handleScroll(e) {
     const nextIsScrolledDown = isScrolledDown(
       this._el,
-      isScrolledDownThreshold
+      SCROLLED_DOWN_THRESHOLD
     );
     if (
       !nextIsScrolledDown &&

--- a/packages/xod-client/stories/Debugger.jsx
+++ b/packages/xod-client/stories/Debugger.jsx
@@ -6,6 +6,7 @@ import { action } from '@storybook/addon-actions';
 
 import Debugger from '../src/debugger/containers/Debugger';
 import DebuggerReducer from '../src/debugger/reducer';
+import EditorReducer from '../src/editor/reducer';
 import { getLogForCurrentTab } from '../src/debugger/selectors';
 import {
   addMessagesToDebuggerLog,
@@ -23,20 +24,22 @@ import '../src/core/styles/main.scss';
 const createStore = () =>
   createReduxStore(
     combineReducers({
+      editor: EditorReducer,
       debugger: DebuggerReducer,
     })
   );
 
 const addMessages = store => {
+  const now = Date.now();
   store.dispatch(
     addMessagesToDebuggerLog([
       {
         type: 'log',
-        message: 'Just a simple log message, that readed from Serial',
+        message: `${now}: Just a simple log message, that readed from Serial`,
       },
       {
         type: 'log',
-        message: 'Just another log message',
+        message: `${now}: Just another log message`,
       },
       {
         type: 'xod',
@@ -122,14 +125,17 @@ const startDebugSession = store => {
         type: 'system',
         message: 'Debug session has been started! (system message)',
       },
-      {}
+      {},
+      {},
+      {},
+      '@/main'
     )
   );
 };
 
 // Container that shows Log length
 const LogLength = connect(state => ({ log: getLogForCurrentTab(state) }))(
-  ({ log }) => <div>Log length: {log.length}</div>
+  ({ log }) => <div style={{ color: '#fff' }}>Log length: {log.length}</div>
 );
 
 // =============================================================================
@@ -147,6 +153,8 @@ const idle = () => {
       <Debugger
         onUploadClick={action('onUploadClick')}
         onUploadAndDebugClick={action('onUploadAndDebugClick')}
+        onRunSimulationClick={() => {}}
+        stopDebuggerSession={() => {}}
       />
     ));
 };
@@ -161,6 +169,8 @@ const uploading = () => {
       <Debugger
         onUploadClick={action('onUploadClick')}
         onUploadAndDebugClick={action('onUploadAndDebugClick')}
+        onRunSimulationClick={() => {}}
+        stopDebuggerSession={() => {}}
       />
     ));
 };
@@ -187,6 +197,8 @@ const uploadingSuccess = () => {
       <Debugger
         onUploadClick={action('onUploadClick')}
         onUploadAndDebugClick={action('onUploadAndDebugClick')}
+        onRunSimulationClick={() => {}}
+        stopDebuggerSession={() => {}}
       />
     ));
 };
@@ -213,6 +225,8 @@ const uploadingFail = () => {
       <Debugger
         onUploadClick={action('onUploadClick')}
         onUploadAndDebugClick={action('onUploadAndDebugClick')}
+        onRunSimulationClick={() => {}}
+        stopDebuggerSession={() => {}}
       />
     ));
 };
@@ -221,16 +235,20 @@ const running = () => {
   const store = createStore();
   startDebugSession(store);
   setInterval(() => addMessages(store), 100);
-  setInterval(() => addError(store), 3000);
+  // setInterval(() => addError(store), 5000);
 
   storiesOf('Debugger', module)
     .addDecorator(story => <Provider store={store}>{story()}</Provider>)
     .add('running', () => (
       <div>
         <LogLength />
+        <button onClick={() => addError(store)}>Add error</button>
+        <p />
         <Debugger
           onUploadClick={action('onUploadClick')}
           onUploadAndDebugClick={action('onUploadAndDebugClick')}
+          onRunSimulationClick={() => {}}
+          stopDebuggerSession={() => {}}
         />
       </div>
     ));
@@ -257,7 +275,7 @@ const longMessages = () => {
       status: 'failed',
     },
   });
-  for (let i = 0; i < 300; i += 1) {
+  for (let i = 0; i < 100; i += 1) {
     addMessages(store);
 
     if (i % 10 === 0) {
@@ -281,6 +299,8 @@ const longMessages = () => {
         <Debugger
           onUploadClick={action('onUploadClick')}
           onUploadAndDebugClick={action('onUploadAndDebugClick')}
+          onRunSimulationClick={() => {}}
+          stopDebuggerSession={() => {}}
         />
       </div>
     ));


### PR DESCRIPTION
There is no issue, but there were some small bugs:
- if messages added to the log, but the log is hidden, then it might be opened not on the bottom and "Follow log" will be shown up from the beginning
- after clicking "Follow log" it sometimes does not follow it
- Clearing log did not start following the log