### PR TITLE
Introduce setImmediate API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,23 @@ defs:
       paths:
         - node_modules
 
+    cache-arduino15: &cache-arduino15
+      # update cache only if package_index.json changed
+      key: arduino15-v1-{{ arch }}-{{ .Branch }}-{{ checksum "~/.arduino15/package_index.json" }}
+      paths:
+        - ~/.arduino15/staging # only archives
+
     restore-node_modules: &restore-node_modules
       keys:
         - node_modules-{{ arch }}-{{ checksum ".circleci/cache-version" }}-{{ checksum "yarn.lock" }}
         # if cache for exact version of `yarn.lock` is not present then
         # load any most recent one
         - node_modules-{{ arch }}-{{ checksum ".circleci/cache-version" }}
+
+    restore-arduino15: &restore-arduino15
+      keys:
+        - arduino15-v1-{{ arch }}-{{ .Branch }}-
+        - arduino15-v1-{{ arch }}-
 
   machines:
     docker-custom-nodejs: &docker-custom-nodejs
@@ -138,10 +149,20 @@ jobs:
     docker: *docker-custom-nodejs
     environment:
       XOD_OUTPUT: /tmp/tabtests-cpp
+      XOD_ARDUINO_CLI: /tmp/arduino-cli/arduino-cli
     steps:
       - checkout
       - restore_cache: *restore-node_modules
       - run: *step-install
+      - run: *step-install-arduino-cli-on-linux
+      - restore_cache: *restore-arduino15
+      - run:
+          name: Install arduino:avr platform for arduino-cli
+          command: $XOD_ARDUINO_CLI core install arduino:avr
+      - save_cache: *cache-arduino15
+      - run:
+          name: Test AVR Size
+          command: ./packages/xod-arduino/tools/test-avr-size.sh
       - run:
           name: Build CLI
           command: yarn build:cli

--- a/packages/xod-arduino/platform/patchContext.tpl.cpp
+++ b/packages/xod-arduino/platform/patchContext.tpl.cpp
@@ -43,6 +43,9 @@ NodeErrors errors = {};
 {{#if usesTimeouts}}
 TimeMs timeoutAt = 0;
 {{/if}}
+{{#if usesSetImmediate}}
+bool isSetImmediate = false;
+{{/if}}
 
 {{#eachNonPulseOrConstant outputs}}
 typeof_{{ pinKey }} _output_{{ pinKey }};
@@ -104,6 +107,11 @@ void clearTimeout(__attribute__((unused)) Context ctx) {
 
 bool isTimedOut(__attribute__((unused)) const Context ctx) {
     return detail::isTimedOut(this);
+}
+{{/if}}
+{{#if usesSetImmediate}}
+void setImmediate() {
+  this->isSetImmediate = true;
 }
 {{/if}}
 

--- a/packages/xod-arduino/platform/program.tpl.cpp
+++ b/packages/xod-arduino/platform/program.tpl.cpp
@@ -274,7 +274,6 @@ void handleDefers() {
           {{/each}}
 
             g_transaction.node_{{id}}_isNodeDirty = false;
-            detail::clearTimeout(&node_{{ id }});
         }
 
         // propagate the error hold by the defer node
@@ -305,6 +304,13 @@ void runTransaction() {
   {{#eachNodeUsingTimeouts nodes}}
     g_transaction.node_{{id}}_isNodeDirty |= detail::isTimedOut(&node_{{id}});
   {{/eachNodeUsingTimeouts}}
+  {{#eachNodeUsingSetImmediate nodes}}
+    if (node_{{id}}.isSetImmediate) {
+      node_{{id}}.isSetImmediate = false;
+      g_transaction.node_{{id}}_isNodeDirty = true;
+    }
+  {{/eachNodeUsingSetImmediate}}
+  
 
     if (isSettingUp()) {
         initializeTweakStrings();

--- a/packages/xod-arduino/src/Directives.re
+++ b/packages/xod-arduino/src/Directives.re
@@ -117,6 +117,11 @@ let areTimeoutsEnabled = code =>
   |. Code.lastPragmaEndis("timeouts")
   |. Endis.toBoolean(Code.doesReferSymbol("setTimeout", code));
 
+let isSetImmediateEnabled = code =>
+  code
+  |. Code.lastPragmaEndis("immediate")
+  |. Endis.toBoolean(Code.doesReferSymbol("setImmediate", code));
+
 let isNodeIdEnabled = code =>
   code
   |. Code.lastPragmaEndis("nodeid")

--- a/packages/xod-arduino/src/Directives.rei
+++ b/packages/xod-arduino/src/Directives.rei
@@ -19,6 +19,17 @@ module Pragma: {
 let areTimeoutsEnabled: code => bool;
 
 /**
+  Returns whether a C++ code requires immediate timeouts storage, i.e., does it relate on
+  `setImmediate` API. Prefers an explicit declaration:
+
+    #pragma XOD immediate disable
+
+  If no pragma found, looks for `setImmediate` call in the code and returns true
+  if it is found.
+ */
+let isSetImmediateEnabled: code => bool;
+
+/**
   Returns whether a C++ code requires node ID access. Prefers an explicit
   declaration
 

--- a/packages/xod-arduino/src/Directives_Js.re
+++ b/packages/xod-arduino/src/Directives_Js.re
@@ -16,6 +16,8 @@ let getEvaluateOnPinSettings = code =>
 
 let areTimeoutsEnabled = Directives.areTimeoutsEnabled;
 
+let isSetImmediateEnabled = Directives.isSetImmediateEnabled;
+
 let stripCppComments = Directives.stripCppComments;
 
 let findXodPragmas = code =>

--- a/packages/xod-arduino/src/templates.js
+++ b/packages/xod-arduino/src/templates.js
@@ -382,6 +382,10 @@ registerHandlebarsFilterLoopHelper(
   'eachNodeUsingTimeouts',
   R.path(['patch', 'usesTimeouts'])
 );
+registerHandlebarsFilterLoopHelper(
+  'eachNodeUsingSetImmediate',
+  R.path(['patch', 'usesSetImmediate'])
+);
 registerHandlebarsFilterLoopHelper('eachLinkedTweakNode', isLinkedTweakNode);
 registerHandlebarsFilterLoopHelper('eachTweakStringNode', isTweakStringNode);
 registerHandlebarsFilterLoopHelper('eachLinkedInput', R.has('fromNodeId'));

--- a/packages/xod-arduino/src/transpiler.js
+++ b/packages/xod-arduino/src/transpiler.js
@@ -21,6 +21,7 @@ import { LIVENESS } from './constants';
 
 import {
   areTimeoutsEnabled,
+  isSetImmediateEnabled,
   isNodeIdEnabled,
   doesRaiseErrors,
   isDirtienessEnabled,
@@ -166,6 +167,7 @@ const convertPatchToTPatch = def(
       isDefer: XP.isDeferNodeType(patchPath),
       isConstant: XP.isConstantNodeType(patchPath),
       usesTimeouts: areTimeoutsEnabled(impl),
+      usesSetImmediate: isSetImmediateEnabled(impl),
       catchesErrors: doesCatchErrors(impl),
       raisesErrors: doesRaiseErrors(impl),
       usesNodeId: isNodeIdEnabled(impl),

--- a/packages/xod-arduino/src/types.js
+++ b/packages/xod-arduino/src/types.js
@@ -73,6 +73,7 @@ export const TPatch = Model('TPatch', {
   isDefer: $.Boolean,
   isConstant: $.Boolean,
   usesTimeouts: $.Boolean,
+  usesSetImmediate: $.Boolean,
   catchesErrors: $.Boolean,
   raisesErrors: $.Boolean,
   usesNodeId: $.Boolean,

--- a/packages/xod-client/src/editor/codemirrorXodMode.js
+++ b/packages/xod-client/src/editor/codemirrorXodMode.js
@@ -12,7 +12,7 @@ import 'codemirror/addon/scroll/simplescrollbars';
 /* eslint-disable max-len */
 const XOD_TYPE_NAMES = /(Number|NodeId|Context|DirtyFlags|TimeMs|u?int\d{1,2}_t|size_t|XString|State|List|Iterator|(typeof_[A-Za-z0-9_]+))\b/gm;
 const XOD_KEYWORDS = /\b(node|meta)\b/gm;
-const XOD_BUILTIN_NAMES = /(getValue|emitValue|isInputDirty|transactionTime|setTimeout|clearTimeout|isTimedOut|evaluate|getState|raiseError|isSettingUp|getError|(constant_(input|output)_[A-Za-z0-9_]+))\b/gm;
+const XOD_BUILTIN_NAMES = /(getValue|emitValue|isInputDirty|transactionTime|setTimeout|clearTimeout|isTimedOut|setImmediate|evaluate|getState|raiseError|isSettingUp|getError|(constant_(input|output)_[A-Za-z0-9_]+))\b/gm;
 const ARDUINO_BUILTIN_NAMES = /((digital|analog)(Read|Write)|pinMode|analogReference)\b/gm;
 const XOD_TAG_NAMES = /(((input|output)_[A-Za-z0-9_]+)|GENERATED_CODE)\b/gm;
 /* eslint-enable max-len */

--- a/workspace/__lib__/xod/core/animation-unit/patch.cpp
+++ b/workspace/__lib__/xod/core/animation-unit/patch.cpp
@@ -19,7 +19,7 @@ node {
             emitValue<output_OUT>(ctx, 0);
             emitValue<output_ACT>(ctx, true);
             prevTime = now;
-            setTimeout(ctx, 0);
+            setImmediate();
             return;
         }
 
@@ -44,7 +44,7 @@ node {
                 emitValue<output_OUT>(ctx, out);
                 emitValue<output_ACT>(ctx, true);
                 prevTime = now;
-                setTimeout(ctx, 0);
+                setImmediate();
             }
         }
     }

--- a/workspace/__lib__/xod/core/continuously-pausable/patch.cpp
+++ b/workspace/__lib__/xod/core/continuously-pausable/patch.cpp
@@ -2,9 +2,7 @@ node {
     void evaluate(Context ctx) {
         if (getValue<input_EN>(ctx)) {
             emitValue<output_TICK>(ctx, 1);
-            setTimeout(ctx, 0);
-        } else {
-            clearTimeout(ctx);
+            setImmediate();
         }
     }
 }

--- a/workspace/__lib__/xod/core/continuously/patch.cpp
+++ b/workspace/__lib__/xod/core/continuously/patch.cpp
@@ -1,6 +1,6 @@
 node {
     void evaluate(Context ctx) {
         emitValue<output_TICK>(ctx, 1);
-        setTimeout(ctx, 0);
+        setImmediate();
     }
 }

--- a/workspace/__lib__/xod/core/defer(boolean)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(boolean)/patch.cpp
@@ -20,7 +20,7 @@ node {
                 emitValue<output_OUT>(ctx, getValue<input_IN>(ctx));
             }
 
-            setTimeout(ctx, 0);
+            setImmediate();
         }
     }
 }

--- a/workspace/__lib__/xod/core/defer(byte)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(byte)/patch.cpp
@@ -20,7 +20,7 @@ node {
                 emitValue<output_OUT>(ctx, getValue<input_IN>(ctx));
             }
 
-            setTimeout(ctx, 0);
+            setImmediate();
         }
     }
 }

--- a/workspace/__lib__/xod/core/defer(number)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(number)/patch.cpp
@@ -20,7 +20,7 @@ node {
                 emitValue<output_OUT>(ctx, getValue<input_IN>(ctx));
             }
 
-            setTimeout(ctx, 0);
+            setImmediate();
         }
     }
 };

--- a/workspace/__lib__/xod/core/defer(pulse)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(pulse)/patch.cpp
@@ -23,7 +23,7 @@ node {
                 shouldPulseAtTheNextDeferOnlyRun = true;
             }
 
-            setTimeout(ctx, 0);
+            setImmediate();
         }
     }
 };

--- a/workspace/__lib__/xod/core/defer(string)/patch.cpp
+++ b/workspace/__lib__/xod/core/defer(string)/patch.cpp
@@ -20,7 +20,7 @@ node {
                 emitValue<output_OUT>(ctx, getValue<input_IN>(ctx));
             }
 
-            setTimeout(ctx, 0);
+            setImmediate();
         }
     }
 }

--- a/workspace/__lib__/xod/debug/is-receiving/patch.cpp
+++ b/workspace/__lib__/xod/debug/is-receiving/patch.cpp
@@ -13,7 +13,7 @@ node {
 
         if (isInputDirty<input_UPD>(ctx)) {
             startTime = transactionTime();
-            setTimeout(ctx, 0);
+            setImmediate();
             return;
         }
 
@@ -22,12 +22,12 @@ node {
             if (shouldWait && inet->isConnected()) {
                 // No incoming data, but we're still waiting for data
                 if (!inet->isReceiving()) {
-                    setTimeout(ctx, 0);
+                    setImmediate();
                     return;
                 }
                 // Receiving data
                 received = true;
-                setTimeout(ctx, 0);
+                setImmediate();
                 emitValue<output_Y>(ctx, 1);
                 return;
             } else {

--- a/workspace/__lib__/xod/debug/stream-string/patch.cpp
+++ b/workspace/__lib__/xod/debug/stream-string/patch.cpp
@@ -11,7 +11,7 @@ node {
             emitValue<output_OUT1>(ctx, *it);
             emitValue<output_OUT2>(ctx, true);
             ++it;
-            setTimeout(ctx, 0);
+            setImmediate();
         }
     }
 }

--- a/workspace/__lib__/xod/gpio/analog-read/patch.cpp
+++ b/workspace/__lib__/xod/gpio/analog-read/patch.cpp
@@ -2,6 +2,12 @@
 #pragma XOD evaluate_on_pin enable input_UPD
 
 node {
+// reading from analog input too frequently may affect WiFi connection on ESP8266
+// see https://github.com/krzychb/EspScopeA0/tree/master/Bravo#results
+#ifdef ESP8266
+    TimeMs lastReadTime = 0;
+#endif
+
     void evaluate(Context ctx) {
         static_assert(isValidAnalogPort(constant_input_PORT), "must be a valid analog port");
 
@@ -9,7 +15,14 @@ node {
             return;
 
         ::pinMode(constant_input_PORT, INPUT);
+#ifdef ESP8266
+        if (transactionTime() - lastReadTime > 4) {
+            lastReadTime = transactionTime();
+            emitValue<output_VAL>(ctx, ::analogRead(constant_input_PORT) / 1023.);
+        }
+#else
         emitValue<output_VAL>(ctx, ::analogRead(constant_input_PORT) / 1023.);
+#endif
         emitValue<output_DONE>(ctx, 1);
     }
 }

--- a/workspace/__lib__/xod/mutex/mutex-state/patch.cpp
+++ b/workspace/__lib__/xod/mutex/mutex-state/patch.cpp
@@ -27,7 +27,7 @@ node {
 
         if (active) {
             emitValue<output_LOOP>(ctx, 1);
-            setTimeout(ctx, 0);
+            setImmediate();
         }
     }
 }

--- a/workspace/dht-pack-unpack/__fixtures__/arduino.cpp
+++ b/workspace/dht-pack-unpack/__fixtures__/arduino.cpp
@@ -1081,7 +1081,7 @@ struct Node {
       return identity<typeof_TICK>();
     }
 
-    TimeMs timeoutAt = 0;
+    bool isSetImmediate = false;
 
     Node () {
     }
@@ -1093,16 +1093,8 @@ struct Node {
 
     using Context = ContextObject*;
 
-    void setTimeout(__attribute__((unused)) Context ctx, TimeMs timeout) {
-        this->timeoutAt = transactionTime() + timeout;
-    }
-
-    void clearTimeout(__attribute__((unused)) Context ctx) {
-        detail::clearTimeout(this);
-    }
-
-    bool isTimedOut(__attribute__((unused)) const Context ctx) {
-        return detail::isTimedOut(this);
+    void setImmediate() {
+      this->isSetImmediate = true;
     }
 
     template<typename PinT> typename decltype(getValueType(PinT()))::type getValue(Context ctx) {
@@ -1147,7 +1139,7 @@ struct Node {
 
     void evaluate(Context ctx) {
         emitValue<output_TICK>(ctx, 1);
-        setTimeout(ctx, 0);
+        setImmediate();
     }
 
 };
@@ -1691,8 +1683,11 @@ void runTransaction() {
 #endif
 
     // Check for timeouts
-    g_transaction.node_1_isNodeDirty |= detail::isTimedOut(&node_1);
     g_transaction.node_4_isNodeDirty |= detail::isTimedOut(&node_4);
+    if (node_1.isSetImmediate) {
+      node_1.isSetImmediate = false;
+      g_transaction.node_1_isNodeDirty = true;
+    }
 
     if (isSettingUp()) {
         initializeTweakStrings();
@@ -1849,7 +1844,6 @@ void runTransaction() {
     // Clear dirtieness and timeouts for all nodes and pins
     memset(&g_transaction, 0, sizeof(g_transaction));
 
-    detail::clearStaleTimeout(&node_1);
     detail::clearStaleTimeout(&node_4);
 
     XOD_TRACE_F("Transaction completed, t=");

--- a/workspace/two-button-switch/__fixtures__/arduino.cpp
+++ b/workspace/two-button-switch/__fixtures__/arduino.cpp
@@ -987,7 +987,7 @@ struct Node {
       return identity<typeof_TICK>();
     }
 
-    TimeMs timeoutAt = 0;
+    bool isSetImmediate = false;
 
     Node () {
     }
@@ -999,16 +999,8 @@ struct Node {
 
     using Context = ContextObject*;
 
-    void setTimeout(__attribute__((unused)) Context ctx, TimeMs timeout) {
-        this->timeoutAt = transactionTime() + timeout;
-    }
-
-    void clearTimeout(__attribute__((unused)) Context ctx) {
-        detail::clearTimeout(this);
-    }
-
-    bool isTimedOut(__attribute__((unused)) const Context ctx) {
-        return detail::isTimedOut(this);
+    void setImmediate() {
+      this->isSetImmediate = true;
     }
 
     template<typename PinT> typename decltype(getValueType(PinT()))::type getValue(Context ctx) {
@@ -1053,7 +1045,7 @@ struct Node {
 
     void evaluate(Context ctx) {
         emitValue<output_TICK>(ctx, 1);
-        setTimeout(ctx, 0);
+        setImmediate();
     }
 
 };
@@ -1663,7 +1655,10 @@ void runTransaction() {
 #endif
 
     // Check for timeouts
-    g_transaction.node_3_isNodeDirty |= detail::isTimedOut(&node_3);
+    if (node_3.isSetImmediate) {
+      node_3.isSetImmediate = false;
+      g_transaction.node_3_isNodeDirty = true;
+    }
 
     if (isSettingUp()) {
         initializeTweakStrings();
@@ -1861,8 +1856,6 @@ void runTransaction() {
 
     // Clear dirtieness and timeouts for all nodes and pins
     memset(&g_transaction, 0, sizeof(g_transaction));
-
-    detail::clearStaleTimeout(&node_3);
 
     XOD_TRACE_F("Transaction completed, t=");
     XOD_TRACE_LN(millis());


### PR DESCRIPTION
Before, we used `setTimeout(0, ctx)` to schedule evaluation of a node as soon as possible.
But it would only mark node as dirty on the next millisecond and generate some unnecessary code.

`setImmediate` is a new API for this particular case that works faster, generates less code and occupies less RAM.