### PR TITLE
Fix typo in implementation of xod/common-hardware/ds18b20-thermometer

### DIFF
--- a/workspace/__lib__/xod/common-hardware/ds18b20-thermometer/patch.cpp
+++ b/workspace/__lib__/xod/common-hardware/ds18b20-thermometer/patch.cpp
@@ -134,7 +134,7 @@ void evaluate(Context ctx) {
         return;
 
     Number tc;
-    bool success = readTemperature(port, &tc);
+    bool success = readTemperature(constant_input_PORT, &tc);
     if (!success) {
         raiseError(ctx); // Initialization sequence error
         return;


### PR DESCRIPTION
The issue was [reported on our forum](https://forum.xod.io/t/xod-35-0-soft-uart-fail/4413/4)
