### PR TITLE
Add sugar to table log feature

### DIFF
--- a/packages/xod-arduino/src/transpiler.js
+++ b/packages/xod-arduino/src/transpiler.js
@@ -829,7 +829,7 @@ export const getTableLogNodeIds = def(
   R.compose(
     R.map(R.prop('originalId')),
     R.filter(
-      R.compose(R.propEq('patchPath', XP.TABLELOG_NODETYPE), R.prop('patch'))
+      R.compose(R.propEq('patchPath', XP.TSV_LOG_NODETYPE), R.prop('patch'))
     ),
     R.prop('nodes')
   )

--- a/packages/xod-client/src/debugger/selectors.js
+++ b/packages/xod-client/src/debugger/selectors.js
@@ -11,7 +11,7 @@ import { DEBUGGER_TAB_ID } from '../editor/constants';
 import { SESSION_TYPE } from './constants';
 
 import { createMemoizedSelector } from '../utils/selectorTools';
-import { getTableLogSourceLabels } from './utils';
+import { getTableLogSourceLabels, removeLastNodeIdInChain } from './utils';
 
 export const getDebuggerState = R.prop('debugger');
 
@@ -186,7 +186,14 @@ export const getInteractiveNodeValuesForCurrentPatch = createSelector(
               sheets[lastSheetIndex].length
             }`;
           }),
-          filterOutValuesForCurrentPatch(activeIndex, nodeIdPath)
+          filterOutValuesForCurrentPatch(activeIndex, nodeIdPath),
+          // `tsv-log`, which is actually stores the data, encapsulated
+          // inside `table-log`, which label should be replaced with
+          // this value. So we have to cut the latest nodeId part from
+          // keys of table log values map
+          R.fromPairs,
+          R.map(R.over(R.lensIndex(0), removeLastNodeIdInChain)),
+          R.toPairs
         )(tableLogs);
 
         return R.merge(watchNodeValues, tableLogValues);

--- a/packages/xod-client/src/debugger/utils.js
+++ b/packages/xod-client/src/debugger/utils.js
@@ -39,6 +39,9 @@ export const getTetheringInetNodeId = R.curry(
 
 export const isErrorMessage = R.propEq('type', UPLOAD_MSG_TYPE.ERROR);
 
+// `a~b~c` -> `a~b`
+export const removeLastNodeIdInChain = R.replace(/(~[^~]+)$/, '');
+
 // :: Project -> [NodeId] -> PatchPath -> [{ nodeId: NodeId, label: String }]
 export const getTableLogSourceLabels = R.curry(
   (project, sourceNodeIds, rootPatchPath) =>
@@ -98,7 +101,7 @@ export const getTableLogSourceLabels = R.curry(
             },
             R.applySpec({
               nodeId: R.always(nodeId),
-              chunks: R.identity,
+              chunks: R.init, // Get rid of last NodeId, which points to internal `tsv-log`
             })
           ),
           R.map(

--- a/packages/xod-client/src/editor/actions.js
+++ b/packages/xod-client/src/editor/actions.js
@@ -47,6 +47,7 @@ import * as DebuggerSelectors from '../debugger/selectors';
 
 import { parseDebuggerMessage } from '../debugger/debugProtocol';
 import { addMessagesToDebuggerLog } from '../debugger/actions';
+import { removeLastNodeIdInChain } from '../debugger/utils';
 import runWasmWorker from '../workers/run';
 import { getAccessToken } from '../user/selectors';
 import { updateBalances } from '../user/actions';
@@ -964,7 +965,14 @@ export const openTableLogTab = nodeId => (dispatch, getState) => {
     R.ifElse(
       R.contains(nodeId),
       () => Maybe.of(nodeId),
-      R.compose(Maybe, R.find(R.endsWith(nodeId)))
+      R.compose(
+        Maybe,
+        // `tsv-log`, which is actually stores the table log values
+        // is encapsulated inside `table-log` node, which node id
+        // is passed in this function so we need to find nodeId
+        // with a prefix with unknown nodeId: `${nodeId}~someNodeId`
+        R.find(R.compose(R.endsWith(nodeId), removeLastNodeIdInChain))
+      )
     ),
     R.unnest,
     R.values,

--- a/packages/xod-client/src/project/components/Node.jsx
+++ b/packages/xod-client/src/project/components/Node.jsx
@@ -11,6 +11,7 @@ import { noop } from '../../utils/ramda';
 import { isPinSelected } from '../../editor/utils';
 
 import RegularNodeBody from './nodeParts/RegularNodeBody';
+import TableLogNodeBody from './nodeParts/TableLogNodeBody';
 import WatchNodeBody from './nodeParts/WatchNodeBody';
 import TweakNodeBody from './nodeParts/TweakNodeBody';
 import TerminalNodeBody from './nodeParts/TerminalNodeBody';
@@ -115,7 +116,7 @@ class Node extends React.Component {
     return R.cond([
       [XP.isTerminalPatchPath, () => <TerminalNodeBody {...this.props} />],
       [XP.isWatchPatchPath, () => <WatchNodeBody {...this.props} />],
-      [XP.isTableLogPatchPath, () => <WatchNodeBody {...this.props} />],
+      [XP.isTableLogPatchPath, () => <TableLogNodeBody {...this.props} />],
       [XP.isConstantNodeType, () => <ConstantNodeBody {...this.props} />],
       [XP.isBindableCustomType, () => <ConstantNodeBody {...this.props} />],
       [XP.isTweakPath, () => <TweakNodeBody {...this.props} />],

--- a/packages/xod-client/src/project/components/nodeParts/TableLogNodeBody.jsx
+++ b/packages/xod-client/src/project/components/nodeParts/TableLogNodeBody.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import * as XP from 'xod-project';
+
+import { NODE_CORNER_RADIUS } from '../../nodeLayout';
+import NodeLabel from './NodeLabel';
+import VariadicHandle from './VariadicHandle';
+
+const NODE_BODY_RECT_PROPS = {
+  rx: NODE_CORNER_RADIUS,
+  ry: NODE_CORNER_RADIUS,
+  // pxSize is set in root svg, let's occupy it all
+  width: '100%',
+  height: '100%',
+};
+
+const TableLogNodeBody = props => (
+  <g className={classNames('watch-node', { active: props.isDebugSession })}>
+    <rect className="body" {...NODE_BODY_RECT_PROPS} />
+    <NodeLabel
+      text={props.nodeValue || props.label || XP.getBaseName(props.type)}
+      width={props.pxSize.width}
+      height={props.pxSize.height}
+    />
+    <rect className="outline" {...NODE_BODY_RECT_PROPS} />
+    <VariadicHandle
+      pxSize={props.pxSize}
+      onMouseDown={event => {
+        event.stopPropagation();
+        props.onVariadicHandleDown(event, props.id);
+      }}
+    />
+  </g>
+);
+
+TableLogNodeBody.propTypes = {
+  id: PropTypes.string,
+  type: PropTypes.string,
+  label: PropTypes.string,
+  pxSize: PropTypes.shape({
+    width: PropTypes.number,
+    height: PropTypes.number,
+  }),
+  nodeValue: PropTypes.string,
+  isDebugSession: PropTypes.bool,
+  onVariadicHandleDown: PropTypes.func,
+};
+
+export default TableLogNodeBody;

--- a/packages/xod-client/test/tableLogSources.spec.js
+++ b/packages/xod-client/test/tableLogSources.spec.js
@@ -4,6 +4,17 @@ import { defaultizeProject } from 'xod-project/test/helpers';
 
 import { getTableLogSourceLabels } from '../src/debugger/utils';
 
+const TABLE_LOG_NODES = {
+  'xod/debug/tsv-log': {},
+  'xod/debug/table-log': {
+    nodes: {
+      log: {
+        type: 'xod/debug/tsv-log',
+      },
+    },
+  },
+};
+
 describe('generate labels for table log sources', () => {
   const assertSameSources = (project, rootPatchPath, expectedLabelsForIds) => {
     const ids = R.keys(expectedLabelsForIds);
@@ -24,12 +35,12 @@ describe('generate labels for table log sources', () => {
     const project = defaultizeProject({
       patches: {
         '@/main': {},
-        'xod/debug/table-log': {},
+        ...TABLE_LOG_NODES,
       },
     });
 
     assertSameSources(project, '@/main', {
-      'a~n~t': '@/main > DELETED (a~n~t)',
+      'a~n~t~log': '@/main > DELETED (a~n~t~log)',
       t: '@/main > DELETED (t)',
     });
   });
@@ -63,14 +74,14 @@ describe('generate labels for table log sources', () => {
             },
           },
         },
-        'xod/debug/table-log': {},
+        ...TABLE_LOG_NODES,
       },
     });
 
     assertSameSources(project, '@/main', {
-      'a~n~t': '@/main > nested-1 > nested-2 > table-log',
-      'b~t': '@/main > nested-2 > table-log',
-      t: '@/main > table-log',
+      'a~n~t~log': '@/main > nested-1 > nested-2 > table-log',
+      'b~t~log': '@/main > nested-2 > table-log',
+      't~log': '@/main > table-log',
     });
   });
   it('should contain node labels if it is set', () => {
@@ -118,15 +129,15 @@ describe('generate labels for table log sources', () => {
             },
           },
         },
-        'xod/debug/table-log': {},
+        ...TABLE_LOG_NODES,
       },
     });
 
     assertSameSources(project, '@/main', {
-      'a~n~t': '@/main > Nested One > nested-2 > table-log',
-      'b~t': '@/main > Nested Two > table-log',
-      'c~n~t': '@/main > Nested Label > Log > table-log',
-      t: '@/main > My Table Log',
+      'a~n~t~log': '@/main > Nested One > nested-2 > table-log',
+      'b~t~log': '@/main > Nested Two > table-log',
+      'c~n~t~log': '@/main > Nested Label > Log > table-log',
+      't~log': '@/main > My Table Log',
     });
   });
   it('should add numbers to the duplicates on a correct nesting level', () => {
@@ -219,45 +230,49 @@ describe('generate labels for table log sources', () => {
             nd2: { type: '@/nested-double' },
           },
         },
-        'xod/debug/table-log': {},
+        ...TABLE_LOG_NODES,
       },
     });
 
     assertSameSources(project, '@/main', {
-      'a~n~t': '@/main > Nested > nested-2 > table-log',
-      'a2~n~t': '@/main > Nested #2 > nested-2 > table-log',
-      'a3~n~t': '@/main > nested-1 > nested-2 > table-log',
-      'b~n~t': '@/main > nested-label > Log > table-log',
-      'b2~n~t': '@/main > nested-label #2 > Log > table-log',
-      'd~t': '@/main > nested-double > table-log',
-      'd~t2': '@/main > nested-double > table-log #2',
-      'd2~t': '@/main > nested-double #2 > table-log',
-      'd2~t2': '@/main > nested-double #2 > table-log #2',
-      'd3~t': '@/main > Double Inside > table-log',
-      'd3~t2': '@/main > Double Inside > table-log #2',
-      'nc~n~n~t': '@/main > nested-complex > nested-1 > nested-2 > table-log',
-      'nc~n2~n~t':
+      'a~n~t~log': '@/main > Nested > nested-2 > table-log',
+      'a2~n~t~log': '@/main > Nested #2 > nested-2 > table-log',
+      'a3~n~t~log': '@/main > nested-1 > nested-2 > table-log',
+      'b~n~t~log': '@/main > nested-label > Log > table-log',
+      'b2~n~t~log': '@/main > nested-label #2 > Log > table-log',
+      'd~t~log': '@/main > nested-double > table-log',
+      'd~t2~log': '@/main > nested-double > table-log #2',
+      'd2~t~log': '@/main > nested-double #2 > table-log',
+      'd2~t2~log': '@/main > nested-double #2 > table-log #2',
+      'd3~t~log': '@/main > Double Inside > table-log',
+      'd3~t2~log': '@/main > Double Inside > table-log #2',
+      'nc~n~n~t~log':
+        '@/main > nested-complex > nested-1 > nested-2 > table-log',
+      'nc~n2~n~t~log':
         '@/main > nested-complex > nested-1 #2 > nested-2 > table-log',
-      'nc~nn~t': '@/main > nested-complex > nested-2 > table-log',
-      'nc~nn2~t': '@/main > nested-complex > nested-2 #2 > table-log',
-      'nc~nd~t': '@/main > nested-complex > nested-double > table-log',
-      'nc~nd~t2': '@/main > nested-complex > nested-double > table-log #2',
-      'nc~nd2~t': '@/main > nested-complex > nested-double #2 > table-log',
-      'nc~nd2~t2': '@/main > nested-complex > nested-double #2 > table-log #2',
-      'nc2~n~n~t':
+      'nc~nn~t~log': '@/main > nested-complex > nested-2 > table-log',
+      'nc~nn2~t~log': '@/main > nested-complex > nested-2 #2 > table-log',
+      'nc~nd~t~log': '@/main > nested-complex > nested-double > table-log',
+      'nc~nd~t2~log': '@/main > nested-complex > nested-double > table-log #2',
+      'nc~nd2~t~log': '@/main > nested-complex > nested-double #2 > table-log',
+      'nc~nd2~t2~log':
+        '@/main > nested-complex > nested-double #2 > table-log #2',
+      'nc2~n~n~t~log':
         '@/main > nested-complex #2 > nested-1 > nested-2 > table-log',
-      'nc2~n2~n~t':
+      'nc2~n2~n~t~log':
         '@/main > nested-complex #2 > nested-1 #2 > nested-2 > table-log',
-      'nc2~nn~t': '@/main > nested-complex #2 > nested-2 > table-log',
-      'nc2~nn2~t': '@/main > nested-complex #2 > nested-2 #2 > table-log',
-      'nc2~nd~t': '@/main > nested-complex #2 > nested-double > table-log',
-      'nc2~nd~t2': '@/main > nested-complex #2 > nested-double > table-log #2',
-      'nc2~nd2~t': '@/main > nested-complex #2 > nested-double #2 > table-log',
-      'nc2~nd2~t2':
+      'nc2~nn~t~log': '@/main > nested-complex #2 > nested-2 > table-log',
+      'nc2~nn2~t~log': '@/main > nested-complex #2 > nested-2 #2 > table-log',
+      'nc2~nd~t~log': '@/main > nested-complex #2 > nested-double > table-log',
+      'nc2~nd~t2~log':
+        '@/main > nested-complex #2 > nested-double > table-log #2',
+      'nc2~nd2~t~log':
+        '@/main > nested-complex #2 > nested-double #2 > table-log',
+      'nc2~nd2~t2~log':
         '@/main > nested-complex #2 > nested-double #2 > table-log #2',
-      t: '@/main > My Table Log',
-      t2: '@/main > My Table Log #2',
-      t3: '@/main > My Table Log #3',
+      't~log': '@/main > My Table Log',
+      't2~log': '@/main > My Table Log #2',
+      't3~log': '@/main > My Table Log #3',
     });
   });
 });

--- a/packages/xod-project/src/constants.js
+++ b/packages/xod-project/src/constants.js
@@ -126,7 +126,11 @@ export const PULSE_CONST_NODETYPES = {
 };
 
 export const WATCH_NODETYPE = 'xod/debug/watch';
+
+// User-friendly table-log node, that uses a tsv-log inside
 export const TABLELOG_NODETYPE = 'xod/debug/table-log';
+// Utility node that actually sends a tsv data to the XOD IDE
+export const TSV_LOG_NODETYPE = 'xod/debug/tsv-log';
 
 // node types that prints values into Serial
 // to debug xod programm, it should be omitted

--- a/workspace/__lib__/xod/debug/arity-aware-join/patch.cpp
+++ b/workspace/__lib__/xod/debug/arity-aware-join/patch.cpp
@@ -1,0 +1,23 @@
+
+node {
+    ConcatListView<char> accPlusDelimiter;
+    ConcatListView<char> result;
+
+    void evaluate(Context ctx) {
+        auto arity = getValue<input_AR>(ctx);
+        emitValue<output_ARU0027>(ctx, arity + 1);
+
+        auto input = getValue<input_IN>(ctx);
+
+        if (arity == 0) {
+            emitValue<output_OUT>(ctx, input);
+            return;
+        }
+
+        auto acc = getValue<input_ACC>(ctx);
+        auto delimeter = getValue<input_D>(ctx);
+        accPlusDelimiter = ConcatListView<char>(acc, delimeter);
+        result = ConcatListView<char>(XString(&accPlusDelimiter), input);
+        emitValue<output_OUT>(ctx, XString(&result));
+    }
+}

--- a/workspace/__lib__/xod/debug/arity-aware-join/patch.xodp
+++ b/workspace/__lib__/xod/debug/arity-aware-join/patch.xodp
@@ -1,0 +1,95 @@
+{
+  "description": "Joins multiple strings together inserting a delimiter between each pair. Unlike `xod/core/join` this one works fine with only one input string and in this case it leaves it as it is.",
+  "nodes": [
+    {
+      "description": "Utility pin to calculate the arity level of the node. Should not be linked anywhere and should have a bound value `0`.",
+      "id": "r1FfzR4mO",
+      "label": "AR",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/input-number"
+    },
+    {
+      "description": "Accumulator of the concatenated strings. In the common case it should have an empty string.",
+      "id": "Bkk7GANQ_",
+      "label": "ACC",
+      "position": {
+        "units": "slots",
+        "x": 3,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/input-string"
+    },
+    {
+      "description": "Strings to join",
+      "id": "BJ9rM047O",
+      "position": {
+        "units": "slots",
+        "x": 5,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/input-string"
+    },
+    {
+      "description": "Incremented arity level. See description for the `AR` input pin.",
+      "id": "ByKPGCEXu",
+      "label": "AR'",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 3
+      },
+      "type": "xod/patch-nodes/output-number"
+    },
+    {
+      "id": "HyluM0VX_",
+      "position": {
+        "units": "slots",
+        "x": 3,
+        "y": 3
+      },
+      "type": "xod/patch-nodes/output-string"
+    },
+    {
+      "id": "ryx2G0Nmu",
+      "position": {
+        "units": "slots",
+        "x": 7,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/variadic-1"
+    },
+    {
+      "id": "BJVhfA47d",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "description": "Delimeter character or string",
+      "id": "H1HgQ047O",
+      "label": "D",
+      "position": {
+        "units": "slots",
+        "x": -1,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/input-string"
+    },
+    {
+      "id": "SyXL5CV7_",
+      "position": {
+        "units": "slots",
+        "x": 9,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/utility"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/debug/table-log/patch.xodp
+++ b/workspace/__lib__/xod/debug/table-log/patch.xodp
@@ -1,18 +1,55 @@
 {
   "description": "Collects values as table rows and tables as sheets. Useful to conduct measurement sessions and then analyze the data gathered in spreadsheet software.",
-  "nodes": [
+  "links": [
     {
-      "id": "B1iYZOzoZ",
-      "position": {
-        "units": "slots",
-        "x": 1,
-        "y": 1
+      "id": "HJTOc88Q_",
+      "input": {
+        "nodeId": "rkCPc8U7_",
+        "pinKey": "HJWUGvR4Q_"
       },
-      "type": "xod/patch-nodes/not-implemented-in-xod"
+      "output": {
+        "nodeId": "B1WTUcLLX_",
+        "pinKey": "__out__"
+      }
     },
     {
+      "id": "SkjgK5ILQO",
+      "input": {
+        "nodeId": "r1sw98LXO",
+        "pinKey": "rkvDUOV1O"
+      },
+      "output": {
+        "nodeId": "rkCPc8U7_",
+        "pinKey": "rkUMDCNm_"
+      }
+    },
+    {
+      "id": "BkMF9LL7O",
+      "input": {
+        "nodeId": "r1sw98LXO",
+        "pinKey": "rkWILuNyu"
+      },
+      "output": {
+        "nodeId": "BJ6U5UImd",
+        "pinKey": "__out__"
+      }
+    },
+    {
+      "id": "rJQF9IUmu",
+      "input": {
+        "nodeId": "r1sw98LXO",
+        "pinKey": "B1RI8OEyO"
+      },
+      "output": {
+        "nodeId": "Hkx6L5IUXd",
+        "pinKey": "__out__"
+      }
+    }
+  ],
+  "nodes": [
+    {
       "description": "Adds values to the latest sheet.",
-      "id": "rkWILuNyu",
+      "id": "BJ6U5UImd",
       "label": "PUSH",
       "position": {
         "units": "slots",
@@ -26,24 +63,51 @@
         "__out__": "Never"
       },
       "description": "Creates a new sheet.",
-      "id": "B1RI8OEyO",
+      "id": "Hkx6L5IUXd",
       "label": "NEW",
       "position": {
         "units": "slots",
-        "x": 1,
+        "x": 2,
         "y": 0
       },
       "type": "xod/patch-nodes/input-pulse"
     },
     {
-      "description": "Values to add as a new table row. All values should be separated with tab character `\\t`.",
-      "id": "rkvDUOV1O",
+      "description": "Values to add as a new table row.",
+      "id": "B1WTUcLLX_",
       "position": {
         "units": "slots",
-        "x": 5,
+        "x": 4,
         "y": 0
       },
       "type": "xod/patch-nodes/input-string"
+    },
+    {
+      "id": "SJWwcUU7u",
+      "position": {
+        "units": "slots",
+        "x": 6,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/variadic-pass-1"
+    },
+    {
+      "id": "r1sw98LXO",
+      "position": {
+        "units": "slots",
+        "x": 2,
+        "y": 2
+      },
+      "type": "@/tsv-log"
+    },
+    {
+      "id": "rkCPc8U7_",
+      "position": {
+        "units": "slots",
+        "x": 4,
+        "y": 1
+      },
+      "type": "@/tsv-join"
     }
   ]
 }

--- a/workspace/__lib__/xod/debug/tsv-join/patch.xodp
+++ b/workspace/__lib__/xod/debug/tsv-join/patch.xodp
@@ -1,0 +1,76 @@
+{
+  "links": [
+    {
+      "id": "BJs7vANXO",
+      "input": {
+        "nodeId": "rkUMDCNm_",
+        "pinKey": "__in__"
+      },
+      "output": {
+        "nodeId": "r1w7vA4XO",
+        "pinKey": "HyluM0VX_"
+      }
+    },
+    {
+      "id": "Sy1EvRVXd",
+      "input": {
+        "nodeId": "r1w7vA4XO",
+        "pinKey": "BJ9rM047O"
+      },
+      "output": {
+        "nodeId": "HJWUGvR4Q_",
+        "pinKey": "__out__"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "id": "rkUMDCNm_",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 2
+      },
+      "type": "xod/patch-nodes/output-string"
+    },
+    {
+      "id": "HJWUGvR4Q_",
+      "position": {
+        "units": "slots",
+        "x": 3,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-string"
+    },
+    {
+      "boundLiterals": {
+        "H1HgQ047O": "\"\\t\""
+      },
+      "id": "r1w7vA4XO",
+      "position": {
+        "units": "slots",
+        "x": 0,
+        "y": 1
+      },
+      "type": "@/arity-aware-join"
+    },
+    {
+      "id": "B194PC4Qd",
+      "position": {
+        "units": "slots",
+        "x": 5,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/variadic-pass-1"
+    },
+    {
+      "id": "SJfO5UIXu",
+      "position": {
+        "units": "slots",
+        "x": 7,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/utility"
+    }
+  ]
+}

--- a/workspace/__lib__/xod/debug/tsv-log/patch.cpp
+++ b/workspace/__lib__/xod/debug/tsv-log/patch.cpp
@@ -1,0 +1,33 @@
+nodespace {
+    void printEOL() {
+        XOD_DEBUG_SERIAL.print('\r');
+        XOD_DEBUG_SERIAL.print('\n');
+        XOD_DEBUG_SERIAL.flush();
+    }
+}
+
+node {
+    void printPrefix(Context ctx) {
+        TimeMs tNow = transactionTime();
+        XOD_DEBUG_SERIAL.print(F("+XOD:"));
+        XOD_DEBUG_SERIAL.print(tNow);
+        XOD_DEBUG_SERIAL.print(':');
+        XOD_DEBUG_SERIAL.print(getNodeId(ctx));
+        XOD_DEBUG_SERIAL.print(':');
+    }
+    void evaluate(Context ctx) {
+        if (isInputDirty<input_PUSH>(ctx)) {
+            printPrefix(ctx);
+            auto data = getValue<input_IN>(ctx);
+            for (auto it = data.iterate(); it; ++it)
+              XOD_DEBUG_SERIAL.print((char)*it);
+            printEOL();
+        }
+        if (isInputDirty<input_NEW>(ctx)) {
+            printPrefix(ctx);
+            // Page break character -> new page
+            XOD_DEBUG_SERIAL.print((char)0xC);
+            printEOL();
+        }
+    }
+}

--- a/workspace/__lib__/xod/debug/tsv-log/patch.xodp
+++ b/workspace/__lib__/xod/debug/tsv-log/patch.xodp
@@ -1,0 +1,58 @@
+{
+  "description": "Collects values as table rows and tables as sheets. Useful to conduct measurement sessions and then analyze the data gathered in spreadsheet software.",
+  "nodes": [
+    {
+      "id": "B1iYZOzoZ",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/not-implemented-in-xod"
+    },
+    {
+      "description": "Adds values to the latest sheet.",
+      "id": "rkWILuNyu",
+      "label": "PUSH",
+      "position": {
+        "units": "slots",
+        "x": 3,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "boundLiterals": {
+        "__out__": "Never"
+      },
+      "description": "Creates a new sheet.",
+      "id": "B1RI8OEyO",
+      "label": "NEW",
+      "position": {
+        "units": "slots",
+        "x": 1,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-pulse"
+    },
+    {
+      "description": "Values to add as a new table row. All values should be separated with tab character `\\t`.",
+      "id": "rkvDUOV1O",
+      "position": {
+        "units": "slots",
+        "x": 5,
+        "y": 0
+      },
+      "type": "xod/patch-nodes/input-string"
+    },
+    {
+      "id": "BJ8O98Imu",
+      "position": {
+        "units": "slots",
+        "x": 3,
+        "y": 1
+      },
+      "type": "xod/patch-nodes/utility"
+    }
+  ]
+}


### PR DESCRIPTION
There is no issue.

It includes:
1. A few new utility nodes in `xod/debug` and restyled `table-log`, which is a variadic-pass (no more `join` on the user-side).
2. Tweaks in `xod-arduino` and `xod-client` to keep the behavior of nodes and table log tab as it was before: no excessive labels in the sources dropdown, show collected data on the `table-log`, open correct source by double-clicking on the `table-log` node.