### PR TITLE
Fix `xod-dev/esp8266-mcu/lan-ip` implementation

### DIFF
--- a/workspace/__lib__/xod-dev/esp8266-mcu/lan-ip/patch.cpp
+++ b/workspace/__lib__/xod-dev/esp8266-mcu/lan-ip/patch.cpp
@@ -1,6 +1,6 @@
 node {
     void evaluate(Context ctx) {
         auto inet = getValue<input_INET>(ctx);
-        emitValue<output_IP>(ctx, (typeof_IP)inet->localIP());
+        emitValue<output_IP>(ctx, (typeof_IP)inet.wifi->localIP());
     }
 }


### PR DESCRIPTION
The issue was reported on [our forum](https://forum.xod.io/t/lan-ip-is-not-compiling/4470)