### PR TITLE
Ensure hotkeys work fine

### DIFF
--- a/packages/xod-client-browser/src/containers/App.jsx
+++ b/packages/xod-client-browser/src/containers/App.jsx
@@ -48,11 +48,13 @@ class App extends client.App {
 
     this.hideInstallAppPopup = this.hideInstallAppPopup.bind(this);
 
-    this.hotkeyHandlers = {
-      [client.COMMAND.NEW_PROJECT]: this.onCreateProject,
-      [client.COMMAND.UNDO]: this.props.actions.undoCurrentPatch,
-      [client.COMMAND.REDO]: this.props.actions.redoCurrentPatch,
-    };
+    this.hotkeyHandlers = R.merge(
+      {
+        [client.COMMAND.NEW_PROJECT]: this.onCreateProject,
+        [client.COMMAND.ADD_PATCH]: this.props.actions.createPatch,
+      },
+      this.defaultHotkeyHandlers
+    );
 
     this.urlActions = {
       [client.URL_ACTION_TYPES.OPEN_TUTORIAL]: this.onOpenTutorial,

--- a/packages/xod-client-electron/src/view/containers/App.jsx
+++ b/packages/xod-client-electron/src/view/containers/App.jsx
@@ -191,10 +191,7 @@ class App extends client.App {
       this.showError(error);
     });
 
-    this.hotkeyHandlers = {
-      [client.COMMAND.UNDO]: this.props.actions.undoCurrentPatch,
-      [client.COMMAND.REDO]: this.props.actions.redoCurrentPatch,
-    };
+    this.hotkeyHandlers = this.defaultHotkeyHandlers;
 
     this.urlActions = {
       // actionPathName: params => this.props.actions.someAction(params.foo, params.bar),

--- a/packages/xod-client/src/editor/containers/Editor.jsx
+++ b/packages/xod-client/src/editor/containers/Editor.jsx
@@ -8,7 +8,7 @@ import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { HotKeys, FocusTrap } from 'react-hotkeys';
+import { FocusTrap } from 'react-hotkeys';
 import * as XP from 'xod-project';
 import debounce from 'throttle-debounce/debounce';
 
@@ -19,7 +19,6 @@ import * as DebuggerSelectors from '../../debugger/selectors';
 import * as EditorSelectors from '../selectors';
 
 import { isInputTarget } from '../../utils/browser';
-import { COMMAND } from '../../utils/constants';
 import sanctuaryPropType from '../../utils/sanctuaryPropType';
 import { FOCUS_AREAS, TAB_TYPES, SIDEBAR_IDS } from '../constants';
 
@@ -45,7 +44,6 @@ class Editor extends React.Component {
   constructor(props) {
     super(props);
 
-    this.getHotkeyHandlers = this.getHotkeyHandlers.bind(this);
     this.toggleHelp = this.toggleHelp.bind(this);
     this.onAddNode = this.onAddNode.bind(this);
     this.onInstallLibrary = this.onInstallLibrary.bind(this);
@@ -82,19 +80,6 @@ class Editor extends React.Component {
   }
   onLibSuggesterFocus() {
     this.props.actions.setFocusedArea(FOCUS_AREAS.LIB_SUGGESTER);
-  }
-
-  getHotkeyHandlers() {
-    return {
-      [COMMAND.HIDE_HELPBOX]: () => this.props.actions.hideHelpbox(),
-      [COMMAND.TOGGLE_HELP]: this.toggleHelp,
-      [COMMAND.INSERT_NODE]: event => {
-        if (isInputTarget(event)) return;
-        this.showSuggester(null);
-      },
-      [COMMAND.PAN_TO_ORIGIN]: this.props.actions.panToOrigin,
-      [COMMAND.PAN_TO_CENTER]: this.props.actions.panToCenter,
-    };
   }
 
   toggleHelp(e) {
@@ -261,8 +246,7 @@ class Editor extends React.Component {
     )(this.props.panelsSettings);
 
     return (
-      <HotKeys
-        handlers={this.getHotkeyHandlers()}
+      <div
         className={cn('Editor', {
           leftSidebarMaximized: areSidebarsMaximized[SIDEBAR_IDS.LEFT],
           rightSidebarMaximized: areSidebarsMaximized[SIDEBAR_IDS.RIGHT],
@@ -301,7 +285,7 @@ class Editor extends React.Component {
           onAutohideClick={this.props.actions.togglePanelAutohide}
         />
         <Tooltip />
-      </HotKeys>
+      </div>
     );
   }
 }
@@ -342,8 +326,6 @@ Editor.propTypes = {
     togglePanelAutohide: PropTypes.func.isRequired,
     hideHelpbox: PropTypes.func.isRequired,
     showHelpbox: PropTypes.func.isRequired,
-    panToOrigin: PropTypes.func.isRequired,
-    panToCenter: PropTypes.func.isRequired,
     runTabtest: PropTypes.func.isRequired,
   }),
 };
@@ -387,10 +369,8 @@ const mapDispatchToProps = dispatch => ({
       minimizePanel: Actions.minimizePanel,
       movePanel: Actions.movePanel,
       togglePanelAutohide: Actions.togglePanelAutohide,
-      hideHelpbox: Actions.hideHelpbox,
       showHelpbox: Actions.showHelpbox,
-      panToOrigin: Actions.setCurrentPatchOffsetToOrigin,
-      panToCenter: Actions.setCurrentPatchOffsetToCenter,
+      hideHelpbox: Actions.hideHelpbox,
       runTabtest: Actions.runTabtest,
     },
     dispatch

--- a/packages/xod-client/src/utils/browser.js
+++ b/packages/xod-client/src/utils/browser.js
@@ -52,3 +52,6 @@ export const isMacOS = () => window.navigator.appVersion.indexOf('Mac') !== -1;
 export const restoreFocusOnApp = () => {
   document.getElementById('App').focus();
 };
+
+export const elementHasFocusFunction = el =>
+  el && typeof el.focus === 'function';


### PR DESCRIPTION
It fixes #1737 

It includes:
- moving hotkeys from `Editor` to `App` component
- auto-focus on the `App` element on startup
- capture `focusout` events and in case that focus moved to the body (focused element was deleted) focus to the `App` component