### PR TITLE
Paste expanded nodes to the right position

### DIFF
--- a/packages/xod-client/src/editor/utils.js
+++ b/packages/xod-client/src/editor/utils.js
@@ -97,10 +97,14 @@ export const getBBoxTopLeftPosition = R.compose(
 
 // :: Patch -> Project -> Node -> Size
 const getNodeSize = R.curry((currentPatch, project, node) =>
-  R.compose(calcutaleNodeSizeFromPins, R.values, XP.getPinsForNode)(
-    node,
-    currentPatch,
-    project
+  R.maxBy(
+    R.prop('width'),
+    XP.getNodeSize(node),
+    R.compose(calcutaleNodeSizeFromPins, R.values, XP.getPinsForNode)(
+      node,
+      currentPatch,
+      project
+    )
   )
 );
 


### PR DESCRIPTION
It closes #1441 

Previously, the position for pasted nodes calculates only by pins. This PR takes into account a node width, which might be changed on such nodes as constants, watches, tweaks.