### PR TITLE
Fix: configure electron-settings for all kinds of processes

### DIFF
--- a/packages/xod-client-electron/src/app/main.js
+++ b/packages/xod-client-electron/src/app/main.js
@@ -35,6 +35,8 @@ import {
   IS_DEV,
   getFilePathToOpen,
   getPathToBundledWorkspace,
+  setUserDataArg,
+  getUserDataDir,
 } from './utils';
 import * as WA from './workspaceActions';
 import {
@@ -61,12 +63,8 @@ app.setName('xod');
 
 configureAutoUpdater(autoUpdater, log);
 
-// to ensure compatibility with the old default
-settings.rewriteElectronSettingsFileName('Settings');
-
 if (process.env.USERDATA_DIR) {
   app.setPath('userData', process.env.USERDATA_DIR);
-  settings.rewriteElectronSettingsFilePath(app.getPath('userData'));
 }
 
 if (IS_DEV) {
@@ -119,6 +117,7 @@ function createWindow() {
       contextIsolation: false,
       additionalArguments: [
         IS_DEV ? 'ELECTRON_IS_DEV' : 'ELECTRON_IS_PACKAGED',
+        setUserDataArg(getUserDataDir()),
       ],
     },
   });

--- a/packages/xod-client-electron/src/app/settings.js
+++ b/packages/xod-client-electron/src/app/settings.js
@@ -1,6 +1,8 @@
 import * as R from 'ramda';
 import electronSettings from 'electron-settings';
 
+import { getUserDataDir } from './utils';
+
 // =============================================================================
 //
 // Default settings object
@@ -15,21 +17,16 @@ export const DEFAULT_SETTINGS = {
 
 // =============================================================================
 //
-// Unpure save / load / setDefaults settings
+// Configure settings file
+//
+// The `electron-settings` pakage creates a `config` variable to store paths and
+// file names in it. So separate processes, like main process and renderer
+// will have the separate instances of this variable.
+// To achieve the same data in all processes, we use utility `getUserDataDir`
+// and will set the correct config for `electron-settings` every time we call to
+// load or save the settings file.
 //
 // =============================================================================
-
-// TODO: Add catching broken settings (if user opens settings file and break it)
-//       On catch — show error to user and fallback to default settings.
-export const load = () => R.merge(DEFAULT_SETTINGS, electronSettings.getSync());
-
-// TODO: Add schema and validating on save to prevent errors
-export const save = settings => electronSettings.setSync(settings);
-
-export const setDefaults = R.compose(
-  R.when(R.isEmpty, () => save(DEFAULT_SETTINGS)),
-  load
-);
 
 /**
  * To make settings path changeble in dependency of env varialbe (E.G. for functional tests)
@@ -47,6 +44,36 @@ export const rewriteElectronSettingsFileName = fileName => {
     fileName,
   });
 };
+
+const ensureSettingsFileConfiguration = () => {
+  // to ensure compatibility with the old default
+  rewriteElectronSettingsFileName('Settings');
+  rewriteElectronSettingsFilePath(getUserDataDir());
+};
+
+// =============================================================================
+//
+// Unpure save / load / setDefaults settings
+//
+// =============================================================================
+
+// TODO: Add catching broken settings (if user opens settings file and break it)
+//       On catch — show error to user and fallback to default settings.
+export const load = () => {
+  ensureSettingsFileConfiguration();
+  return R.merge(DEFAULT_SETTINGS, electronSettings.getSync());
+};
+
+// TODO: Add schema and validating on save to prevent errors
+export const save = settings => {
+  ensureSettingsFileConfiguration();
+  return electronSettings.setSync(settings);
+};
+
+export const setDefaults = R.compose(
+  R.when(R.isEmpty, () => save(DEFAULT_SETTINGS)),
+  load
+);
 
 // =============================================================================
 //

--- a/packages/xod-client-electron/src/app/utils.js
+++ b/packages/xod-client-electron/src/app/utils.js
@@ -10,12 +10,39 @@ export const IS_DEV =
     ? process.argv.includes('ELECTRON_IS_DEV')
     : !electron.app.isPackaged) || process.env.NODE_ENV === 'development';
 
+const USERDATA_ARGNAME = '--userdata-dir=';
+
+// Utility to set the user data directory arguments for the renerer processes
+// from the main process on creating a renderer.
+export const setUserDataArg = userDataDir =>
+  `${USERDATA_ARGNAME}${userDataDir}`;
+
+export const getUserDataDir = () =>
+  process.type === 'renderer'
+    ? R.compose(
+        R.slice(USERDATA_ARGNAME.length, Infinity),
+        R.find(arg => arg.startsWith(USERDATA_ARGNAME))
+      )(process.argv)
+    : process.env.USERDATA_DIR || electron.app.getPath('userData');
+
+// =============================================================================
+//
+// IPC
+//
+// =============================================================================
+
 // for IPC. see https://electron.atom.io/docs/api/remote/#remote-objects
 // if we don't do this, we get empty objects on the other side instead of errors
 export const errorToPlainObject = R.when(
   R.is(Error),
   R.converge(R.pick, [Object.getOwnPropertyNames, R.identity])
 );
+
+// =============================================================================
+//
+// Cross-platform
+//
+// =============================================================================
 
 /**
  * It provides one iterface for getting file path, that
@@ -57,6 +84,8 @@ export const getFilePathToOpen = app => {
 
   return () => pathToOpen;
 };
+
+// =============================================================================
 
 /**
  * Returns Path to the resources directory root.


### PR DESCRIPTION
There is no issue 😬 

## What was wrong?
Updating of the electron also causes an update of the `electron-settings` package. The newer version of this package changed the default name of the settings file. To keep user settings we've changed the filename, but only in the main process. So it produced a bug when the user compile&upload something with third-party C++ libraries — the libraries from his workspace does not copy if he set a workspace in the custom (not default) path.

## How it fixed?
On loading/saving settings we always set the path and file name for the settings file (for both kinds of processes).