### PR TITLE
Release 0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.38.0"></a>
+
+## 0.38.0 (2021-03-12)
+
+### Features and enhancements
+
+* [core] Make possible to pass variadic pins to children variadic nodes (#2107)
+* [ide] Add table log feature: collect, view and save tabular data in live session mode (#2098, #2108)
+* [nodes] Add nodes to handle interrupts in [xod/gpio](https://xod.io/libs/xod/gpio) standard library (#2106)
+* [nodes] Add [xod/core/micros](https://xod.io/libs/xod/core/micros) node and some utilities for this type (#2106)
+* [nodes] Add `variadic-pass-*` marker nodes (#2107)
+* [nodes] Add [xod/debug/table-log](https://xod.io/libs/xod/debug/table-log) node to collect tabular data (#2098, #2108)
+
+### Bug fixes
+
+* [ide] Fix minor mistakes in welcome-to-xod project (#2096)
+* [ide] Prevent corrupting projects when workspace contains libaries with invalid names (#2099)
+* [ide] Fix scrollbars in C++ editor (#2104)
+
 <a name="0.37.3"></a>
 
 ## 0.37.3 (2021-02-17)

--- a/lerna.json
+++ b/lerna.json
@@ -6,5 +6,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/packages/xod-arduino/package.json
+++ b/packages/xod-arduino/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xod-arduino",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "XOD project: Arduino transpiler",
   "scripts": {
     "build:nearley": "nearleyc src/implementationGrammar.ne -o src/implementationGrammar.ne.js",
@@ -31,14 +31,14 @@
     "ramda-fantasy": "^0.8.0",
     "sanctuary-def": "^0.14.0",
     "xod-func-tools": "^0.34.0",
-    "xod-project": "^0.37.0"
+    "xod-project": "^0.38.0"
   },
   "devDependencies": {
     "babel-plugin-inline-import": "^2.0.4",
     "bs-platform": "7.1.1",
     "chai": "^4.1.2",
     "onchange": "^5.2.0",
-    "xod-fs": "^0.37.0"
+    "xod-fs": "^0.38.0"
   },
   "files": [
     "dist",

--- a/packages/xod-cli/package.json
+++ b/packages/xod-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xod-cli",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "XOD project: Command Line Interface",
   "author": "XOD Team <dev@xod.io>",
   "bin": {
@@ -24,12 +24,12 @@
     "node-fetch": "^2.3.0",
     "ramda": "^0.24.1",
     "source-map-support": "^0.5.9",
-    "xod-arduino": "^0.37.0",
-    "xod-deploy-bin": "^0.37.0",
-    "xod-fs": "^0.37.0",
+    "xod-arduino": "^0.38.0",
+    "xod-deploy-bin": "^0.38.0",
+    "xod-fs": "^0.38.0",
     "xod-func-tools": "^0.34.0",
-    "xod-project": "^0.37.0",
-    "xod-tabtest": "^0.37.0"
+    "xod-project": "^0.38.0",
+    "xod-tabtest": "^0.38.0"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.19.4",

--- a/packages/xod-client-browser/package.json
+++ b/packages/xod-client-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xod-client-browser",
-  "version": "0.37.3",
+  "version": "0.38.0",
   "description": "XOD project: Client browser application",
   "scripts": {
     "build:tutorial-project": "node ./tools/loadTutorialProject.js",
@@ -24,17 +24,17 @@
     "redux": "^3.0.5",
     "redux-thunk": "^2.1.0",
     "url-parse": "^1.2.0",
-    "xod-arduino": "^0.37.0",
-    "xod-client": "^0.37.3",
+    "xod-arduino": "^0.38.0",
+    "xod-client": "^0.38.0",
     "xod-func-tools": "^0.34.0",
-    "xod-project": "^0.37.0"
+    "xod-project": "^0.38.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "expose-loader": "^1.0.3",
     "node-static": "^0.7.10",
     "why-did-you-update": "^0.1.0",
-    "xod-fs": "^0.37.0"
+    "xod-fs": "^0.38.0"
   },
   "author": "XOD Team <dev@xod.io>",
   "license": "AGPL-3.0"

--- a/packages/xod-client-electron/package.json
+++ b/packages/xod-client-electron/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0",
   "main": "src-babel/app/main.js",
   "name": "xod-client-electron",
-  "version": "0.37.3",
+  "version": "0.38.0",
   "scripts": {
     "build:workspace": "cpx \"../../workspace/**/*\" \"src-babel/workspace\"",
     "build:gui": "webpack --colors",
@@ -43,13 +43,13 @@
     "redux": "^3.0.5",
     "redux-thunk": "^2.1.0",
     "serialport": "^9.0.4",
-    "xod-arduino": "^0.37.0",
-    "xod-client": "^0.37.3",
-    "xod-deploy": "^0.37.0",
-    "xod-deploy-bin": "^0.37.0",
-    "xod-fs": "^0.37.0",
+    "xod-arduino": "^0.38.0",
+    "xod-client": "^0.38.0",
+    "xod-deploy": "^0.38.0",
+    "xod-deploy-bin": "^0.38.0",
+    "xod-fs": "^0.38.0",
     "xod-func-tools": "^0.34.0",
-    "xod-project": "^0.37.0",
+    "xod-project": "^0.38.0",
     "xod-tethering-inet": "^0.34.0"
   },
   "devDependencies": {

--- a/packages/xod-client/package.json
+++ b/packages/xod-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xod-client",
-  "version": "0.37.3",
+  "version": "0.38.0",
   "description": "XOD project: Client application",
   "scripts": {
     "build": "babel src/ -d dist/ --source-maps",
@@ -64,13 +64,13 @@
     "url-search-params-polyfill": "^2.0.1",
     "vec-la-fp": "^1.5.2",
     "wait-for-element": "^1.0.2",
-    "xod-arduino": "^0.37.0",
-    "xod-cloud-compile": "^0.37.0",
+    "xod-arduino": "^0.38.0",
+    "xod-cloud-compile": "^0.38.0",
     "xod-func-tools": "^0.34.0",
-    "xod-patch-search": "^0.37.0",
-    "xod-pm": "^0.37.0",
-    "xod-project": "^0.37.0",
-    "xod-tabtest": "^0.37.0"
+    "xod-patch-search": "^0.38.0",
+    "xod-pm": "^0.38.0",
+    "xod-project": "^0.38.0",
+    "xod-tabtest": "^0.38.0"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.2.17",

--- a/packages/xod-cloud-compile/package.json
+++ b/packages/xod-cloud-compile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xod-cloud-compile",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {
@@ -21,12 +21,12 @@
     "ramda": "^0.24.1",
     "string-to-arraybuffer": "^1.0.2",
     "xod-func-tools": "^0.34.0",
-    "xod-tabtest": "^0.37.0"
+    "xod-tabtest": "^0.38.0"
   },
   "devDependencies": {
     "babel-plugin-inline-import": "^2.0.4",
     "chai": "^4.1.2",
-    "xod-fs": "^0.37.0"
+    "xod-fs": "^0.38.0"
   },
   "files": [
     "dist",

--- a/packages/xod-deploy-bin/package.json
+++ b/packages/xod-deploy-bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xod-deploy-bin",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "XOD wrapper over arduino-cli wrapper",
   "main": "dist/index.js",
   "scripts": {
@@ -20,7 +20,7 @@
     "fs-extra": "^7.0.1",
     "ramda": "0.24.1",
     "which": "^1.3.1",
-    "xod-fs": "^0.37.0",
+    "xod-fs": "^0.38.0",
     "xod-func-tools": "^0.34.0"
   },
   "devDependencies": {

--- a/packages/xod-deploy/package.json
+++ b/packages/xod-deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xod-deploy",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {
@@ -32,7 +32,7 @@
     "tar": "^4.0.1",
     "unbzip2-stream": "^1.2.5",
     "ws": "^3.1.0",
-    "xod-fs": "^0.37.0",
+    "xod-fs": "^0.38.0",
     "xod-func-tools": "^0.34.0"
   },
   "devDependencies": {

--- a/packages/xod-fs/package.json
+++ b/packages/xod-fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xod-fs",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {
@@ -20,7 +20,7 @@
     "recursive-readdir": "^2.1.0",
     "sanctuary-def": "^0.14.0",
     "xod-func-tools": "^0.34.0",
-    "xod-project": "^0.37.0"
+    "xod-project": "^0.38.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/packages/xod-patch-search/package.json
+++ b/packages/xod-patch-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xod-patch-search",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {
@@ -24,10 +24,10 @@
     "ramda": "^0.24.1",
     "ramda-fantasy": "^0.8.0",
     "xod-func-tools": "^0.34.0",
-    "xod-project": "^0.37.0"
+    "xod-project": "^0.38.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "xod-fs": "^0.37.0"
+    "xod-fs": "^0.38.0"
   }
 }

--- a/packages/xod-pm/package.json
+++ b/packages/xod-pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xod-pm",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {
@@ -25,7 +25,7 @@
     "ramda-fantasy": "^0.8.0",
     "swagger-client": "^3.4.3",
     "xod-func-tools": "^0.34.0",
-    "xod-project": "^0.37.0"
+    "xod-project": "^0.38.0"
   },
   "devDependencies": {
     "chai": "^4.1.2"

--- a/packages/xod-project/package.json
+++ b/packages/xod-project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xod-project",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "API functions to work on XOD project state",
   "keywords": [],
   "license": "AGPL-3.0",

--- a/packages/xod-tabtest/package.json
+++ b/packages/xod-tabtest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xod-tabtest",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "scripts": {
     "refmt": "find src/ test/ -name '*.re*' -exec refmt --in-place {} +",
     "build:lib": "node ./tools/loadTabtestLibPatches.js",
@@ -18,15 +18,15 @@
   "main": "src/Tabtest_Js.bs.js",
   "dependencies": {
     "belt-holes": "^0.34.0",
-    "xod-arduino": "^0.37.0",
+    "xod-arduino": "^0.38.0",
     "xod-func-tools": "^0.34.0",
-    "xod-project": "^0.37.0"
+    "xod-project": "^0.38.0"
   },
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.9",
     "bs-platform": "7.1.1",
     "ramda": "^0.24.1",
-    "xod-fs": "^0.37.0"
+    "xod-fs": "^0.38.0"
   },
   "jest": {
     "testMatch": [

--- a/workspace/__lib__/xod-cloud/basics/project.xod
+++ b/workspace/__lib__/xod-cloud/basics/project.xod
@@ -5,5 +5,5 @@
   "description": "Nodes to get some basic data from the XOD Cloud API",
   "license": "AGPL-3.0",
   "name": "basics",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod-cloud/feeds/project.xod
+++ b/workspace/__lib__/xod-cloud/feeds/project.xod
@@ -5,5 +5,5 @@
   "description": "Nodes for communicating with the XOD Cloud Feeds service",
   "license": "AGPL-3.0",
   "name": "feeds",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod-dev/dht/project.xod
+++ b/workspace/__lib__/xod-dev/dht/project.xod
@@ -2,5 +2,5 @@
   "description": "Nodes to work with DHT11 or DHT21 sensors, or compatible sensors: RHT01, DHT22, DHT33, DHT44, AM2301, HM2301, AM2302, AM2303, RHT02, RHT03, RHT04, RHT05.",
   "license": "AGPL-3.0",
   "name": "dht",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod-dev/ds-rtc/project.xod
+++ b/workspace/__lib__/xod-dev/ds-rtc/project.xod
@@ -5,5 +5,5 @@
   "description": "This library operates DS1302/DS1307/DS3231 based breakout RTC boards",
   "license": "AGPL-3.0",
   "name": "ds-rtc",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod-dev/esp8266-mcu/project.xod
+++ b/workspace/__lib__/xod-dev/esp8266-mcu/project.xod
@@ -5,5 +5,5 @@
   "description": "Support for ESP8266-based MCUs.",
   "license": "AGPL-3.0",
   "name": "esp8266-mcu",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod-dev/esp8266/project.xod
+++ b/workspace/__lib__/xod-dev/esp8266/project.xod
@@ -5,5 +5,5 @@
   "description": "Support for ESP8266 as a slave module",
   "license": "AGPL-3.0",
   "name": "esp8266",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod-dev/hc-sr04/project.xod
+++ b/workspace/__lib__/xod-dev/hc-sr04/project.xod
@@ -2,5 +2,5 @@
   "description": "Nodes to work with the HC-SR04 ultrasonic range meters.",
   "license": "AGPL-3.0",
   "name": "hc-sr04",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod-dev/pn532-nfc/project.xod
+++ b/workspace/__lib__/xod-dev/pn532-nfc/project.xod
@@ -2,5 +2,5 @@
   "description": "Support for RFID/NFC modules based on a PN532 chip.",
   "license": "MIT",
   "name": "pn532-nfc",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod-dev/servo/project.xod
+++ b/workspace/__lib__/xod-dev/servo/project.xod
@@ -5,5 +5,5 @@
   "description": "Nodes to control RC hobby servos",
   "license": "AGPL-3.0",
   "name": "servo",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod-dev/sharp-irm/project.xod
+++ b/workspace/__lib__/xod-dev/sharp-irm/project.xod
@@ -5,5 +5,5 @@
   "description": "Nodes to read analog infrared range meters by Sharp (GP2Y0A) and convert the signal to distance values.",
   "license": "AGPL-3.0",
   "name": "sharp-irm",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod-dev/ssd1306-display/project.xod
+++ b/workspace/__lib__/xod-dev/ssd1306-display/project.xod
@@ -2,5 +2,5 @@
   "description": "Nodes to drive SD1306-based monochrome LCDs with I2C interface.",
   "license": "AGPL-3.0",
   "name": "ssd1306-display",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod-dev/st-mems/project.xod
+++ b/workspace/__lib__/xod-dev/st-mems/project.xod
@@ -2,5 +2,5 @@
   "description": "Nodes to work with gyroscopes, accelerometers and barometers based on chips by STMicroelectronics: L3G4200, L3GD20H, LIS331DLH, LIS331HH, LIS3DH, LPS331.",
   "license": "AGPL-3.0",
   "name": "st-mems",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod-dev/st7735-display/project.xod
+++ b/workspace/__lib__/xod-dev/st7735-display/project.xod
@@ -2,5 +2,5 @@
   "description": "Nodes to drive ST7735 based TFT LCD displays. This library supports 128x160 resolution displays which are connected through the hardware SPI interface. Physically, some displays based on the 7735 chip may differ from each other and have different sets of instructions for initialization. To solve this, the library contains several device nodes for different types of displays. These nodes are labeled \"B\", \"G\", \"RG\", and \"RR\".",
   "license": "AGPL-3.0",
   "name": "st7735-display",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod-dev/text-lcd/project.xod
+++ b/workspace/__lib__/xod-dev/text-lcd/project.xod
@@ -2,5 +2,5 @@
   "description": "Nodes to drive a common text liquid crystal displays with I²C or parallel interfaces.",
   "license": "AGPL-3.0",
   "name": "text-lcd",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod-dev/w5500/project.xod
+++ b/workspace/__lib__/xod-dev/w5500/project.xod
@@ -5,5 +5,5 @@
   "description": "Support for ethernet shields that use Wiznet W5500 chipset.",
   "license": "AGPL-3.0",
   "name": "w5500",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod-dev/ws2812/project.xod
+++ b/workspace/__lib__/xod-dev/ws2812/project.xod
@@ -2,5 +2,5 @@
   "description": "Nodes to work with WS2812 (NeoPixel). The main difference from the other libraries that this library does not use a buffer to light up the LEDs. So it gives a possibility to light up a really long LED strip with a small microcontroller without a huge amount of RAM.",
   "license": "AGPL-3.0",
   "name": "ws2812",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/bits/project.xod
+++ b/workspace/__lib__/xod/bits/project.xod
@@ -5,5 +5,5 @@
   "description": "Low-level bits and bytes operations",
   "license": "AGPL-3.0",
   "name": "bits",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/color/project.xod
+++ b/workspace/__lib__/xod/color/project.xod
@@ -5,5 +5,5 @@
   "description": "Library to work with color",
   "license": "AGPL-3.0",
   "name": "color",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/common-hardware/project.xod
+++ b/workspace/__lib__/xod/common-hardware/project.xod
@@ -5,5 +5,5 @@
   "description": "Hardware drivers for popular and simple peripherals",
   "license": "AGPL-3.0",
   "name": "common-hardware",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/core/project.xod
+++ b/workspace/__lib__/xod/core/project.xod
@@ -5,5 +5,5 @@
   "description": "The very basic nodes of XOD",
   "license": "AGPL-3.0",
   "name": "core",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/datetime/project.xod
+++ b/workspace/__lib__/xod/datetime/project.xod
@@ -5,5 +5,5 @@
   "description": "Date and timestamp operations",
   "license": "AGPL-3.0",
   "name": "datetime",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/debug/project.xod
+++ b/workspace/__lib__/xod/debug/project.xod
@@ -5,5 +5,5 @@
   "description": "Debug nodes for XOD",
   "license": "AGPL-3.0",
   "name": "debug",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/gpio/project.xod
+++ b/workspace/__lib__/xod/gpio/project.xod
@@ -5,5 +5,5 @@
   "description": "Nodes of XOD to deal with GPIO (hardware pins)",
   "license": "AGPL-3.0",
   "name": "gpio",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/graphics/project.xod
+++ b/workspace/__lib__/xod/graphics/project.xod
@@ -5,5 +5,5 @@
   "description": "Nodes to work with graphics in XOD",
   "license": "AGPL-3.0",
   "name": "graphics",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/i2c/project.xod
+++ b/workspace/__lib__/xod/i2c/project.xod
@@ -1,5 +1,5 @@
 {
   "description": "My fork of \"xod/i2c\"",
   "name": "i2c",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/json/project.xod
+++ b/workspace/__lib__/xod/json/project.xod
@@ -2,5 +2,5 @@
   "description": "Nodes for parsing JSON from a stream of characters",
   "license": "AGPL-3.0",
   "name": "json",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/math/project.xod
+++ b/workspace/__lib__/xod/math/project.xod
@@ -5,5 +5,5 @@
   "description": "Nodes of XOD for basic mathematical operations",
   "license": "AGPL-3.0",
   "name": "math",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/mutex/project.xod
+++ b/workspace/__lib__/xod/mutex/project.xod
@@ -5,5 +5,5 @@
   "description": "Library to work with mutually exclusive resources. Useful to avoid conflicts between nodes controlling long-running processes.",
   "license": "AGPL-3.0",
   "name": "mutex",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/net/project.xod
+++ b/workspace/__lib__/xod/net/project.xod
@@ -5,5 +5,5 @@
   "description": "General types and operations to manage network connections",
   "license": "AGPL-3.0",
   "name": "net",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/stream/project.xod
+++ b/workspace/__lib__/xod/stream/project.xod
@@ -5,5 +5,5 @@
   "description": "Nodes to process sequences of bytes one by one",
   "license": "AGPL-3.0",
   "name": "stream",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/uart/project.xod
+++ b/workspace/__lib__/xod/uart/project.xod
@@ -5,5 +5,5 @@
   "description": "Provides constructors and Nodes to interact with UARTs (Software, Hardware, USB) in XOD.",
   "license": "AGPL-3.0",
   "name": "uart",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/units/project.xod
+++ b/workspace/__lib__/xod/units/project.xod
@@ -5,5 +5,5 @@
   "description": "Units of measurement conversions",
   "license": "AGPL-3.0",
   "name": "units",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }

--- a/workspace/__lib__/xod/waves/project.xod
+++ b/workspace/__lib__/xod/waves/project.xod
@@ -5,5 +5,5 @@
   "description": "A collection of nodes that generate wave signals",
   "license": "AGPL",
   "name": "waves",
-  "version": "0.37.3"
+  "version": "0.38.0"
 }


### PR DESCRIPTION
A formal PR, part of the [release procedure](https://github.com/xodio/xod/wiki/Releasing-a-New-Version).

## 0.38.0 (2021-03-12)

### Features and enhancements

* [core] Make possible to pass variadic pins to children variadic nodes (#2107)
* [ide] Add table log feature: collect, view and save tabular data in live session mode (#2098, #2108)
* [nodes] Add nodes to handle interrupts in [xod/gpio](https://xod.io/libs/xod/gpio) standard library (#2106)
* [nodes] Add [xod/core/micros](https://xod.io/libs/xod/core/micros) node and some utilities for this type (#2106)
* [nodes] Add `variadic-pass-*` marker nodes (#2107)
* [nodes] Add [xod/debug/table-log](https://xod.io/libs/xod/debug/table-log) node to collect tabular data (#2098, #2108)
* [infra] Pin node versions in CircleCI runners (#2093)
* [infra] Change base of CircleCI docker image (#2095)

### Bug fixes

* [ide] Fix minor mistakes in welcome-to-xod project (#2096)
* [ide] Prevent corrupting projects when workspace contains libaries with invalid names (#2099)
* [ide] Fix scrollbars in C++ editor (#2104)