### PR TITLE
Support esp32 boards

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,5 @@
 .github/ISSUE_TEMPLATE/
 packages/xod-cli/README.md
+workspace/__ardulib__/*/
+packages/xod-cli/bundle/
+packages/xod-client-electron/src-babel/

--- a/packages/xod-deploy-bin/src/arduinoCli.js
+++ b/packages/xod-deploy-bin/src/arduinoCli.js
@@ -433,13 +433,15 @@ export const listBoards = async (wsPath, cli) => {
       available: res[1],
     }))
     .catch(async err => {
-      if (R.propEq('code', 6, err)) {
-        // Catch error produced by arduino-cli, but actually it's not an error:
+      if (R.propEq('code', 'ENOENT', err)) {
         // When User added a new URL into `extra.txt` file it causes that
         // arduino-cli tries to read new JSON but it's not existing yet
         // so it fails with error "no such file or directory"
         // To avoid this and make a good UX, we'll force call `updateIndexes`
-        return updateIndexesInternal(wsPath, cli).then(() => listBoards(cli));
+        // and then run `listBoards` again.
+        return updateIndexesInternal(wsPath, cli).then(() =>
+          listBoards(wsPath, cli)
+        );
       }
 
       throw createError('UPDATE_INDEXES_ERROR_BROKEN_FILE', {

--- a/workspace/__ardulib__/ESP32Servo/.gitignore
+++ b/workspace/__ardulib__/ESP32Servo/.gitignore
@@ -1,0 +1,1 @@
+/.project

--- a/workspace/__ardulib__/ESP32Servo/README.md
+++ b/workspace/__ardulib__/ESP32Servo/README.md
@@ -1,0 +1,90 @@
+# Servo Library for ESP32
+
+This library attempts to faithfully replicate the semantics of the
+Arduino Servo library (see http://www.arduino.cc/en/Reference/Servo)
+for the ESP32, with two (optional) additions. The two new functions
+expose the ability of the ESP32 PWM timers to vary timer width.
+# Documentation by Doxygen
+
+[ESP32Servo Doxygen](https://madhephaestus.github.io/ESP32Servo/annotated.html)
+
+## License
+
+Copyright (c) 2017 John K. Bennett.  All right reserved.
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+## Library Description:
+```
+    Servo - Class for manipulating servo motors connected to ESP32 pins.
+    
+    int attach(pin )  - Attaches the given GPIO pin to the next free channel
+        (channels that have previously been detached are used first), 
+        returns channel number or 0 if failure. All pin numbers are allowed,
+        but only pins 2,4,12-19,21-23,25-27,32-33 are recommended.
+    
+    int attach(pin, min, max  ) - Attaches to a pin setting min and max 
+        values in microseconds; enforced minimum min is 500, enforced max
+        is 2500. Other semantics are the same as attach().
+    
+    void write () - Sets the servo angle in degrees; a value below 500 is
+        treated as a value in degrees (0 to 180). These limit are enforced,
+        i.e., values are constrained as follows:
+            Value                                   Becomes
+            -----                                   -------
+            < 0                                        0
+            0 - 180                                  value (treated as degrees)
+            181 - 499                                 180
+            500 - (min-1)                             min
+            min-max (from attach or default)         value (treated as microseconds)
+            (max+1) - 2500                            max
+    
+    void writeMicroseconds() - Sets the servo pulse width in microseconds.
+        min and max are enforced (see above). 
+        
+    int read() - Gets the last written servo pulse width as an angle between 0 and 180. 
+    
+    int readMicroseconds()   - Gets the last written servo pulse width in microseconds.
+    
+    bool attached() - Returns true if this servo instance is attached to a pin.
+    
+    void detach() - Stops an the attached servo, frees the attached pin, and frees
+        its channel for reuse.  
+```
+
+### **New ESP32-specific functions**
+ 
+```
+    setTimerWidth(value) - Sets the PWM timer width (must be 16-20) (ESP32 ONLY);
+        as a side effect, the pulse width is recomputed.
+
+    int readTimerWidth() - Gets the PWM timer width (ESP32 ONLY) 
+```
+ 
+### Useful Defaults:
+
+default min pulse width for attach(): 544us
+
+default max pulse width for attach(): 2400us
+
+default timer width 16 (if timer width is not set)
+
+default pulse width 1500us (servos are initialized with this value)
+
+MINIMUM pulse with: 500us
+
+MAXIMUM pulse with: 2500us
+
+MAXIMUM number of servos: 16 (this is the number of PWM channels in the ESP32)  

--- a/workspace/__ardulib__/ESP32Servo/examples/Knob/Knob.ino
+++ b/workspace/__ardulib__/ESP32Servo/examples/Knob/Knob.ino
@@ -1,0 +1,81 @@
+/*
+ Controlling a servo position using a potentiometer (variable resistor)
+ by Michal Rinott <http://people.interaction-ivrea.it/m.rinott>
+
+ modified on 8 Nov 2013
+ by Scott Fitzgerald
+
+ modified for the ESP32 on March 2017
+ by John Bennett
+ 
+ see  http://www.arduino.cc/en/Tutorial/Knob for a description of the original code
+
+ * Different servos require different pulse widths to vary servo angle, but the range is 
+ * an approximately 500-2500 microsecond pulse every 20ms (50Hz). In general, hobbyist servos
+ * sweep 180 degrees, so the lowest number in the published range for a particular servo
+ * represents an angle of 0 degrees, the middle of the range represents 90 degrees, and the top
+ * of the range represents 180 degrees. So for example, if the range is 1000us to 2000us,
+ * 1000us would equal an angle of 0, 1500us would equal 90 degrees, and 2000us would equal 1800
+ * degrees.
+ * 
+ * Circuit: (using an ESP32 Thing from Sparkfun)
+ * Servo motors have three wires: power, ground, and signal. The power wire is typically red,
+ * the ground wire is typically black or brown, and the signal wire is typically yellow,
+ * orange or white. Since the ESP32 can supply limited current at only 3.3V, and servos draw
+ * considerable power, we will connect servo power to the VBat pin of the ESP32 (located
+ * near the USB connector). THIS IS ONLY APPROPRIATE FOR SMALL SERVOS. 
+ * 
+ * We could also connect servo power to a separate external
+ * power source (as long as we connect all of the grounds (ESP32, servo, and external power).
+ * In this example, we just connect ESP32 ground to servo ground. The servo signal pins
+ * connect to any available GPIO pins on the ESP32 (in this example, we use pin 18.
+ * 
+ * In this example, we assume a Tower Pro SG90 small servo connected to VBat.
+ * The published min and max for this servo are 500 and 2400, respectively.
+ * These values actually drive the servos a little past 0 and 180, so
+ * if you are particular, adjust the min and max values to match your needs.
+ */
+
+// Include the ESP32 Arduino Servo Library instead of the original Arduino Servo Library
+#include <ESP32Servo.h> 
+
+Servo myservo;  // create servo object to control a servo
+
+// Possible PWM GPIO pins on the ESP32: 0(used by on-board button),2,4,5(used by on-board LED),12-19,21-23,25-27,32-33 
+// Possible PWM GPIO pins on the ESP32-S2: 0(used by on-board button),1-17,18(used by on-board LED),19-21,26,33-42 
+int servoPin = 18;      // GPIO pin used to connect the servo control (digital out)
+// Possible ADC pins on the ESP32: 0,2,4,12-15,32-39; 34-39 are recommended for analog input
+// Possible ADC pins on the ESP32-S2: 1-20 are recommended for analog input
+#if defined(ARDUINO_ESP32S2_DEV)
+int potPin = 10;        // GPIO pin used to connect the potentiometer (analog in)
+#else
+int potPin = 34;        // GPIO pin used to connect the potentiometer (analog in)
+#endif
+int ADC_Max = 4096;     // This is the default ADC max value on the ESP32 (12 bit ADC width);
+                        // this width can be set (in low-level oode) from 9-12 bits, for a
+                        // a range of max values of 512-4096
+  
+int val;    // variable to read the value from the analog pin
+
+void setup()
+{
+	// Allow allocation of all timers
+	ESP32PWM::allocateTimer(0);
+	ESP32PWM::allocateTimer(1);
+	ESP32PWM::allocateTimer(2);
+	ESP32PWM::allocateTimer(3);
+  myservo.setPeriodHertz(50);// Standard 50hz servo
+  myservo.attach(servoPin, 500, 2400);   // attaches the servo on pin 18 to the servo object
+                                         // using SG90 servo min/max of 500us and 2400us
+                                         // for MG995 large servo, use 1000us and 2000us,
+                                         // which are the defaults, so this line could be
+                                         // "myservo.attach(servoPin);"
+}
+
+void loop() {
+  val = analogRead(potPin);            // read the value of the potentiometer (value between 0 and 1023)
+  val = map(val, 0, ADC_Max, 0, 180);     // scale it to use it with the servo (value between 0 and 180)
+  myservo.write(val);                  // set the servo position according to the scaled value
+  delay(200);                          // wait for the servo to get there
+}
+

--- a/workspace/__ardulib__/ESP32Servo/examples/Multiple-Servo-Example-Arduino/Multiple-Servo-Example-Arduino.ino
+++ b/workspace/__ardulib__/ESP32Servo/examples/Multiple-Servo-Example-Arduino/Multiple-Servo-Example-Arduino.ino
@@ -1,0 +1,150 @@
+/*
+ * ESP32 Servo Example Using Arduino ESP32 Servo Library
+ * John K. Bennett
+ * March, 2017
+ * 
+ * This sketch uses the Arduino ESP32 Servo Library to sweep 4 servos in sequence.
+ * 
+ * Different servos require different pulse widths to vary servo angle, but the range is 
+ * an approximately 500-2500 microsecond pulse every 20ms (50Hz). In general, hobbyist servos
+ * sweep 180 degrees, so the lowest number in the published range for a particular servo
+ * represents an angle of 0 degrees, the middle of the range represents 90 degrees, and the top
+ * of the range represents 180 degrees. So for example, if the range is 1000us to 2000us,
+ * 1000us would equal an angle of 0, 1500us would equal 90 degrees, and 2000us would equal 1800
+ * degrees.
+ * 
+ * Circuit:
+ * Servo motors have three wires: power, ground, and signal. The power wire is typically red,
+ * the ground wire is typically black or brown, and the signal wire is typically yellow,
+ * orange or white. Since the ESP32 can supply limited current at only 3.3V, and servos draw
+ * considerable power, we will connect servo power to the VBat pin of the ESP32 (located
+ * near the USB connector). THIS IS ONLY APPROPRIATE FOR SMALL SERVOS. 
+ * 
+ * We could also connect servo power to a separate external
+ * power source (as long as we connect all of the grounds (ESP32, servo, and external power).
+ * In this example, we just connect ESP32 ground to servo ground. The servo signal pins
+ * connect to any available GPIO pins on the ESP32 (in this example, we use pins
+ * 22, 19, 23, & 18).
+ * 
+ * In this example, we assume four Tower Pro SG90 small servos.
+ * The published min and max for this servo are 500 and 2400, respectively.
+ * These values actually drive the servos a little past 0 and 180, so
+ * if you are particular, adjust the min and max values to match your needs.
+ * Experimentally, 550 and 2350 are pretty close to 0 and 180.
+ */
+
+#include <ESP32Servo.h>
+
+// create four servo objects 
+Servo servo1;
+Servo servo2;
+Servo servo3;
+Servo servo4;
+Servo servo5;
+// Published values for SG90 servos; adjust if needed
+int minUs = 1000;
+int maxUs = 2000;
+
+// These are all GPIO pins on the ESP32
+// Recommended pins include 2,4,12-19,21-23,25-27,32-33
+// for the ESP32-S2 the GPIO pins are 1-21,26,33-42
+int servo1Pin = 15;
+int servo2Pin = 16;
+int servo3Pin = 14;
+#if defined(ARDUINO_ESP32S2_DEV)
+int servo4Pin = 13;
+#else
+int servo4Pin = 32;
+#endif
+int servo5Pin = 4;
+
+int pos = 0;      // position in degrees
+ESP32PWM pwm;
+void setup() {
+	// Allow allocation of all timers
+	ESP32PWM::allocateTimer(0);
+	ESP32PWM::allocateTimer(1);
+	ESP32PWM::allocateTimer(2);
+	ESP32PWM::allocateTimer(3);
+	Serial.begin(115200);
+	servo1.setPeriodHertz(50);      // Standard 50hz servo
+	servo2.setPeriodHertz(50);      // Standard 50hz servo
+	servo3.setPeriodHertz(330);      // Standard 50hz servo
+	servo4.setPeriodHertz(200);      // Standard 50hz servo
+	//servo5.setPeriodHertz(50);      // Standard 50hz servo
+
+
+}
+
+void loop() {
+	servo1.attach(servo1Pin, minUs, maxUs);
+	servo2.attach(servo2Pin, minUs, maxUs);
+#if defined(ARDUINO_ESP32S2_DEV)
+	pwm.attachPin(37, 10000);//10khz
+#else
+	pwm.attachPin(27, 10000);//10khz
+#endif
+	servo3.attach(servo3Pin, minUs, maxUs);
+	servo4.attach(servo4Pin, minUs, maxUs);
+
+	//servo5.attach(servo5Pin, minUs, maxUs);
+
+
+	for (pos = 0; pos <= 180; pos += 1) { // sweep from 0 degrees to 180 degrees
+		// in steps of 1 degree
+		servo1.write(pos);
+		delay(1);             // waits 20ms for the servo to reach the position
+	}
+	for (pos = 180; pos >= 0; pos -= 1) { // sweep from 180 degrees to 0 degrees
+		servo1.write(pos);
+		delay(1);
+	}
+
+	for (pos = 0; pos <= 180; pos += 1) { // sweep from 0 degrees to 180 degrees
+		// in steps of 1 degree
+		servo2.write(pos);
+		delay(1);             // waits 20ms for the servo to reach the position
+	}
+	for (pos = 180; pos >= 0; pos -= 1) { // sweep from 180 degrees to 0 degrees
+		servo2.write(pos);
+		delay(1);
+	}
+
+	for (pos = 0; pos <= 180; pos += 1) { // sweep from 0 degrees to 180 degrees
+		// in steps of 1 degree
+		servo3.write(pos);
+		delay(1);             // waits 20ms for the servo to reach the position
+	}
+	for (pos = 180; pos >= 0; pos -= 1) { // sweep from 180 degrees to 0 degrees
+		servo3.write(pos);
+		delay(1);
+	}
+
+	for (pos = 0; pos <= 180; pos += 1) { // sweep from 0 degrees to 180 degrees
+		// in steps of 1 degree
+		servo4.write(pos);
+		delay(1);             // waits 20ms for the servo to reach the position
+	}
+	for (pos = 180; pos >= 0; pos -= 1) { // sweep from 180 degrees to 0 degrees
+		servo4.write(pos);
+		delay(1);
+	}
+	for (pos = 0; pos <= 180; pos += 1) { // sweep from 0 degrees to 180 degrees
+		// in steps of 1 degree
+		servo5.write(pos);
+		delay(1);             // waits 20ms for the servo to reach the position
+	}
+	for (pos = 180; pos >= 0; pos -= 1) { // sweep from 180 degrees to 0 degrees
+		servo5.write(pos);
+		delay(1);
+	}
+	servo1.detach();
+	servo2.detach();;
+	servo3.detach();
+	servo4.detach();
+	pwm.detachPin(27);
+
+	delay(5000);
+
+}
+

--- a/workspace/__ardulib__/ESP32Servo/examples/PWMExample/PWMExample.ino
+++ b/workspace/__ardulib__/ESP32Servo/examples/PWMExample/PWMExample.ino
@@ -1,0 +1,36 @@
+#include <ESP32Servo.h>
+int APin = 13;
+ESP32PWM pwm;
+int freq = 1000;
+void setup() {
+	// Allow allocation of all timers
+	ESP32PWM::allocateTimer(0);
+	ESP32PWM::allocateTimer(1);
+	ESP32PWM::allocateTimer(2);
+	ESP32PWM::allocateTimer(3);
+	Serial.begin(115200);
+	pwm.attachPin(APin, freq, 10); // 1KHz 8 bit
+
+}
+void loop() {
+
+	// fade the LED on thisPin from off to brightest:
+	for (float brightness = 0; brightness <= 0.5; brightness += 0.001) {
+		// Write a unit vector value from 0.0 to 1.0
+		pwm.writeScaled(brightness);
+		delay(2);
+	}
+	//delay(1000);
+	// fade the LED on thisPin from brithstest to off:
+	for (float brightness = 0.5; brightness >= 0; brightness -= 0.001) {
+		freq += 10;
+		// Adjust the frequency on the fly with a specific brightness
+		// Frequency is in herts and duty cycle is a unit vector 0.0 to 1.0
+		pwm.adjustFrequency(freq, brightness); // update the time base of the PWM
+		delay(2);
+	}
+	// pause between LEDs:
+	delay(1000);
+	freq = 1000;
+	pwm.adjustFrequency(freq, 0.0);    // reset the time base
+}

--- a/workspace/__ardulib__/ESP32Servo/examples/Sweep/Sweep.ino
+++ b/workspace/__ardulib__/ESP32Servo/examples/Sweep/Sweep.ino
@@ -1,0 +1,78 @@
+/* Sweep
+ by BARRAGAN <http://barraganstudio.com>
+ This example code is in the public domain.
+
+ modified 8 Nov 2013
+ by Scott Fitzgerald
+
+ modified for the ESP32 on March 2017
+ by John Bennett
+
+ see http://www.arduino.cc/en/Tutorial/Sweep for a description of the original code
+
+ * Different servos require different pulse widths to vary servo angle, but the range is 
+ * an approximately 500-2500 microsecond pulse every 20ms (50Hz). In general, hobbyist servos
+ * sweep 180 degrees, so the lowest number in the published range for a particular servo
+ * represents an angle of 0 degrees, the middle of the range represents 90 degrees, and the top
+ * of the range represents 180 degrees. So for example, if the range is 1000us to 2000us,
+ * 1000us would equal an angle of 0, 1500us would equal 90 degrees, and 2000us would equal 1800
+ * degrees.
+ * 
+ * Circuit: (using an ESP32 Thing from Sparkfun)
+ * Servo motors have three wires: power, ground, and signal. The power wire is typically red,
+ * the ground wire is typically black or brown, and the signal wire is typically yellow,
+ * orange or white. Since the ESP32 can supply limited current at only 3.3V, and servos draw
+ * considerable power, we will connect servo power to the VBat pin of the ESP32 (located
+ * near the USB connector). THIS IS ONLY APPROPRIATE FOR SMALL SERVOS. 
+ * 
+ * We could also connect servo power to a separate external
+ * power source (as long as we connect all of the grounds (ESP32, servo, and external power).
+ * In this example, we just connect ESP32 ground to servo ground. The servo signal pins
+ * connect to any available GPIO pins on the ESP32 (in this example, we use pin 18.
+ * 
+ * In this example, we assume a Tower Pro MG995 large servo connected to an external power source.
+ * The published min and max for this servo is 1000 and 2000, respectively, so the defaults are fine.
+ * These values actually drive the servos a little past 0 and 180, so
+ * if you are particular, adjust the min and max values to match your needs.
+ */
+
+#include <ESP32Servo.h>
+
+Servo myservo;  // create servo object to control a servo
+// 16 servo objects can be created on the ESP32
+
+int pos = 0;    // variable to store the servo position
+// Recommended PWM GPIO pins on the ESP32 include 2,4,12-19,21-23,25-27,32-33 
+// Possible PWM GPIO pins on the ESP32-S2: 0(used by on-board button),1-17,18(used by on-board LED),19-21,26,33-42
+#if defined(ARDUINO_ESP32S2_DEV)
+int servoPin = 17;
+#else
+int servoPin = 18;
+#endif
+
+void setup() {
+	// Allow allocation of all timers
+	ESP32PWM::allocateTimer(0);
+	ESP32PWM::allocateTimer(1);
+	ESP32PWM::allocateTimer(2);
+	ESP32PWM::allocateTimer(3);
+	myservo.setPeriodHertz(50);    // standard 50 hz servo
+	myservo.attach(servoPin, 1000, 2000); // attaches the servo on pin 18 to the servo object
+	// using default min/max of 1000us and 2000us
+	// different servos may require different min/max settings
+	// for an accurate 0 to 180 sweep
+}
+
+void loop() {
+
+	for (pos = 0; pos <= 180; pos += 1) { // goes from 0 degrees to 180 degrees
+		// in steps of 1 degree
+		myservo.write(pos);    // tell servo to go to position in variable 'pos'
+		delay(15);             // waits 15ms for the servo to reach the position
+	}
+	for (pos = 180; pos >= 0; pos -= 1) { // goes from 180 degrees to 0 degrees
+		myservo.write(pos);    // tell servo to go to position in variable 'pos'
+		delay(15);             // waits 15ms for the servo to reach the position
+	}
+}
+

--- a/workspace/__ardulib__/ESP32Servo/examples/ToneExample/ToneExample.ino
+++ b/workspace/__ardulib__/ESP32Servo/examples/ToneExample/ToneExample.ino
@@ -1,0 +1,25 @@
+/*
+
+
+ */
+
+#include <ESP32Servo.h>
+int pin = 2;
+void setup() {
+	// Allow allocation of all timers
+	ESP32PWM::allocateTimer(0);
+	ESP32PWM::allocateTimer(1);
+	ESP32PWM::allocateTimer(2);
+	ESP32PWM::allocateTimer(3);
+	Serial.begin(115200);
+
+}
+
+void loop() {
+	tone(pin, 4186, // C
+			500); // half a second
+	tone(pin, 5274, // E
+			500); // half a second
+	delay(500);
+
+}

--- a/workspace/__ardulib__/ESP32Servo/examples/analogWriteExample/analogWriteExample.ino
+++ b/workspace/__ardulib__/ESP32Servo/examples/analogWriteExample/analogWriteExample.ino
@@ -1,0 +1,82 @@
+/*
+ Mega analogWrite() test
+
+ This sketch fades LEDs up and down one at a time on digital pins 2 through 13.
+ This sketch was written for the Arduino Mega, and will not work on previous boards.
+
+ The circuit:
+ * LEDs attached from pins 2 through 13 to ground. or for ESP32-S2 pins 1-17,19-21,26,33-42
+
+ created 8 Feb 2009
+ by Tom Igoe
+
+ This example code is in the public domain.
+
+ */
+// These constants won't change.  They're used to give names
+// to the pins used:
+#if defined(ARDUINO_ESP32S2_DEV)
+const int lowestPin = 1;
+const int highestPin = 42;
+#else
+const int lowestPin = 2;
+const int highestPin = 33;
+#endif
+#include <ESP32Servo.h>
+Servo myservo;
+
+void setup() {
+	Serial.begin(115200);
+	// Allow allocation of all timers
+	ESP32PWM::allocateTimer(0);
+	ESP32PWM::allocateTimer(1);
+	ESP32PWM::allocateTimer(2);
+	ESP32PWM::allocateTimer(3);
+}
+
+void loop() {
+	if (!myservo.attached()) {
+		myservo.setPeriodHertz(50); // standard 50 hz servo
+		myservo.attach(33, 1000, 2000); // Attach the servo after it has been detatched
+	}
+	myservo.write(0);
+	// iterate over the pins:
+	for (int thisPin = lowestPin; thisPin <= highestPin; thisPin++) {
+		if (ESP32PWM::hasPwm(thisPin) &&  // Is it possible for this pin to PWM
+				(ESP32PWM::channelsRemaining() > 0 || // New channels availible to allocate
+						pwmFactory(thisPin) != NULL || // already allocated this pin in the factory
+						thisPin == 25 || // one of the  2 DAC outputs, no timer needed
+						thisPin == 26)) { // one of the 2 DAC outputs, no timer needed
+			if (pwmFactory(thisPin) == NULL) { // check if its the first time for the pin or its a DAC
+#if defined(ARDUINO_ESP32S2_DEV)
+				if (thisPin == 17 || // one of the 2 DAC outputs, no timer needed
+						thisPin == 18)
+#else
+				if (thisPin == 25 || // one of the 2 DAC outputs, no timer needed
+						thisPin == 26)
+#endif
+				{
+					Serial.println("DAC to pin " + String(thisPin));
+				} else
+					Serial.println("Writing to pin " + String(thisPin));
+				pinMode(thisPin, OUTPUT);
+			}
+			// fade the LED on thisPin from off to brightest:
+			for (int brightness = 0; brightness < 255; brightness++) {
+				analogWrite(thisPin, brightness);
+				delay(1);
+				myservo.write(brightness);
+			}
+			// fade the LED on thisPin from brithstest to off:
+			for (int brightness = 255; brightness >= 0; brightness--) {
+				analogWrite(thisPin, brightness);
+				myservo.write(brightness);
+				delay(1);
+			}
+
+		}
+	}
+	myservo.detach(); // Turn the servo off for a while
+	delay(2000);
+
+}

--- a/workspace/__ardulib__/ESP32Servo/keywords.txt
+++ b/workspace/__ardulib__/ESP32Servo/keywords.txt
@@ -1,0 +1,26 @@
+#######################################
+# Syntax Coloring Map ESP32_Servo
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+Servo	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+attach	KEYWORD2
+detach	KEYWORD2
+write	KEYWORD2
+read	KEYWORD2
+attached	KEYWORD2
+writeMicroseconds	KEYWORD2
+readMicroseconds	KEYWORD2
+setTimerWidth 		KEYWORD2
+readTimerWidth		KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################

--- a/workspace/__ardulib__/ESP32Servo/library.properties
+++ b/workspace/__ardulib__/ESP32Servo/library.properties
@@ -1,0 +1,11 @@
+name=ESP32Servo
+version=0.9.0
+author=Kevin Harrington,John K. Bennett
+maintainer=Kevin Harrington <mad.hephaestus@gmail.com>
+sentence=Allows ESP32 boards to control servo, tone and analogWrite motors using Arduino semantics. 
+paragraph=This library can control a many types of servos.<br />It makes use of the ESP32 PWM timers: the library can control up to 16 servos on individual channels<br />No attempt has been made to support multiple servos per channel.<br />
+category=Device Control
+url=https://madhephaestus.github.io/ESP32Servo/annotated.html
+architectures=esp32
+includes=ESP32Servo.h,analogWrite.h,tone.h,ESP32Tone.h,ESP32PWM.h
+

--- a/workspace/__ardulib__/ESP32Servo/src/ESP32PWM.cpp
+++ b/workspace/__ardulib__/ESP32Servo/src/ESP32PWM.cpp
@@ -1,0 +1,317 @@
+/*
+ * ESP32PWM.cpp
+ *
+ *  Created on: Sep 22, 2018
+ *      Author: hephaestus
+ */
+
+#include <ESP32PWM.h>
+#include "esp32-hal-ledc.h"
+
+// initialize the class variable ServoCount
+int ESP32PWM::PWMCount = -1;              // the total number of attached servos
+bool  ESP32PWM::explicateAllocationMode=false;
+ESP32PWM * ESP32PWM::ChannelUsed[NUM_PWM]; // used to track whether a channel is in service
+long ESP32PWM::timerFreqSet[4] = { -1, -1, -1, -1 };
+int ESP32PWM::timerCount[4] = { 0, 0, 0, 0 };
+// The ChannelUsed array elements are 0 if never used, 1 if in use, and -1 if used and disposed
+// (i.e., available for reuse)
+/**
+ * allocateTimer
+ * @param a timer number 0-3 indicating which timer to allocate in this library
+ * Switch to explicate allocation mode
+ *
+ */
+void ESP32PWM::allocateTimer(int timerNumber){
+	if(timerNumber<0 || timerNumber>3)
+		return;
+	if(ESP32PWM::explicateAllocationMode==false){
+		ESP32PWM::explicateAllocationMode=true;
+		for(int i=0;i<4;i++)
+			ESP32PWM::timerCount[i]=4;// deallocate all timers to start mode
+	}
+	ESP32PWM::timerCount[timerNumber]=0;
+}
+
+ESP32PWM::ESP32PWM() {
+	resolutionBits = 8;
+	pwmChannel = -1;
+	pin = -1;
+	myFreq = -1;
+	if (PWMCount == -1) {
+		for (int i = 0; i < NUM_PWM; i++)
+			ChannelUsed[i] = NULL; // load invalid data into the storage array of pin mapping
+		PWMCount = PWM_BASE_INDEX; // 0th channel does not work with the PWM system
+	}
+}
+
+ESP32PWM::~ESP32PWM() {
+	if (attached()) {
+		ledcDetachPin(pin);
+	}
+	deallocate();
+}
+
+double ESP32PWM::_ledcSetupTimerFreq(uint8_t chan, double freq,
+		uint8_t bit_num) {
+	return ledcSetup(chan, freq, bit_num);
+
+}
+
+int ESP32PWM::timerAndIndexToChannel(int timerNum, int index) {
+	int localIndex = 0;
+	for (int j = 0; j < NUM_PWM; j++) {
+		if (((j / 2) % 4) == timerNum) {
+			if (localIndex == index) {
+				return j;
+			}
+			localIndex++;
+		}
+	}
+	return -1;
+}
+int ESP32PWM::allocatenext(double freq) {
+	long freqlocal = (long) freq;
+	if (pwmChannel < 0) {
+		for (int i = 0; i < 4; i++) {
+			bool freqAllocated = ((timerFreqSet[i] == freqlocal)
+					|| (timerFreqSet[i] == -1));
+			if (freqAllocated && timerCount[i] < 4) {
+				if (timerFreqSet[i] == -1) {
+					//Serial.println("Starting timer "+String(i)+" at freq "+String(freq));
+					timerFreqSet[i] = freqlocal;
+				}
+				//Serial.println("Free channel timer "+String(i)+" at freq "+String(freq)+" remaining "+String(4-timerCount[i]));
+
+				timerNum = i;
+				for (int index=0; index<4; ++index)
+				{
+					int myTimerNumber = timerAndIndexToChannel(timerNum,index);
+					if ((myTimerNumber >= 0)  && (!ChannelUsed[myTimerNumber]))
+					{
+						pwmChannel = myTimerNumber;
+// 						Serial.println(
+// 							"PWM on ledc channel #" + String(pwmChannel)
+// 									+ " using 'timer " + String(timerNum)
+// 									+ "' to freq " + String(freq) + "Hz");
+						ChannelUsed[pwmChannel] = this;
+						timerCount[timerNum]++;
+						PWMCount++;
+						myFreq = freq;
+						return pwmChannel;
+					}
+				}
+			} else {
+//				if(timerFreqSet[i]>0)
+//					Serial.println("Timer freq mismatch target="+String(freq)+" on timer "+String(i)+" was "+String(timerFreqSet[i]));
+//				else
+//					Serial.println("Timer out of channels target="+String(freq)+" on timer "+String(i)+" was "+String(timerCount[i]));
+			}
+		}
+	} else {
+		return pwmChannel;
+	}
+	Serial.println(
+			"ERROR All PWM timers allocated! Can't accomodate " + String(freq)
+					+ "Hz\r\nHalting...");
+	while (1)
+		;
+}
+void ESP32PWM::deallocate() {
+	if (pwmChannel < 0)
+		return;
+// 	Serial.println("PWM deallocating LEDc #" + String(pwmChannel));
+	timerCount[getTimer()]--;
+	if (timerCount[getTimer()] == 0) {
+		timerFreqSet[getTimer()] = -1; // last pwn closed out
+	}
+	timerNum = -1;
+	attachedState = false;
+	ChannelUsed[pwmChannel] = NULL;
+	pwmChannel = -1;
+	PWMCount--;
+
+}
+
+int ESP32PWM::getChannel() {
+	if (pwmChannel < 0) {
+		Serial.println("FAIL! must setup() before using get channel!");
+	}
+	return pwmChannel;
+}
+
+double ESP32PWM::setup(double freq, uint8_t resolution_bits) {
+	checkFrequencyForSideEffects(freq);
+
+	resolutionBits = resolution_bits;
+	if (attached()) {
+		ledcDetachPin(pin);
+		double val = ledcSetup(getChannel(), freq, resolution_bits);
+		attachPin(pin);
+		return val;
+	}
+	return ledcSetup(getChannel(), freq, resolution_bits);
+}
+float ESP32PWM::getDutyScaled() {
+	return mapf((float) myDuty, 0, (float) ((1 << resolutionBits) - 1), 0.0,
+			1.0);
+}
+void ESP32PWM::writeScaled(float duty) {
+	write(mapf(duty, 0.0, 1.0, 0, (float) ((1 << resolutionBits) - 1)));
+}
+void ESP32PWM::write(uint32_t duty) {
+	myDuty = duty;
+	ledcWrite(getChannel(), duty);
+}
+void ESP32PWM::adjustFrequencyLocal(double freq, float dutyScaled) {
+	timerFreqSet[getTimer()] = (long) freq;
+	myFreq = freq;
+	if (attached()) {
+		ledcDetachPin(pin);
+		// Remove the PWM during frequency adjust
+		_ledcSetupTimerFreq(getChannel(), freq, resolutionBits);
+		writeScaled(dutyScaled);
+		ledcAttachPin(pin, getChannel()); // re-attach the pin after frequency adjust
+	} else {
+		_ledcSetupTimerFreq(getChannel(), freq, resolutionBits);
+		writeScaled(dutyScaled);
+	}
+}
+void ESP32PWM::adjustFrequency(double freq, float dutyScaled) {
+	if(dutyScaled<0)
+		dutyScaled=getDutyScaled();
+	writeScaled(dutyScaled);
+	for (int i = 0; i < timerCount[getTimer()]; i++) {
+		int pwm = timerAndIndexToChannel(getTimer(), i);
+		if (ChannelUsed[pwm] != NULL) {
+			if (ChannelUsed[pwm]->myFreq != freq) {
+				ChannelUsed[pwm]->adjustFrequencyLocal(freq,
+						ChannelUsed[pwm]->getDutyScaled());
+			}
+		}
+	}
+}
+double ESP32PWM::writeTone(double freq) {
+	for (int i = 0; i < timerCount[getTimer()]; i++) {
+		int pwm = timerAndIndexToChannel(getTimer(), i);
+		if (ChannelUsed[pwm] != NULL) {
+			if (ChannelUsed[pwm]->myFreq != freq) {
+				ChannelUsed[pwm]->adjustFrequencyLocal(freq,
+						ChannelUsed[pwm]->getDutyScaled());
+			}
+			write(1 << (resolutionBits-1)); // writeScaled(0.5);
+		}
+	}
+
+	return 0;
+}
+double ESP32PWM::writeNote(note_t note, uint8_t octave) {
+	const uint16_t noteFrequencyBase[12] = {
+			//   C        C#       D        Eb       E        F       F#        G       G#        A       Bb        B
+			4186, 4435, 4699, 4978, 5274, 5588, 5920, 6272, 6645, 7040, 7459,
+			7902 };
+
+	if (octave > 8 || note >= NOTE_MAX) {
+		return 0;
+	}
+	double noteFreq = (double) noteFrequencyBase[note]
+			/ (double) (1 << (8 - octave));
+	return writeTone(noteFreq);
+}
+uint32_t ESP32PWM::read() {
+	return ledcRead(getChannel());
+}
+double ESP32PWM::readFreq() {
+	return myFreq;
+}
+void ESP32PWM::attach(int p) {
+	pin = p;
+	attachedState = true;
+}
+void ESP32PWM::attachPin(uint8_t pin) {
+
+	if (hasPwm(pin)) {
+		attach(pin);
+		ledcAttachPin(pin, getChannel());
+	} else {
+		Serial.println(
+				"ERROR PWM channel unavailible on pin requested! " + String(pin)
+#if defined(ARDUINO_ESP32S2_DEV)
+						+ "\r\nPWM availible on: 1-21,26,33-42"
+#else
+						+ "\r\nPWM availible on: 2,4,5,12-19,21-23,25-27,32-33"
+#endif
+		);
+		return;
+	}
+	//Serial.print(" on pin "+String(pin));
+}
+void ESP32PWM::attachPin(uint8_t pin, double freq, uint8_t resolution_bits) {
+
+	if (hasPwm(pin))
+		setup(freq, resolution_bits);
+	attachPin(pin);
+}
+void ESP32PWM::detachPin(int pin) {
+	ledcDetachPin(pin);
+	deallocate();
+}
+/* Side effects of frequency changes happen because of shared timers
+ *
+ * LEDC Chan to Group/Channel/Timer Mapping
+ ** ledc: 0  => Group: 0, Channel: 0, Timer: 0
+ ** ledc: 1  => Group: 0, Channel: 1, Timer: 0
+ ** ledc: 2  => Group: 0, Channel: 2, Timer: 1
+ ** ledc: 3  => Group: 0, Channel: 3, Timer: 1
+ ** ledc: 4  => Group: 0, Channel: 4, Timer: 2
+ ** ledc: 5  => Group: 0, Channel: 5, Timer: 2
+ ** ledc: 6  => Group: 0, Channel: 6, Timer: 3
+ ** ledc: 7  => Group: 0, Channel: 7, Timer: 3
+ ** ledc: 8  => Group: 1, Channel: 0, Timer: 0
+ ** ledc: 9  => Group: 1, Channel: 1, Timer: 0
+ ** ledc: 10 => Group: 1, Channel: 2, Timer: 1
+ ** ledc: 11 => Group: 1, Channel: 3, Timer: 1
+ ** ledc: 12 => Group: 1, Channel: 4, Timer: 2
+ ** ledc: 13 => Group: 1, Channel: 5, Timer: 2
+ ** ledc: 14 => Group: 1, Channel: 6, Timer: 3
+ ** ledc: 15 => Group: 1, Channel: 7, Timer: 3
+ */
+
+bool ESP32PWM::checkFrequencyForSideEffects(double freq) {
+
+	allocatenext(freq);
+	for (int i = 0; i < timerCount[getTimer()]; i++) {
+		int pwm = timerAndIndexToChannel(getTimer(), i);
+
+		if (pwm == pwmChannel)
+			continue;
+		if (ChannelUsed[pwm] != NULL)
+			if (ChannelUsed[pwm]->getTimer() == getTimer()) {
+				double diff = abs(ChannelUsed[pwm]->myFreq - freq);
+				if (abs(diff) > 0.1) {
+					Serial.println(
+							"\tWARNING PWM channel " + String(pwmChannel)
+									+ " shares a timer with channel "
+									+ String(pwm) + "\n"
+											"\tchanging the frequency to "
+									+ String(freq)
+									+ " Hz will ALSO change channel "
+									+ String(pwm)
+									+ " \n\tfrom its previous frequency of "
+									+ String(ChannelUsed[pwm]->myFreq) + " Hz\n"
+											" ");
+					ChannelUsed[pwm]->myFreq = freq;
+				}
+			}
+	}
+	return true;
+}
+
+ESP32PWM* pwmFactory(int pin) {
+	for (int i = 0; i < NUM_PWM; i++)
+		if (ESP32PWM::ChannelUsed[i] != NULL) {
+			if (ESP32PWM::ChannelUsed[i]->getPin() == pin)
+				return ESP32PWM::ChannelUsed[i];
+		}
+	return NULL;
+}

--- a/workspace/__ardulib__/ESP32Servo/src/ESP32PWM.h
+++ b/workspace/__ardulib__/ESP32Servo/src/ESP32PWM.h
@@ -1,0 +1,125 @@
+/*
+ * ESP32PWM.h
+ *
+ *  Created on: Sep 22, 2018
+ *      Author: hephaestus
+ */
+
+#ifndef LIBRARIES_ESP32SERVO_SRC_ESP32PWM_H_
+#define LIBRARIES_ESP32SERVO_SRC_ESP32PWM_H_
+#include "esp32-hal-ledc.h"
+#define NUM_PWM 16
+#define PWM_BASE_INDEX 0
+#define USABLE_ESP32_PWM (NUM_PWM-PWM_BASE_INDEX)
+#include <cstdint>
+
+#include "Arduino.h"
+class ESP32PWM {
+private:
+
+	void attach(int pin);
+	int pwmChannel = 0;                         // channel number for this servo
+	bool attachedState = false;
+	int pin;
+	uint8_t resolutionBits;
+	double myFreq;
+	int allocatenext(double freq);
+
+	static double _ledcSetupTimerFreq(uint8_t chan, double freq,
+			uint8_t bit_num);
+
+	bool checkFrequencyForSideEffects(double freq);
+
+	void adjustFrequencyLocal(double freq, float dutyScaled);
+	static float mapf(float x, float in_min, float in_max, float out_min,
+			float out_max) {
+		if(x>in_max)
+			return out_max;
+		if(x<in_min)
+			return out_min;
+		return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+	}
+
+	double setup(double freq, uint8_t resolution_bits=10);
+	//channel 0-15 resolution 1-16bits freq limits depend on resolution9
+	void attachPin(uint8_t pin);
+	// pin allocation
+	void deallocate();
+public:
+	// setup
+	ESP32PWM();
+	virtual ~ESP32PWM();
+
+
+	void detachPin(int pin);
+	void attachPin(uint8_t pin, double freq, uint8_t resolution_bits=10);
+	bool attached() {
+		return attachedState;
+	}
+
+	// write raw duty cycle
+	void write(uint32_t duty);
+	// Write a duty cycle to the PWM using a unit vector from 0.0-1.0
+	void writeScaled(float duty);
+	//Adjust frequency
+	double writeTone(double freq);
+	double writeNote(note_t note, uint8_t octave);
+	void adjustFrequency(double freq, float dutyScaled=-1);
+
+	// Read pwm data
+	uint32_t read();
+	double readFreq();
+	float getDutyScaled();
+
+	//Timer data
+	static int timerAndIndexToChannel(int timer, int index);
+	/**
+	 * allocateTimer
+	 * @param a timer number 0-3 indicating which timer to allocate in this library
+	 * Switch to explicate allocation mode
+	 *
+	 */
+	static void allocateTimer(int timerNumber);
+	static bool explicateAllocationMode;
+	int getTimer() {
+		return timerNum;
+	}
+	int timerNum = -1;
+	uint32_t myDuty = 0;
+	int getChannel();
+	static int PWMCount;              // the total number of attached pwm
+	static int timerCount[4];
+	static ESP32PWM * ChannelUsed[NUM_PWM]; // used to track whether a channel is in service
+	static long timerFreqSet[4];
+
+	// Helper functions
+	int getPin() {
+		return pin;
+	}
+	static bool hasPwm(int pin) {
+#if defined(ARDUINO_ESP32S2_DEV)
+		if ((pin >=1 && pin <= 21) || //20
+				(pin == 26) || //1
+				(pin >= 33 && pin <= 42)) //10
+#else
+		if ((pin == 2) || //1
+				(pin == 4) || //1
+				(pin == 5) || //1
+				((pin >= 12) && (pin <= 19)) || //8
+				((pin >= 21) && (pin <= 23)) || //3
+				((pin >= 25) && (pin <= 27)) || //3
+				(pin == 32) || (pin == 33)) //2
+#endif
+			return true;
+		return false;
+	}
+	static int channelsRemaining() {
+		return NUM_PWM - PWMCount;
+	}
+
+
+};
+
+ESP32PWM* pwmFactory(int pin);
+
+#endif /* LIBRARIES_ESP32SERVO_SRC_ESP32PWM_H_ */

--- a/workspace/__ardulib__/ESP32Servo/src/ESP32Servo.cpp
+++ b/workspace/__ardulib__/ESP32Servo/src/ESP32Servo.cpp
@@ -1,0 +1,243 @@
+/*
+Copyright (c) 2017 John K. Bennett. All right reserved.
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+* Notes on the implementation:
+* The ESP32 supports 16 hardware LED PWM channels that are intended
+* to be used for LED brightness control. The low level ESP32 code
+* (esp32-hal-ledc.*) allows us to set the PWM frequency and bit-depth,
+* and then manipulate them by setting bits in the relevant control
+* registers.
+*
+* Different servos require different pulse widths to vary servo angle, but the range is
+* an approximately 500-2500 microsecond pulse every 20ms (50Hz). In general, hobbyist servos
+* sweep 180 degrees, so the lowest number in the published range for a particular servo
+* represents an angle of 0 degrees, the middle of the range represents 90 degrees, and the top
+* of the range represents 180 degrees. So for example, if the range is 1000us to 2000us,
+* 1000us would equal an angle of 0, 1500us would equal 90 degrees, and 2000us would equal 180
+* degrees. We vary pulse width (recall that the pulse period is already set to 20ms) as follows:
+*
+* The ESP32 PWM timers allow us to set the timer width (max 20 bits). Thus
+* the timer "tick" length is (pulse_period/2**timer_width), and the equation for pulse_high_width
+* (the portion of the 20ms cycle that the signal is high) becomes:
+*
+*                  pulse_high_width  = count * tick_length
+*                                    = count * (pulse_period/2**timer_width)
+*
+*            and   count = (pulse_high_width / (pulse_period/2**timer_width))
+*
+* So, for example, if I want a 1500us pulse_high_width, I set pulse_period to 20ms (20000us)
+* (this value is set in the ledcSetup call), and count (used in the ledcWrite call) to
+* 1500/(20000/65536), or 4924. This is the value we write to the timer in the ledcWrite call.
+* If we increase the timer_width, the timer_count values need to be adjusted.
+*
+* The servo signal pins connect to any available GPIO pins on the ESP32, but not all pins are
+* GPIO pins.
+*
+* The ESP32 is a 32 bit processor that includes FP support; this code reflects that fact.
+*/
+
+#include <ESP32Servo.h>
+#include "Arduino.h"
+
+//
+Servo::Servo()
+{		// initialize this channel with plausible values, except pin # (we set pin # when attached)
+	REFRESH_CPS = 50;
+	this->ticks = DEFAULT_PULSE_WIDTH_TICKS;
+	this->timer_width = DEFAULT_TIMER_WIDTH;
+	this->pinNumber = -1;     // make it clear that we haven't attached a pin to this channel
+	this->min = DEFAULT_uS_LOW;
+	this->max = DEFAULT_uS_HIGH;
+	this->timer_width_ticks = pow(2,this->timer_width);
+
+}
+ESP32PWM * Servo::getPwm(){
+
+	return &pwm;
+}
+
+int Servo::attach(int pin)
+{
+
+    return (this->attach(pin, DEFAULT_uS_LOW, DEFAULT_uS_HIGH));
+}
+
+int Servo::attach(int pin, int min, int max)
+{
+
+#ifdef ENFORCE_PINS
+        // ESP32 Recommend only the following pins 2,4,12-19,21-23,25-27,32-33
+		// ESP32-S2 only the following pins 1-21,26,33-42
+        if (pwm.hasPwm(pin))
+        {
+#endif
+
+            // OK to proceed; first check for new/reuse
+            if (this->pinNumber < 0) // we are attaching to a new or previously detached pin; we need to initialize/reinitialize
+            {
+                this->ticks = DEFAULT_PULSE_WIDTH_TICKS;
+                this->timer_width = DEFAULT_TIMER_WIDTH;
+                this->timer_width_ticks = pow(2,this->timer_width);
+            }
+            this->pinNumber = pin;
+#ifdef ENFORCE_PINS
+        }
+        else
+        {
+        	Serial.println("This pin can not be a servo: "+String(pin)+
+#if defined(ARDUINO_ESP32S2_DEV)
+				"\r\nServo availible on: 1-21,26,33-42"
+#else
+				"\r\nServo availible on: 2,4,5,12-19,21-23,25-27,32-33"
+#endif
+			);
+            return 0;
+        }
+#endif
+
+
+        // min/max checks 
+        if (min < MIN_PULSE_WIDTH)          // ensure pulse width is valid
+            min = MIN_PULSE_WIDTH;
+        if (max > MAX_PULSE_WIDTH)
+            max = MAX_PULSE_WIDTH;
+        this->min = min;     //store this value in uS
+        this->max = max;    //store this value in uS
+        // Set up this channel
+        // if you want anything other than default timer width, you must call setTimerWidth() before attach
+        pwm.attachPin(this->pinNumber,REFRESH_CPS, this->timer_width );   // GPIO pin assigned to channel
+        //Serial.println("Attaching servo : "+String(pin)+" on PWM "+String(pwm.getChannel()));
+        return 1;
+}
+
+void Servo::detach()
+{
+    if (this->attached())
+    {
+        //keep track of detached servos channels so we can reuse them if needed
+        pwm.detachPin(this->pinNumber);
+
+        this->pinNumber = -1;
+    }
+}
+
+void Servo::write(int value)
+{
+    // treat values less than MIN_PULSE_WIDTH (500) as angles in degrees (valid values in microseconds are handled as microseconds)
+    if (value < MIN_PULSE_WIDTH)
+    {
+        if (value < 0)
+            value = 0;
+        else if (value > 180)
+            value = 180;
+
+        value = map(value, 0, 180, this->min, this->max);
+    }
+    this->writeMicroseconds(value);
+}
+
+void Servo::writeMicroseconds(int value)
+{
+    // calculate and store the values for the given channel
+    if (this->attached())   // ensure channel is valid
+    {
+        if (value < this->min)          // ensure pulse width is valid
+            value = this->min;
+        else if (value > this->max)
+            value = this->max;
+
+        value = usToTicks(value);  // convert to ticks
+        this->ticks = value;
+        // do the actual write
+        pwm.write( this->ticks);
+    }
+}
+
+int Servo::read() // return the value as degrees
+{
+    return (map(readMicroseconds()+1, this->min, this->max, 0, 180));
+}
+
+int Servo::readMicroseconds()
+{
+    int pulsewidthUsec;
+    if (this->attached())
+    { 
+        pulsewidthUsec = ticksToUs(this->ticks);
+    }
+    else
+    {
+        pulsewidthUsec = 0;
+    }
+
+    return (pulsewidthUsec);
+}
+
+bool Servo::attached()
+{
+    return (pwm.attached());
+}
+
+void Servo::setTimerWidth(int value)
+{
+    // only allow values between 16 and 20
+    if (value < 16)
+        value = 16;
+    else if (value > 20)
+        value = 20;
+        
+    // Fix the current ticks value after timer width change
+    // The user can reset the tick value with a write() or writeUs()
+    int widthDifference = this->timer_width - value;
+    // if positive multiply by diff; if neg, divide
+    if (widthDifference > 0)
+    {
+        this->ticks = widthDifference * this->ticks;
+    }
+    else if (widthDifference < 0)
+    {
+        this->ticks = this->ticks/-widthDifference;
+    }
+    
+    this->timer_width = value;
+    this->timer_width_ticks = pow(2,this->timer_width);
+    
+    // If this is an attached servo, clean up
+    if (this->attached())
+    {
+        // detach, setup and attach again to reflect new timer width
+    	pwm.detachPin(this->pinNumber);
+    	pwm.attachPin(this->pinNumber, REFRESH_CPS, this->timer_width);
+    }        
+}
+
+int Servo::readTimerWidth()
+{
+    return (this->timer_width);
+}
+
+int Servo::usToTicks(int usec)
+{
+    return (int)((float)usec / ((float)REFRESH_USEC / (float)this->timer_width_ticks)*(((float)REFRESH_CPS)/50.0));
+}
+
+int Servo::ticksToUs(int ticks)
+{
+    return (int)((float)ticks * ((float)REFRESH_USEC / (float)this->timer_width_ticks)/(((float)REFRESH_CPS)/50.0));
+}
+
+ 

--- a/workspace/__ardulib__/ESP32Servo/src/ESP32Servo.h
+++ b/workspace/__ardulib__/ESP32Servo/src/ESP32Servo.h
@@ -1,0 +1,160 @@
+/*
+ Copyright (c) 2017 John K. Bennett. All right reserved.
+
+ ESP32_Servo.h - Servo library for ESP32 - Version 1
+
+ Original Servo.h written by Michael Margolis in 2009
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/* 
+ A servo is activated by creating an instance of the Servo class, and passing
+ the desired GPIO pin to the attach() method.
+ The servos are pulsed in the background using the value most recently
+ written using the write() method.
+
+ The class methods are:
+
+ Servo - Class for manipulating servo motors connected to ESP32 pins.
+ int attach(pin )  - Attaches the given GPIO pin to the next free channel
+ (channels that have previously been detached are used first),
+ returns channel number or 0 if failure. All pin numbers are allowed,
+ but only pins 2,4,12-19,21-23,25-27,32-33 are recommended.
+ int attach(pin, min, max  ) - Attaches to a pin setting min and max
+ values in microseconds; enforced minimum min is 500, enforced max
+ is 2500. Other semantics same as attach().
+ void write () - Sets the servo angle in degrees; a value below 500 is
+ treated as a value in degrees (0 to 180). These limit are enforced,
+ i.e., values are treated as follows:
+ Value                                   Becomes
+ -----                                   -------
+ < 0                                        0
+ 0 - 180                             value (treated as degrees)
+ 181 - 499                                 180
+ 500 - (min-1)                             min
+ min-max (from attach or default)    value (treated as microseconds)
+ (max+1) - 2500                            max
+
+ void writeMicroseconds() - Sets the servo pulse width in microseconds.
+ min and max are enforced (see above).
+ int read() - Gets the last written servo pulse width as an angle between 0 and 180.
+ int readMicroseconds()   - Gets the last written servo pulse width in microseconds.
+ bool attached() - Returns true if this servo instance is attached.
+ void detach() - Stops an the attached servo, frees its attached pin, and frees
+ its channel for reuse).
+
+ *** ESP32-specific functions **
+ setTimerWidth(value) - Sets the PWM timer width (must be 16-20) (ESP32 ONLY);
+ as a side effect, the pulse width is recomputed.
+ int readTimerWidth() - Gets the PWM timer width (ESP32 ONLY)
+ */
+
+#ifndef ESP32_Servo_h
+#define ESP32_Servo_h
+#include "analogWrite.h"
+#include "ESP32PWM.h"
+#include "ESP32Tone.h"
+//Enforce only using PWM pins on the ESP32
+#define ENFORCE_PINS
+// Default Arduino Servo.h
+#define DEFAULT_uS_LOW 544
+#define DEFAULT_uS_HIGH 2400
+
+// Values for TowerPro MG995 large servos (and many other hobbyist servos)
+//#define DEFAULT_uS_LOW 1000        // 1000us
+//#define DEFAULT_uS_HIGH 2000      // 2000us
+
+// Values for TowerPro SG90 small servos
+//#define DEFAULT_uS_LOW 400
+//#define DEFAULT_uS_HIGH 2400
+
+#define DEFAULT_TIMER_WIDTH 16
+#define DEFAULT_TIMER_WIDTH_TICKS 65536
+
+#define ESP32_Servo_VERSION           1     // software version of this library
+
+#define MIN_PULSE_WIDTH       500     // the shortest pulse sent to a servo  
+#define MAX_PULSE_WIDTH      2500     // the longest pulse sent to a servo 
+#define DEFAULT_PULSE_WIDTH  1500     // default pulse width when servo is attached
+#define DEFAULT_PULSE_WIDTH_TICKS 4825
+//#define REFRESH_CPS            50
+#define REFRESH_USEC         20000
+
+#define MAX_SERVOS              16     // no. of PWM channels in ESP32
+
+/*
+ * This group/channel/timmer mapping is for information only;
+ * the details are handled by lower-level code
+ *
+ * LEDC Chan to Group/Channel/Timer Mapping
+ ** ledc: 0  => Group: 0, Channel: 0, Timer: 0
+ ** ledc: 1  => Group: 0, Channel: 1, Timer: 0
+ ** ledc: 2  => Group: 0, Channel: 2, Timer: 1
+ ** ledc: 3  => Group: 0, Channel: 3, Timer: 1
+ ** ledc: 4  => Group: 0, Channel: 4, Timer: 2
+ ** ledc: 5  => Group: 0, Channel: 5, Timer: 2
+ ** ledc: 6  => Group: 0, Channel: 6, Timer: 3
+ ** ledc: 7  => Group: 0, Channel: 7, Timer: 3
+ ** ledc: 8  => Group: 1, Channel: 0, Timer: 0
+ ** ledc: 9  => Group: 1, Channel: 1, Timer: 0
+ ** ledc: 10 => Group: 1, Channel: 2, Timer: 1
+ ** ledc: 11 => Group: 1, Channel: 3, Timer: 1
+ ** ledc: 12 => Group: 1, Channel: 4, Timer: 2
+ ** ledc: 13 => Group: 1, Channel: 5, Timer: 2
+ ** ledc: 14 => Group: 1, Channel: 6, Timer: 3
+ ** ledc: 15 => Group: 1, Channel: 7, Timer: 3
+ */
+
+class Servo {
+
+public:
+	Servo();
+	// Arduino Servo Library calls
+	int attach(int pin); // attach the given pin to the next free channel, returns channel number or 0 if failure
+	int attach(int pin, int min, int max); // as above but also sets min and max values for writes.
+	void detach();
+	void write(int value); // if value is < MIN_PULSE_WIDTH its treated as an angle, otherwise as pulse width in microseconds
+	void writeMicroseconds(int value);     // Write pulse width in microseconds
+	int read(); // returns current pulse width as an angle between 0 and 180 degrees
+	int readMicroseconds(); // returns current pulse width in microseconds for this servo
+	bool attached(); // return true if this servo is attached, otherwise false
+
+	// ESP32 only functions
+	void setTimerWidth(int value);     // set the PWM timer width (ESP32 ONLY)
+	int readTimerWidth();              // get the PWM timer width (ESP32 ONLY)
+	void setPeriodHertz(int hertz){
+		REFRESH_CPS=hertz;
+		setTimerWidth(this->timer_width);
+	}
+private:
+	int usToTicks(int usec);
+	int ticksToUs(int ticks);
+//   static int ServoCount;                             // the total number of attached servos
+//   static int ChannelUsed[];                          // used to track whether a channel is in service
+//   int servoChannel = 0;                              // channel number for this servo
+
+	int min = DEFAULT_uS_LOW;           // minimum pulse width for this servo
+	int max = DEFAULT_uS_HIGH;            // maximum pulse width for this servo
+	int pinNumber = 0;                      // GPIO pin assigned to this channel
+	int timer_width = DEFAULT_TIMER_WIDTH; // ESP32 allows variable width PWM timers
+	int ticks = DEFAULT_PULSE_WIDTH_TICKS; // current pulse width on this channel
+	int timer_width_ticks = DEFAULT_TIMER_WIDTH_TICKS; // no. of ticks at rollover; varies with width
+	ESP32PWM * getPwm(); // get the PWM object
+	ESP32PWM pwm;
+	int REFRESH_CPS = 50;
+
+};
+#endif

--- a/workspace/__ardulib__/ESP32Servo/src/ESP32Tone.cpp
+++ b/workspace/__ardulib__/ESP32Servo/src/ESP32Tone.cpp
@@ -1,0 +1,38 @@
+/*
+ * ESP32Tone.cpp
+ *
+ *  Created on: Sep 23, 2018
+ *      Author: hephaestus
+ */
+
+
+#include "ESP32Tone.h"
+
+void tone(int APin,unsigned int frequency){
+	ESP32PWM* chan = pwmFactory(APin);
+	if (chan == NULL) {
+		chan = new ESP32PWM();
+	}
+	if(!chan->attached()){
+		chan->attachPin(APin,frequency, 10); // This adds the PWM instance to the factory list
+		//Serial.println("Attaching tone : "+String(APin)+" on PWM "+String(chan->getChannel()));
+	}
+	chan->writeTone(frequency);// update the time base of the PWM
+}
+
+void tone(int pin, unsigned int frequency, unsigned long duration){
+	tone(pin,frequency);
+	delay(duration);
+	noTone(pin);
+}
+
+void noTone(int pin){
+	ESP32PWM* chan = pwmFactory(pin);
+	if (chan != NULL) {
+		if(chan->attached())
+		{
+			chan->detachPin(pin);
+			delete chan;
+		}
+	}
+}

--- a/workspace/__ardulib__/ESP32Servo/src/ESP32Tone.h
+++ b/workspace/__ardulib__/ESP32Servo/src/ESP32Tone.h
@@ -1,0 +1,19 @@
+/*
+ * ESP32Tone.h
+ *
+ *  Created on: Sep 23, 2018
+ *      Author: hephaestus
+ */
+
+#ifndef LIBRARIES_ESP32SERVO_SRC_ESP32TONE_H_
+#define LIBRARIES_ESP32SERVO_SRC_ESP32TONE_H_
+#include "ESP32PWM.h"
+void tone(int pin,unsigned int frequency);
+
+void tone(int pin, unsigned int frequency, unsigned long duration);
+
+void noTone(int pin);
+
+
+
+#endif /* LIBRARIES_ESP32SERVO_SRC_ESP32TONE_H_ */

--- a/workspace/__ardulib__/ESP32Servo/src/analogWrite.cpp
+++ b/workspace/__ardulib__/ESP32Servo/src/analogWrite.cpp
@@ -1,0 +1,43 @@
+/*
+ * analogWrite.cpp
+ *
+ *  Created on: Sep 17, 2018
+ *      Author: Harry-Laptop
+ */
+
+#include "analogWrite.h"
+#include "ESP32PWM.h"
+
+void analogWrite(uint8_t APin, uint16_t AValue) {
+	if(APin== 25 ||APin==26){
+		dacWrite(APin, AValue);
+		return;
+	}
+	ESP32PWM* chan = pwmFactory(APin);
+	if (AValue == 0) {
+		if ((chan != NULL) && chan->attached()) {
+			chan->detachPin(APin);
+			delete chan;
+			pinMode(APin, OUTPUT);
+		}
+		digitalWrite(APin, 0);
+	} else if (AValue >= 255) {
+		if ((chan != NULL) && chan->attached()) {
+			chan->detachPin(APin);
+			delete chan;
+			pinMode(APin, OUTPUT);
+		}
+		digitalWrite(APin, 1);
+	} else
+	{
+		if (chan == NULL) {
+			chan = new ESP32PWM();
+		}
+		if(!chan->attached()){
+			chan->attachPin(APin,1000, 8); // This adds the PWM instance to the factory list
+			//Serial.println("Attaching AnalogWrite : "+String(APin)+" on PWM "+String(chan->getChannel()));
+		}
+		chan->write(AValue);
+		//    Serial.print( "ledcWrite: " ); Serial.print(  CESP32PWMPinMap[ APin ] - 1 ); Serial.print( " " ); Serial.println( AValue );
+	}
+}

--- a/workspace/__ardulib__/ESP32Servo/src/analogWrite.h
+++ b/workspace/__ardulib__/ESP32Servo/src/analogWrite.h
@@ -1,0 +1,11 @@
+#if !defined (ESP32AnalogWrite)
+#define ESP32AnalogWrite
+#include <cstdint>
+#include <esp32-hal-ledc.h>
+#include <Arduino.h>
+
+#define PWMRANGE 255
+
+  void analogWrite( uint8_t APin, uint16_t AValue );
+
+#endif

--- a/workspace/__ardulib__/README.md
+++ b/workspace/__ardulib__/README.md
@@ -12,3 +12,4 @@ The directory contains vendoring copies of some Arduino Libraries used in native
 * `Graphics` -- custom library. Implements basic graphic functions in XOD.
 * `ST7735` -- custom library. It is used to drive ST7735 chip-based TFT LCD displays controlled by SPI.
 * `SSD1306` -- custom library. It is used to drive SSD1306 chip-based monochrome TFT LCDs controlled by I2C.
+* `ESP32Servo` -- https://github.com/madhephaestus/ESP32Servo includes class ESP32PWM to work with PWM channels and attach pins and `analogWrite`

--- a/workspace/__lib__/xod-dev/servo/servo-device/patch.cpp
+++ b/workspace/__lib__/xod-dev/servo/servo-device/patch.cpp
@@ -1,6 +1,10 @@
 #pragma XOD error_raise enable
 
+#ifdef ESP32
+#include <ESP32Servo.h>
+#else
 #include <Servo.h>
+#endif
 
 node {
     meta {

--- a/workspace/__lib__/xod/gpio/pwm-write/patch.cpp
+++ b/workspace/__lib__/xod/gpio/pwm-write/patch.cpp
@@ -1,6 +1,10 @@
 #pragma XOD evaluate_on_pin disable
 #pragma XOD evaluate_on_pin enable input_UPD
 
+#ifdef ESP32
+#include <analogWrite.h>
+#endif
+
 node {
     #ifdef PWMRANGE
     static constexpr Number pwmRange = PWMRANGE;
@@ -14,14 +18,13 @@ node {
         if (!isInputDirty<input_UPD>(ctx))
             return;
 
-        const uint8_t port = getValue<input_PORT>(ctx);
-
         auto duty = getValue<input_DUTY>(ctx);
         duty = duty > 1 ? 1 : (duty < 0 ? 0 : duty);
         int val = (int)(duty * pwmRange);
 
-        ::pinMode(port, OUTPUT);
-        ::analogWrite(port, val);
+        pinMode(constant_input_PORT, OUTPUT);
+        analogWrite(constant_input_PORT, val);
+
         emitValue<output_DONE>(ctx, 1);
     }
 }

--- a/workspace/big-patch/__fixtures__/arduino.cpp
+++ b/workspace/big-patch/__fixtures__/arduino.cpp
@@ -1143,7 +1143,11 @@ struct Node {
 //-----------------------------------------------------------------------------
 //#pragma XOD error_raise enable
 
+#ifdef ESP32
+#include <ESP32Servo.h>
+#else
 #include <Servo.h>
+#endif
 
 namespace xod {
 namespace xod_dev__servo__servo_device {
@@ -4430,6 +4434,10 @@ struct Node {
 //#pragma XOD evaluate_on_pin disable
 //#pragma XOD evaluate_on_pin enable input_UPD
 
+#ifdef ESP32
+#include <analogWrite.h>
+#endif
+
 namespace xod {
 namespace xod__gpio__pwm_write {
 template <uint8_t constant_input_PORT>
@@ -4538,14 +4546,13 @@ struct Node {
         if (!isInputDirty<input_UPD>(ctx))
             return;
 
-        const uint8_t port = getValue<input_PORT>(ctx);
-
         auto duty = getValue<input_DUTY>(ctx);
         duty = duty > 1 ? 1 : (duty < 0 ? 0 : duty);
         int val = (int)(duty * pwmRange);
 
-        ::pinMode(port, OUTPUT);
-        ::analogWrite(port, val);
+        pinMode(constant_input_PORT, OUTPUT);
+        analogWrite(constant_input_PORT, val);
+
         emitValue<output_DONE>(ctx, 1);
     }
 


### PR DESCRIPTION
This PR includes:
- fix of adding new URLs into `extra.txt`: updated arduino-cli returns "ENOENT" code instead of `6` when JSON file is not found and our `catch` does not work as expected. This bug does not break a loading new file, but it shows an error message, and list of boards appears only after clicking "Update" button or opening of the upload popup next time.
- Bundle https://github.com/madhephaestus/ESP32Servo library into desktop IDE to support PWM and Servos without requiring libraries from the internet
- Tweak `xod-dev/servo/servo-device` and `xod/gpio/pwm-write` to use the bundled library and work fine on ESP32