### PR TITLE
Fix workspace errors when user deleted a workspace

### DIFF
--- a/packages/xod-cli/src/commands/boards.js
+++ b/packages/xod-cli/src/commands/boards.js
@@ -45,7 +45,7 @@ class BoardsCommand extends BaseCommand {
         })),
         sortBy(prop('name')),
         b => mergeAvailableInstalled(b.available, b.installed)
-      )(await xdb.listBoards(workspace, aCli));
+      )(await xdb.listBoards(resolveBundledWorkspacePath(), workspace, aCli));
 
       const rows = quiet ? map(b => [b['Board Name'], b.FQBN])(boards) : boards;
 

--- a/packages/xod-cli/src/listrTasks.js
+++ b/packages/xod-cli/src/listrTasks.js
@@ -5,6 +5,8 @@ import { loadProject } from 'xod-fs';
 import { createError, foldEither } from 'xod-func-tools';
 import * as xdb from 'xod-deploy-bin';
 
+import { resolveBundledWorkspacePath } from './paths';
+
 export const loadProjectTask = (workspaces, projectPath) => ({
   title: 'Project loading',
   task: ctx =>
@@ -45,7 +47,11 @@ export const transpileTask = () => ({
 export const checkBoardTask = (workspace, fqbn) => ({
   title: 'Check board',
   task: async ctx => {
-    const boards = await xdb.listBoards(workspace, ctx.arduinoCli);
+    const boards = await xdb.listBoards(
+      resolveBundledWorkspacePath(),
+      workspace,
+      ctx.arduinoCli
+    );
     const board = last(filter(el => el.fqbn === fqbn, boards.installed));
 
     // toolchain not installed - handle it

--- a/packages/xod-client-electron/src/app/arduinoCli.js
+++ b/packages/xod-client-electron/src/app/arduinoCli.js
@@ -3,6 +3,7 @@ import * as xdb from 'xod-deploy-bin';
 
 import subscribeIpc from './subscribeIpc';
 import { loadWorkspacePath } from './workspaceActions';
+import { getPathToBundledWorkspace } from './utils';
 import {
   LIST_BOARDS,
   UPLOAD_TO_ARDUINO,
@@ -34,7 +35,10 @@ export const upload = (onProgress, cli, payload) => {
 // =============================================================================
 export const subscribeListBoards = cli =>
   subscribeIpc(
-    () => loadWorkspacePath().then(ws => xdb.listBoards(ws, cli)),
+    () =>
+      loadWorkspacePath().then(ws =>
+        xdb.listBoards(getPathToBundledWorkspace(), ws, cli)
+      ),
     LIST_BOARDS
   );
 
@@ -46,7 +50,10 @@ export const subscribeUpload = cli =>
 
 export const subscribeUpdateIndexes = cli =>
   subscribeIpc(
-    () => loadWorkspacePath().then(ws => xdb.updateIndexes(ws, cli)),
+    () =>
+      loadWorkspacePath().then(ws =>
+        xdb.updateIndexes(getPathToBundledWorkspace(), ws, cli)
+      ),
     UPDATE_INDEXES
   );
 

--- a/packages/xod-deploy-bin/package.json
+++ b/packages/xod-deploy-bin/package.json
@@ -20,6 +20,7 @@
     "fs-extra": "^7.0.1",
     "ramda": "0.24.1",
     "which": "^1.3.1",
+    "xod-fs": "^0.36.0",
     "xod-func-tools": "^0.34.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It fixes a couple of bugs:

# 1. Error on the first run of the XOD IDE

## How to reproduce
1. Open the XOD IDE first time (clean App data, delete workspace)
2. Click "Upload to Arduino"

## Expected behavior
Everything works as usual.

## Actual behavior
The error message "Package Index Broken: Unexpected end of JSON input" appeared in the snack bar. The list of boards is empty. Will appear if you open the upload popup again or click the "Update" button.

# 2. The user deletes a workspace directory while the XOD IDE is opened

## How to reproduce
1. Open the XOD IDE
2. Delete the workspace directory
3. Click "Upload to Arduino" button

## Expected behavior
Upload popup appeared, there is a list of the boards in the select box.

## Actual
No boards in the select box are listed.
Also, the error "ENOENT ... extra.txt file" appears in the snack bar.