### PR TITLE
fix(stdlib): make xod graphics bitmaps compile on non-avr boards

### DIFF
--- a/workspace/__ardulib__/Graphics/Bitmap.h
+++ b/workspace/__ardulib__/Graphics/Bitmap.h
@@ -8,7 +8,7 @@ using xod::XColor;
  * A structure to hold basic bitmap parameters.
  */
 struct Bitmap {
-    Bitmap(uint8_t* newBuffer = nullptr, uint8_t newColorDepth = 0, uint16_t newWidth = 0, uint16_t newHeight = 0, uint16_t newKeyColor = 0x0000) {
+    Bitmap(const uint8_t* newBuffer, uint8_t newColorDepth = 0, uint16_t newWidth = 0, uint16_t newHeight = 0, uint16_t newKeyColor = 0x0000) {
         buffer = newBuffer;
         colorDepth = newColorDepth;
         width = newWidth;
@@ -16,7 +16,7 @@ struct Bitmap {
         keyColor = newKeyColor;
     }
 
-    uint8_t* buffer;
+    const uint8_t* buffer;
     uint8_t colorDepth; // 0 = Black and white bitmap, 1 = Colored bitmap (565 format), 2 = Colored bitmap (565) with mask color;
     uint16_t width;
     uint16_t height;


### PR DESCRIPTION
This bug was found here: https://forum.xod.io/t/graphics-arduino-due-st7735/4411
