### PR TITLE
Add hotkeys to show upload popup

### DIFF
--- a/packages/xod-client-browser/src/containers/App.jsx
+++ b/packages/xod-client-browser/src/containers/App.jsx
@@ -52,6 +52,10 @@ class App extends client.App {
       {
         [client.COMMAND.NEW_PROJECT]: this.onCreateProject,
         [client.COMMAND.ADD_PATCH]: this.props.actions.createPatch,
+        [client.COMMAND.TOGGLE_DEBUGGER]: e => {
+          e.preventDefault();
+          this.props.actions.toggleDebugger();
+        },
       },
       this.defaultHotkeyHandlers
     );

--- a/packages/xod-client-electron/src/view/containers/App.jsx
+++ b/packages/xod-client-electron/src/view/containers/App.jsx
@@ -191,7 +191,13 @@ class App extends client.App {
       this.showError(error);
     });
 
-    this.hotkeyHandlers = this.defaultHotkeyHandlers;
+    this.hotkeyHandlers = R.merge(
+      {
+        [client.COMMAND.UPLOAD_WITH_DEBUG]: this
+          .onUploadToArduinoAndDebugClicked,
+      },
+      this.defaultHotkeyHandlers
+    );
 
     this.urlActions = {
       // actionPathName: params => this.props.actions.someAction(params.foo, params.bar),

--- a/packages/xod-client/src/utils/constants.js
+++ b/packages/xod-client/src/utils/constants.js
@@ -35,6 +35,9 @@ export const COMMAND = {
   MAKE_TERMINAL: 'makeTerminal',
   MAKE_CONSTANT: 'makeConstant',
   MAKE_INTERACTIVE: 'makeInteractive',
+
+  UPLOAD: 'upload',
+  UPLOAD_WITH_DEBUG: 'uploadWithDebug',
 };
 
 export const HOTKEY = {
@@ -58,7 +61,7 @@ export const HOTKEY = {
 
   [COMMAND.HIDE_HELPBOX]: 'escape',
   [COMMAND.TOGGLE_HELP]: ['h'],
-  [COMMAND.TOGGLE_DEBUGGER]: ['ctrl+shift+u'],
+  [COMMAND.TOGGLE_DEBUGGER]: 'CmdOrCtrl+d',
   [COMMAND.INSERT_NODE]: ['i'],
 
   [COMMAND.MAKE_BUS]: ['b'],
@@ -68,6 +71,8 @@ export const HOTKEY = {
 
   [COMMAND.PAN_TO_ORIGIN]: ['home'],
   [COMMAND.PAN_TO_CENTER]: 'CmdOrCtrl+home',
+
+  [COMMAND.UPLOAD_WITH_DEBUG]: 'CmdOrCtrl+shift+u',
 };
 
 export const ELECTRON_ACCELERATOR = {
@@ -92,10 +97,13 @@ export const ELECTRON_ACCELERATOR = {
   [COMMAND.SAVE_COPY_AS]: 'CmdOrCtrl+Shift+Alt+S',
 
   [COMMAND.HIDE_HELPBOX]: 'Escape',
-  [COMMAND.TOGGLE_DEBUGGER]: 'CmdOrCtrl+Shift+U',
+  [COMMAND.TOGGLE_DEBUGGER]: 'CmdOrCtrl+D',
 
   [COMMAND.PAN_TO_ORIGIN]: 'Home',
   [COMMAND.PAN_TO_CENTER]: 'CmdOrCtrl+Home',
+
+  [COMMAND.UPLOAD]: 'CmdOrCtrl+u',
+  [COMMAND.UPLOAD_WITH_DEBUG]: 'CmdOrCtrl+shift+u',
 };
 
 export const KEYCODE = {

--- a/packages/xod-client/src/utils/menu.js
+++ b/packages/xod-client/src/utils/menu.js
@@ -108,6 +108,7 @@ const rawItems = {
   },
   uploadToArduino: {
     label: 'Upload to Arduino...',
+    command: COMMAND.UPLOAD,
   },
   connectSerial: {
     label: 'Connect Serial...',


### PR DESCRIPTION
It closes #2072 

I choose `Ctrl+U` and `Ctrl+Shift+U` hotkeys to open the popup. I decided to use a `Shift` modifier because this hotkey opens the same popup.

Also, there was a hotkey to toggle the debug pane: `Ctrl+Shift+U`. So I've replaced it with `Ctrl+D`.