### PR TITLE
Fix calling of GPIO functions only from global namespace

### DIFF
--- a/workspace/__lib__/xod/gpio/analog-read/patch.cpp
+++ b/workspace/__lib__/xod/gpio/analog-read/patch.cpp
@@ -18,10 +18,10 @@ node {
 #ifdef ESP8266
         if (transactionTime() - lastReadTime > 4) {
             lastReadTime = transactionTime();
-            emitValue<output_VAL>(ctx, ::analogRead(constant_input_PORT) / 1023.);
+            emitValue<output_VAL>(ctx, analogRead(constant_input_PORT) / 1023.);
         }
 #else
-        emitValue<output_VAL>(ctx, ::analogRead(constant_input_PORT) / 1023.);
+        emitValue<output_VAL>(ctx, analogRead(constant_input_PORT) / 1023.);
 #endif
         emitValue<output_DONE>(ctx, 1);
     }

--- a/workspace/__lib__/xod/gpio/digital-read-pullup/patch.cpp
+++ b/workspace/__lib__/xod/gpio/digital-read-pullup/patch.cpp
@@ -9,7 +9,7 @@ node {
             return;
 
         ::pinMode(constant_input_PORT, INPUT_PULLUP);
-        emitValue<output_SIG>(ctx, ::digitalRead(constant_input_PORT));
+        emitValue<output_SIG>(ctx, digitalRead(constant_input_PORT));
         emitValue<output_DONE>(ctx, 1);
     }
 }

--- a/workspace/__lib__/xod/gpio/digital-read/patch.cpp
+++ b/workspace/__lib__/xod/gpio/digital-read/patch.cpp
@@ -9,7 +9,7 @@ node {
             return;
 
         ::pinMode(constant_input_PORT, INPUT);
-        emitValue<output_SIG>(ctx, ::digitalRead(constant_input_PORT));
+        emitValue<output_SIG>(ctx, digitalRead(constant_input_PORT));
         emitValue<output_DONE>(ctx, 1);
     }
 }

--- a/workspace/__lib__/xod/gpio/digital-write/patch.cpp
+++ b/workspace/__lib__/xod/gpio/digital-write/patch.cpp
@@ -10,7 +10,7 @@ node {
 
         ::pinMode(constant_input_PORT, OUTPUT);
         const bool val = getValue<input_SIG>(ctx);
-        ::digitalWrite(constant_input_PORT, val);
+        digitalWrite(constant_input_PORT, val);
         emitValue<output_DONE>(ctx, 1);
     }
 }

--- a/workspace/big-patch/__fixtures__/arduino.cpp
+++ b/workspace/big-patch/__fixtures__/arduino.cpp
@@ -1999,10 +1999,10 @@ struct Node {
 #ifdef ESP8266
         if (transactionTime() - lastReadTime > 4) {
             lastReadTime = transactionTime();
-            emitValue<output_VAL>(ctx, ::analogRead(constant_input_PORT) / 1023.);
+            emitValue<output_VAL>(ctx, analogRead(constant_input_PORT) / 1023.);
         }
 #else
-        emitValue<output_VAL>(ctx, ::analogRead(constant_input_PORT) / 1023.);
+        emitValue<output_VAL>(ctx, analogRead(constant_input_PORT) / 1023.);
 #endif
         emitValue<output_DONE>(ctx, 1);
     }
@@ -2126,7 +2126,7 @@ struct Node {
             return;
 
         ::pinMode(constant_input_PORT, INPUT_PULLUP);
-        emitValue<output_SIG>(ctx, ::digitalRead(constant_input_PORT));
+        emitValue<output_SIG>(ctx, digitalRead(constant_input_PORT));
         emitValue<output_DONE>(ctx, 1);
     }
 

--- a/workspace/blink/__fixtures__/arduino.cpp
+++ b/workspace/blink/__fixtures__/arduino.cpp
@@ -1449,7 +1449,7 @@ struct Node {
 
         ::pinMode(constant_input_PORT, OUTPUT);
         const bool val = getValue<input_SIG>(ctx);
-        ::digitalWrite(constant_input_PORT, val);
+        digitalWrite(constant_input_PORT, val);
         emitValue<output_DONE>(ctx, 1);
     }
 

--- a/workspace/two-button-switch/__fixtures__/arduino.cpp
+++ b/workspace/two-button-switch/__fixtures__/arduino.cpp
@@ -1169,7 +1169,7 @@ struct Node {
             return;
 
         ::pinMode(constant_input_PORT, INPUT);
-        emitValue<output_SIG>(ctx, ::digitalRead(constant_input_PORT));
+        emitValue<output_SIG>(ctx, digitalRead(constant_input_PORT));
         emitValue<output_DONE>(ctx, 1);
     }
 
@@ -1538,7 +1538,7 @@ struct Node {
 
         ::pinMode(constant_input_PORT, OUTPUT);
         const bool val = getValue<input_SIG>(ctx);
-        ::digitalWrite(constant_input_PORT, val);
+        digitalWrite(constant_input_PORT, val);
         emitValue<output_DONE>(ctx, 1);
     }
 


### PR DESCRIPTION
There is no issue.

Calling `digitalRead,` digitalWrite`, or `analogRead` functions only from the global namespace may not work on some architectures, like SAMD. So there is no need to call these functions exactly from the global namespace, much better to allow the compiler to find the function that matches the signature.