### PR TITLE
Fix hotkeys in Inspector Pin widgets

### DIFF
--- a/packages/xod-client/src/editor/components/inspectorWidgets/Widget.jsx
+++ b/packages/xod-client/src/editor/components/inspectorWidgets/Widget.jsx
@@ -38,6 +38,7 @@ class Widget extends React.Component {
     this.onChange = this.onChange.bind(this);
     this.onBlur = this.onBlur.bind(this);
     this.onKeyDown = this.onKeyDown.bind(this);
+    this.updateValue = this.updateValue.bind(this);
 
     this.shouldComponentUpdate = deepSCU.bind(this);
   }
@@ -62,6 +63,10 @@ class Widget extends React.Component {
       this.props.commitOnChange || forceCommit ? this.commit.bind(this) : noop;
 
     this.setState({ value }, commitCallback);
+  }
+
+  updateValue(newValue) {
+    this.setState({ value: newValue });
   }
 
   commit(valueUpdateCallback = noop) {


### PR DESCRIPTION
There is no issue.
Some time ago, when we refactor widgets, we'd lost a method `updateValue` of `Widget` class.

Now it's back and these hotkeys will work again:

- Escape button to cancel changes
- Arrow keys (optionally with shift key) to change numbers
