### PR TITLE
Remove C++ typo in humidity icon implementation.

### DIFF
--- a/workspace/__lib__/xod/graphics/humidity-16x16-rgba/patch.cpp
+++ b/workspace/__lib__/xod/graphics/humidity-16x16-rgba/patch.cpp
@@ -21,7 +21,7 @@ nodespace {
     };
 }
 node {
-    Bitmap myBitmap = Bitmap(icon, 2, 16, 16 0x0000);
+    Bitmap myBitmap = Bitmap(icon, 2, 16, 16, 0x0000);
 
     void evaluate(Context ctx) {
         emitValue<output_BMP>(ctx, &myBitmap);


### PR DESCRIPTION
:neutral_face: